### PR TITLE
Fix code sign

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -54,7 +54,7 @@ jobs:
             displayName: Publish NuGet to preview feed
             inputs:
               command: push
-              packagesToPush: $(Build.ArtifactStagingDirectory)/**/Microsoft.Graph.*.nupkg
+              packagesToPush: $(Build.ArtifactStagingDirectory)/**/Microsoft.Graph.Entra*.nupkg
               publishVstsFeed: $(PROJECT_NAME)/$(PREVIEW_FEED_NAME)
               allowPackageConflicts: true
 


### PR DESCRIPTION
We are publishing `Microsoft.Graph.*` modules to locally gallery https://github.com/microsoftgraph/entra-powershell/pull/853

We need to only push `Microsoft.Graph.Entra.*` packages to PS Gallery