### PR TITLE
Adding custom code for types

### DIFF
--- a/build/Create-CompatModule.ps1
+++ b/build/Create-CompatModule.ps1
@@ -2,7 +2,7 @@
 #  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 # ------------------------------------------------------------------------------
 [cmdletbinding()]
-param($TargetDirectory = $null, $Module = "AzureAD", [switch] $noclean)
+param($TargetDirectory = $null, $Module = "AzureADPreview", [switch] $noclean)
 
 . (join-path $psscriptroot "/common-functions.ps1")
 . (join-path $psscriptroot "../src/CompatibilityAdapter.ps1")
@@ -16,7 +16,12 @@ $mapper = [CompatibilityAdapterBuilder]::new($Module)
 $customizationFiles = Get-CustomizationFiles -Module $Module
 foreach($file in $customizationFiles){
     $cmds = & $file
-    $mapper.AddCustomization($cmds)
+    if($file -like "*Types.ps1"){
+        $mapper.AddTypes($cmds)
+    }
+    else{
+        $mapper.AddCustomization($cmds)
+    }
 }
 $AdditionalFunctions = Get-CustomizationFiles -Directory 'AdditionalFunctions'  -Module $Module
 foreach($file in $AdditionalFunctions){

--- a/module/AzureADPreview/customizations/Types.ps1
+++ b/module/AzureADPreview/customizations/Types.ps1
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+@{
+        "Microsoft.Open.MSGraph.Model.DirectorySettingTemplate" = @"
+public DirectorySetting CreateDirectorySetting()
+        {
+            DirectorySetting directorySetting = new DirectorySetting();
+
+            directorySetting.TemplateId = this.Id;
+
+            directorySetting.Values = new System.Collections.Generic.List<SettingValue>();
+            foreach (var definition in this.Values)
+            {
+                SettingValue item = new SettingValue();
+                item.Name = definition.Name;
+
+                string value = definition.DefaultValue;
+                if (string.IsNullOrEmpty(value))
+                {
+                    item.Value = value;
+                }
+                else if (value.Length == 1)
+                {
+                    item.Value = value.ToUpper();
+                }
+                else
+                {
+                    item.Value = char.ToUpper(value[0]) + value.Substring(1);
+                }
+
+                directorySetting.Values.Add(item);
+            }
+
+            return directorySetting;
+        }
+"@
+}

--- a/src/CompatibilityAdapterBuilder.ps1
+++ b/src/CompatibilityAdapterBuilder.ps1
@@ -16,6 +16,7 @@ class CompatibilityAdapterBuilder {
     hidden [hashtable] $CmdCustomizations = @{}
     hidden [hashtable] $GenericParametersTransformations = @{}
     hidden [hashtable] $GenericOutputTransformations = @{}
+    hidden [hashtable] $TypeCustomizations = @{}
     hidden [string] $OutputFolder = (join-path $PSScriptRoot '../bin')
     hidden [string] $HelpFolder = $null
     hidden [MappedCmdCollection] $ModuleMap = $null
@@ -76,7 +77,14 @@ class CompatibilityAdapterBuilder {
         $this.WriteModuleManifest()             
     }
     
-        # Add customization based on the the CommandMap object.
+    AddTypes($types) {
+        $this.TypeCustomizations = $types
+        foreach($type in $types.Keys){
+            $this.TypesToCreate += $type
+        }
+    }
+
+    # Add customization based on the the CommandMap object.
     AddCustomization([hashtable[]] $Commands) {
         foreach($cmd in $Commands) {
             $parameters = $null
@@ -324,8 +332,14 @@ public $($object.GetType().Name)($name value)
 "@
         }
 
+        $extraFunctions = ""
+        if($this.TypeCustomizations.ContainsKey($object.GetType().FullName)){
+            $extraFunctions = $this.TypeCustomizations[$object.GetType().FullName]
+        }
+
         $def += @"
         $constructor
+        $extraFunctions
     }
 
 "@


### PR DESCRIPTION
The adapter already creates all the required types in order to allow the code to work, this change allow to customize that type adding any additional code apart from the actual type properties those are added by the process itself.