### PR TITLE
Fix for a bug then customizing "id" 

### DIFF
--- a/src/CompatibilityAdapterBuilder.ps1
+++ b/src/CompatibilityAdapterBuilder.ps1
@@ -928,7 +928,10 @@ $($output)
                 $genericParam = $this.GenericParametersTransformations[$param.Name]
                 if(5 -eq $genericParam.ConversionType){
                     $tempName = "$($Cmdlet.Noun)$($genericParam.TargetName)"
-                    if($targetCmd.Parameters.ContainsKey($tempName)){
+                    if($targetCmd.Parameters.ContainsKey($genericParam.TargetName)){
+                        $paramObj.SetTargetName($genericParam.TargetName)
+                    }
+                    elseif($targetCmd.Parameters.ContainsKey($tempName)){
                         $paramObj.SetTargetName($tempName)
                     }
                     else


### PR DESCRIPTION
Fix for a bug then customizing "id" parameter that the target is "id". The problem is that the system tries to find the nounId conbination, but if the transformation is direct the process fail.