### PR TITLE
chore: capture initial branch policy settings

### DIFF
--- a/.github/policies/msgraph-ps-compatibility-azuread-branch-protection.yml
+++ b/.github/policies/msgraph-ps-compatibility-azuread-branch-protection.yml
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# File initially created using https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1.
+
+name: msgraph-ps-compatibility-azuread-branch-protection
+description: Branch protection policy for the msgraph-ps-compatibility-azuread repository
+resource: repository
+configuration:
+  branchProtectionRules:
+
+  - branchNamePattern: dev
+    # This branch pattern applies to the following branches as of 06/09/2023 14:08:50:
+    # dev
+
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: false
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Indicates whether "Require a pull request before merging" is enabled. boolean
+    requiresPullRequestBeforeMerging: true
+    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: false
+    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
+    requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
+    requiresStrictStatusChecks: true
+    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews. boolean
+    restrictsReviewDismissals: false
+


### PR DESCRIPTION
Capture current policy state so that we can make versioned changes to branch protection policies. This will enable policy history, auditing, review, standardization, and templatization. We will update policy in later PR.

This branch protection policy will not take effect until https://github.com/microsoftgraph/.github/blob/main/policies/branch-protection-sdks.yml has been removed.