### PR TITLE
Removing Get-AzureADDeviceConfiguration

### DIFF
--- a/customizations/Get-AzureADDeviceConfiguration.ps1
+++ b/customizations/Get-AzureADDeviceConfiguration.ps1
@@ -1,9 +1,0 @@
-# ------------------------------------------------------------------------------
-#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-# ------------------------------------------------------------------------------
-@{
-    SourceName = "Get-AzureADDeviceConfiguration"
-    TargetName = "Get-MgDeviceManagementDeviceConfiguration"
-    Parameters = $null
-    Outputs = $null
-}

--- a/test/General.Tests.ps1
+++ b/test/General.Tests.ps1
@@ -25,11 +25,11 @@ Describe 'Module checks' {
 
     It 'Known number translated commands' {
         $module = Get-Module -Name Microsoft.Graph.Compatibility.AzureAD
-        $module.ExportedCommands.Keys.Count | Should -Be 210
+        $module.ExportedCommands.Keys.Count | Should -Be 209
     }
 
     It 'Known number of missing commands' {        
-        $MISSING_CMDS.Count | Should -Be 20
+        $MISSING_CMDS.Count | Should -Be 21
     }
 
     It 'Running a simple command Set-CompatADAlias'{


### PR DESCRIPTION
Get-AzureADDeviceConfiguration is being translated to the wrong command because the proper command is not yet ready on Microsoft Graph. Feature team is working on parity.