### PR TITLE
Fixing Set-AzureADUserManager error binding the parameters.

### DIFF
--- a/customizations/Set-AzureADUserManager.ps1
+++ b/customizations/Set-AzureADUserManager.ps1
@@ -4,6 +4,15 @@
 @{
     SourceName = "Set-AzureADUserManager"
     TargetName = "Set-MgUserManagerByRef"
-    Parameters = $null
+    Parameters = @(
+        @{
+            SourceName = "RefObjectId"
+            TargetName = "BodyParameter"
+            ConversionType = "ScriptBlock"
+            SpecialMapping = @"
+`$Value = @{ "@odata.id" = "https://graph.microsoft.com/v1.0/users/`$TmpValue"}
+"@
+        }
+    )
     Outputs = $null
 }


### PR DESCRIPTION
Fixing error binding parameters. New command does not have reference object as a parameter we need to form the body payload for the command to pass to the api.