### PR TITLE
Find-EntraBetaCommand POC

### DIFF
--- a/module/EntraBeta/AdditionalFunctions/Find-EntraBetaCommand.ps1
+++ b/module/EntraBeta/AdditionalFunctions/Find-EntraBetaCommand.ps1
@@ -1,0 +1,127 @@
+function Find-EntraBetaCommand {
+    [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
+    param (
+    [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+    [System.String] $Command,
+    [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
+    [System.String] $Uri,
+    [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+    [System.String] $ApiVersion="v1.0"
+    )
+
+    PROCESS {    
+        $params = @{}
+        if($null -ne $PSBoundParameters["Command"])
+        {
+            $params["Command"]=$PSBoundParameters["Command"]
+        }
+        if($null -ne $PSBoundParameters["Uri"])
+        {
+            $params["Uri"] = $PSBoundParameters["Uri"]
+        }
+        if($null -ne $PSBoundParameters["ApiVersion"])
+        {
+            $params["ApiVersion"] = $PSBoundParameters["ApiVersion"]
+        }
+        
+        if($PSBoundParameters.ContainsKey("Verbose"))
+        {
+            $params["Verbose"] = $Null
+        }
+       
+        if($PSBoundParameters.ContainsKey("Debug"))
+        {
+            $params["Debug"] = $Null
+        }
+        if($null -ne $PSBoundParameters["WarningVariable"])
+        {
+            $params["WarningVariable"] = $PSBoundParameters["WarningVariable"]
+        }
+        if($null -ne $PSBoundParameters["InformationVariable"])
+        {
+            $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
+        }
+      if($null -ne $PSBoundParameters["InformationAction"])
+        {
+            $params["InformationAction"] = $PSBoundParameters["InformationAction"]
+        }
+        if($null -ne $PSBoundParameters["OutVariable"])
+        {
+            $params["OutVariable"] = $PSBoundParameters["OutVariable"]
+        }
+        if($null -ne $PSBoundParameters["OutBuffer"])
+        {
+            $params["OutBuffer"] = $PSBoundParameters["OutBuffer"]
+        }
+        if($null -ne $PSBoundParameters["ErrorVariable"])
+        {
+            $params["ErrorVariable"] = $PSBoundParameters["ErrorVariable"]
+        }
+        if($null -ne $PSBoundParameters["PipelineVariable"])
+        {
+            $params["PipelineVariable"] = $PSBoundParameters["PipelineVariable"]
+        }
+        if($null -ne $PSBoundParameters["ErrorAction"])
+        {
+            $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
+        }
+        if($null -ne $PSBoundParameters["WarningAction"])
+        {
+            $params["WarningAction"] = $PSBoundParameters["WarningAction"]
+        }
+        if($null -ne $PSBoundParameters["Top"])
+        {
+            $params["Top"] = $PSBoundParameters["Top"]
+        }
+    
+        Write-Debug("============================ TRANSFORMATIONS ============================")
+        $params.Keys | ForEach-Object {"$_ : $($params[$_])" } | Write-Debug
+        Write-Debug("=========================================================================`n")
+
+        #Look up to map from a Cmdlet to the Uris. 
+        $dictionary=@{}
+
+        ###############################################################################################################################
+        #TODO: ADD NEW CMDLETS -> URIs MAPPINGS HERE
+        $dictionary["Set-EntraBetaApplicationProxyApplication"]=@("applications/{object-id}","applications/{object-Id}/connectorGroup")
+        $dictionary["New-EntraBetaApplicationProxyApplication"]=@("applications/{object-id}","/servicePrincipals","applications/{object-Id}/connectorGroup")
+        $dictionary["Remove-EntraBetaApplicationProxyApplicationConnectorGroup"]=@("applications/{object-Id}/connectorGroup")
+        
+
+        ##############################################################################################################################
+
+        $responses=@()
+        # keyCmdlet is the commandlet that maps to more than one API call.
+        $keyCmdlet=$params["Command"]
+      
+       if ($null -ne $keyCmdlet) {
+        if($dictionary.ContainsKey($keyCmdlet)){
+         $uris = $dictionary.$keyCmdlet
+        
+          foreach($uri in $uris){
+             $response=Find-MgGraphCommand -Uri $uri -ApiVersion beta
+             if($null -ne $response){
+                $responses+=$response
+             }  
+           }
+        }
+        
+       } else {
+        #Invoke the Find-MgGraphCommand with the params
+        $responses=Find-MgGraphCommand @params -ApiVersion beta
+      }
+
+      #Map the Command names and Module names 
+        foreach($response in $responses){
+             $commandValue=$response.Command
+             $newCommandValue=$commandValue -replace '(Mg|MgGraph)', "Entra"
+             $response.Command=$newCommandValue
+
+             $appValue=$response.Module
+             $newAppValue=$appValue -replace "Beta", "EntraBeta"
+             $response.Module=$newAppValue
+        }
+
+        $responses
+    }        
+}


### PR DESCRIPTION
Find-EntraBetaCommand/Find-EntraCommand extracts the details of a given Cmdlet or Graph API Uri that includes the Command name, Module, Uri, Method, OutputType, and Permissions.

Implementation details
Proposed Solution:
1.	We maintain a dictionary that will contain key-value pairs, where the Key is a command name, and the value is an array of Graph API endpoints invoked by that command. We store that array as an array of strings.

2.	In the implementation of the Find-EntraBetaCommand/ Find-EntraCommand function, we’ll use the parse the -Command parameter to get the name of the command.

3.	We’ll look up that command in the dictionary. If not found, we’ll proceed and invoke the Find- 
        MgGraphCommand using the bound parameters and return the results.
4.	If found, we’ll extract the array of endpoints and for each of the endpoints, we’ll invoke the Find- 
        MgGraphCommand using the -Uri parameter. 

7.	Map the Command and Module value from the array IGraphCommand result returned from *-Mg| MgGraph* to *-EntraBeta* or *Entra*
8.	We’ll concatenate the results and return the results.
