### PR TITLE
Get-AzureADApplicationProxyConnectorGroupMember

### DIFF
--- a/module/EntraBeta/AdditionalFunctions/Get-EntraBetaApplicationProxyConnectorGroupMember.ps1
+++ b/module/EntraBeta/AdditionalFunctions/Get-EntraBetaApplicationProxyConnectorGroupMember.ps1
@@ -1,0 +1,61 @@
+function Get-EntraBetaApplicationProxyConnectorGroupMember {
+    [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
+    param (
+    [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+    [System.String] $Id,
+    [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+    [System.Nullable`1[System.Int32]] $Top,
+    [Parameter( ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+    [System.String] $Filter,
+    [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+    [System.Nullable`1[System.Boolean]] $All
+    )
+
+    PROCESS {    
+        $params = @{}
+        $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
+        $params["Method"] = "GET"
+        $Id = $PSBoundParameters["Id"]
+        $params["Uri"] = "https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationProxy/connectorGroups/$Id/members"
+        if($PSBoundParameters.ContainsKey("Id"))
+        {
+            $params["Uri"] = "https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationProxy/connectorGroups/$Id/members"
+        }
+        if($PSBoundParameters.ContainsKey("Filter"))
+        {
+            $f = '$' + 'Filter'
+            $params["Uri"] = "https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationProxy/connectorGroups/$Id/members?$f=$filter"
+        }
+        if($PSBoundParameters.ContainsKey("Verbose"))
+        {
+            $params["Verbose"] = $Null
+        }
+        if($PSBoundParameters.ContainsKey("All"))
+        {
+            $params["Uri"] = "https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationProxy/connectorGroups/$Id/members"
+        }
+        if($PSBoundParameters.ContainsKey("Debug"))
+        {
+            $params["Debug"] = $Null
+        }
+        if($PSBoundParameters.ContainsKey("top"))
+        {
+            $t = '$' + 'Top'
+            $params["Uri"] = "https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationProxy/connectorGroups/$Id/members?$t=$top"
+        }
+
+        Write-Debug("============================ TRANSFORMATIONS ============================")
+        $params.Keys | ForEach-Object {"$_ : $($params[$_])" } | Write-Debug
+        Write-Debug("=========================================================================`n")
+
+        $response = Invoke-GraphRequest -Headers $customHeaders -Method $params.method -Uri $params.uri 
+        try {    
+            $call = $response.value 
+            $call
+        }
+        catch {
+            $response
+        }
+
+    }        
+}

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorGroupMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorGroupMember.md
@@ -1,0 +1,160 @@
+---
+title: Get-EntraBetaApplicationProxyConnectorGroupMember
+description: This article provides details on the Get-EntraBetaApplicationProxyConnectorGroupMember.
+ms.service: active-directory
+ms.topic: reference
+ms.date: 04/15/2023
+ms.author: eunicewaweru
+ms.reviewer: stevemutungi
+manager: CelesteDG
+author: msewaweru
+external help file: Microsoft.Graph.Entra.Beta-Help.xml
+Module Name: Microsoft.Graph.Entra.Beta
+online version:
+schema: 2.0.0
+---
+
+# Get-EntraBetaApplicationProxyConnectorGroupMember
+
+## SYNOPSIS
+The Get-EntraBetaApplicationProxyConnectorGroupMember get all the Application Proxy connectors associated with the given connector group.
+
+## SYNTAX
+
+```powershell
+Get-EntraBetaApplicationProxyConnectorGroupMember
+ -Id <String> 
+ [-All <Boolean>] 
+ [-Top <Int32>]
+ [-Filter <String>]
+```
+
+## DESCRIPTION
+The Get-EntraBetaApplicationProxyConnectorGroupMember get all the Application Proxy connectors associated with the given connector group. 
+
+## EXAMPLES
+
+### Example 1: Gets all the connectors in the group.
+```powershell
+PS C:\> Get-EntraBetaApplicationProxyConnectorGroupMember -Id 87ffe1e2-6313-4a22-93eb-da1eb8a2bf8d
+```
+```output
+Name                           Value
+----                           -----
+id                             147bd8b4-2134-4454-8f2a-1da81cf27917
+externalIp                     3.7.211.5
+machineName                    PERE-VARSHAM-FULLSTAK
+version                        1.5.3437.0
+status                         active
+
+```
+The output of this command, showing all the connectors in the group.
+
+### Example 2: Gets top one connector in the group.
+```powershell
+PS C:\>Get-EntraBetaApplicationProxyConnectorGroupMember -Id 87ffe1e2-6313-4a22-93eb-da1eb8a2bf8d -Top 1
+```
+```output
+Name                           Value
+----                           -----
+id                             147bd8b4-2134-4454-8f2a-1da81cf27917
+externalIp                     3.7.211.5
+machineName                    PERE-VARSHAM-FULLSTAK
+version                        1.5.3437.0
+status                         active
+
+```
+The output of this command, showing top one connector in the group.
+
+### Example 3: Gets the connectors in the group with filter parameter.
+```powershell
+PS C:\> Get-EntraBetaApplicationProxyConnectorGroupMember -Id 87ffe1e2-6313-4a22-93eb-da1eb8a2bf8d -Filter "machineName eq 'PERE-VARSHAM-FULLSTAK'"
+```
+```output
+Name                           Value
+----                           -----
+id                             147bd8b4-2134-4454-8f2a-1da81cf27917
+externalIp                     3.7.211.5
+machineName                    PERE-VARSHAM-FULLSTAK
+version                        1.5.3437.0
+status                         active
+
+```
+The output of this command, showing all the connectors in the group with filter parameter.
+
+## PARAMETERS
+
+### -All
+If true, return all users. If false, return the number of objects specified by the Top parameter.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Filter
+Specifies an oData v3.0 filter statement. This parameter controls which objects are returned. Details on querying with oData can be found here: https://www.odata.org/documentation/odata-version-3-0/odata-version-3-0-core-protocol/#queryingcollections
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+The ID of the Connector group. This ID can be found by running the Get-EntraBetaApplicationProxyConnectorGroup command. 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Top
+Specifies the maximum number of records to return.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### System.String
+System. Nullable`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/src/CompatibilityAdapterBuilder.ps1
+++ b/src/CompatibilityAdapterBuilder.ps1
@@ -502,6 +502,8 @@ function Get-EntraUnsupportedCommand {
             foreach ($func in $this.MissingCommandsToMap) {
                 $aliases += "   Set-Alias -Name $($func) -Value Get-EntraUnsupportedCommand -Scope Global -Force`n"
             }
+            $aliases += "   Set-Alias -Name Get-AzureADApplicationProxyConnectorGroupMember -Value Get-EntraUnsupportedCommand -Scope Global -Force`n"
+
             #Adding direct aliases for Connect-Entra and Disconnect-Entra
             $aliases += "   Set-Alias -Name Connect-Entra -Value Connect-MgGraph -Scope Global -Force`n"
             $aliases += "   Set-Alias -Name Disconnect-Entra -Value Disconnect-MgGraph -Scope Global -Force`n"


### PR DESCRIPTION
Resolved the issue with Get-AzureADApplicationProxyConnectorGroupMember by adding an Set-Alias in CompatibilityAdapter. As earlier it was not present in the Beta cmdlets list. 
Now It's working, and also able to modify the Get-Help for it.

But the Set-Alias for Get-AzureADApplicationProxyConnectorGroupMember is added twice in Entra because it was already included in that Module. However, it's functioning correctly in the Beta module.

![image](https://github.com/microsoftgraph/entra-powershell/assets/142799789/60db84b3-ed83-455b-9502-7ae65e4d35a9)
