### PR TITLE
Add scopes - batch 1 for Entra PowerShell cmdlets

### DIFF
--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraEnvironment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraEnvironment.md
@@ -23,7 +23,6 @@ Adds Microsoft Entra environment to the settings file.
 
 ## Syntax
 
-
 ### Add Entra Environment Name
 
 ```powershell
@@ -46,13 +45,22 @@ Adds Microsoft Entra environment to the settings file.
 ### Example 1: Add a user defined environment
 
 ```powershell
-PS C:\>Add-EntraEnvironment -Name "Canary" -GraphEndpoint "https://canary.graph.microsoft.com" -AzureADEndpoint "https://login.microsoftonline.com"
+$params = @{
+    Name = 'Canary'
+    GraphEndpoint = 'https://canary.graph.microsoft.com'
+    AzureADEndpoint = 'https://login.microsoftonline.com'
+}
+
+Add-EntraEnvironment @params
+```
+
+```Output
 Name     AzureADEndpoint                      GraphEndpoint                 Type
 ----     ---------------                      -------------                 ----
 Canary    https://login.microsoftonline.com   https://microsoftgraph.com User-defined                                                                                    {}
 ```
 
-Adds a User defined Entra environment to the settings file.
+Adds a user-defined Entra environment to the settings file.
 
 ## Parameters
 
@@ -97,7 +105,7 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Convert-EntraFederatedUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Convert-EntraFederatedUser.md
@@ -98,6 +98,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-- See more details : <https://learn.microsoft.com/graph/api/authenticationmethod-resetpassword>
+- For more information, see [resetPassword](/graph/api/authenticationmethod-resetpassword).
 
 ## Related Links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Convert-EntraFederatedUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Convert-EntraFederatedUser.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Convert-EntraFederatedUser
 
 ## Synopsis
+
 Updates a user in a domain that was recently converted from single sign-on (also known as identity federation) to standard authentication type.
 
 ## Syntax
@@ -31,13 +32,22 @@ Convert-EntraFederatedUser
 ```
 
 ## Description
-The Convert-EntraFederatedUser cmdlet is used to update a user in a domain that was recently converted from single sign-on (also known as identity federation) to standard authentication type. A new password must be provided for the user.
+
+The `Convert-EntraFederatedUser` cmdlet is used to update a user in a domain that was recently converted from single sign-on (also known as identity federation) to standard authentication type. A new password must be provided for the user.
+
+This process writes the new password to Microsoft Entra ID and, if configured with password writeback, pushes it to on-premises Active Directory. The admin can provide a new password or let the system generate one. The user will be prompted to change their password at their next sign-in.
+
+For delegated scenarios, the administrator needs at least the Authentication Administrator or Privileged Authentication Administrator Microsoft Entra role.
+
+Admins with User Administrator, Helpdesk Administrator, or Password Administrator roles can also reset passwords for non-admin users and a limited set of admin roles.
 
 ## Examples
 
 ### EXAMPLE 1: Update a user in a domain
+
 ```powershell
-PS C:\> Convert-EntraFederatedUser -UserPrincipalName "pattifuller@contoso.com"
+Connect-Entra -Scopes 'UserAuthenticationMethod.ReadWrite.All'
+Convert-EntraFederatedUser -UserPrincipalName 'pattifuller@contoso.com'
 ```
 
 This command updates a user in a domain.
@@ -45,10 +55,11 @@ This command updates a user in a domain.
 ## Parameters
 
 ### -UserPrincipalName
+
 The Microsoft Entra ID UserID for the user to convert.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -60,10 +71,13 @@ Accept wildcard characters: False
 ```
 
 ### -NewPassword
+
 The new password of the user.
 
+The new password is required for tenants with hybrid password scenarios. If omitted for a cloud-only password, the system generates a password. This password is a Unicode string with no other encoding. It is validated against the tenant's banned password system before acceptance and must meet the tenant's cloud and/or on-premises password requirements.
+
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -75,12 +89,15 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ## Outputs
 
 ## Notes
+
+- See more details : <https://learn.microsoft.com/graph/api/authenticationmethod-resetpassword>
 
 ## Related Links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraDirectoryRole.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraDirectoryRole.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-- See additional details - <https://learn.microsoft.com/graph/api/directoryrole-post-directoryroles>
+- For additional details see [Activate directoryRole](/graph/api/directoryrole-post-directoryroles).
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraDirectoryRole.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraDirectoryRole.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Enable-EntraDirectoryRole
 
 ## Synopsis
+
 Activates an existing directory role in Microsoft Entra ID.
 
 ## Syntax
@@ -30,33 +31,39 @@ Enable-EntraDirectoryRole
 ```
 
 ## Description
-The Enable-EntraDirectoryRole cmdlet activates an existing directory role in Microsoft Entra ID.
+
+The `Enable-EntraDirectoryRole` cmdlet activates an existing directory role in Microsoft Entra ID.
+
+The Company Administrators and the default user directory roles (User, Guest User, and Restricted Guest User) are activated by default. To access and assign members to other directory roles, you must first activate them using their corresponding directory role template ID.
 
 ## Examples
 
 ### Example 1: Enable a directory role
+
 ```powershell
-PS C:\> $InviterRole = Get-EntraDirectoryRoleTemplate | Where-Object {$_.DisplayName -eq "Guest Inviter"}
-PS C:\> Enable-EntraDirectoryRole -RoleTemplateId $InviterRole.ObjectId
+Connect-Entra -Scopes 'RoleManagement.ReadWrite.Directory'
+$InviterRole = Get-EntraDirectoryRoleTemplate | Where-Object {$_.DisplayName -eq 'Guest Inviter'}
+Enable-EntraDirectoryRole -RoleTemplateId $InviterRole.ObjectId
 ```
 
-```output
+```Output
 DeletedDateTime Id                                   Description                                      DisplayName   RoleTemplateId
 --------------- --                                   -----------                                      -----------   --------------
                 b5baa59b-86ab-4053-ac3a-0396116d1924 Guest Inviter has access to invite guest users.  Guest Inviter 92ed04bf-c94a-4b82-9729-b799a7a4c178
 ```
 
-The first command gets an inviter role that has the display name Guest Inviter by using the [Get-EntraDirectoryRoleTemplate](./Get-EntraDirectoryRoleTemplate.md) cmdlet and stores Guest Inviter in the $InviterRole variable.  
+The example shows how to enable the directory role.
 
-The final command enables the directory role in $InviterRole.  
+You can use `Get-EntraDirectoryRoleTemplate` to fetch a specific directory role to activate.
 
 ## Parameters
 
 ### -RoleTemplateId
-The ID of the Role template to enable
+
+The ID of the directoryRoleTemplate that the role is based on.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -68,7 +75,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
@@ -76,9 +84,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## Notes
 
+- See additional details - <https://learn.microsoft.com/graph/api/directoryrole-post-directoryroles>
+
 ## Related Links
 
 [Get-EntraDirectoryRole](Get-EntraDirectoryRole.md)
 
 [Get-EntraDirectoryRoleTemplate](Get-EntraDirectoryRoleTemplate.md)
-

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAccountSku.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAccountSku.md
@@ -19,17 +19,20 @@ schema: 2.0.0
 # Get-EntraAccountSku
 
 ## Synopsis
+
 Retrieves all the SKUs for a company.
 
 ## Syntax
 
 ### GetQuery (Default)
+
 ```powershell
 Get-EntraAccountSku 
  [<CommonParameters>]
 ```
 
 ### GetById
+
 ```powershell
 Get-EntraAccountSku 
  [-TenantId <Guid>] 
@@ -37,47 +40,54 @@ Get-EntraAccountSku
 ```
 
 ## Description
-The Get-EntraAccountSku returns all the SKUs that the company owns.
+
+The `Get-EntraAccountSku` retrieves the list of commercial subscriptions acquired by an organization.
+
+To map license names as displayed in the Microsoft Entra admin center or the Microsoft 365 admin center to their Microsoft Graph skuId and skuPartNumber properties, refer to the provided mapping information.
 
 ## Examples
 
 ### EXAMPLE 1: Gets a list of SKUs
+
 ```powershell
-PS C:\> Get-EntraAccountSku
+Connect-Entra -Scopes 'Organization.Read.All'
+Get-EntraAccountSku
 ```
 
-```output
+```Output
 Id                                            AccountId                            AccountName   AppliesTo
 --                                            ---------                            -----------   -------
-95d4390e_b05e124f-c7cc-45a0-a6aa-8cf78c946968 d5aec55f-2d12-4442-8d2f-ccca95d4390e M365x99297270 User
-95d4390e_c7df2760-2c81-4ef7-b578-5b5392b571df d5aec55f-2d12-4442-8d2f-ccca95d4390e M365x99297270 User
-95d4390e_6fd2c87f-b296-42f0-b197-1e91e994b900 d5aec55f-2d12-4442-8d2f-ccca95d4390e M365x99297270 User
+eeeeeeee-4444-5555-6666-ffffffffffff aaaabbbb-0000-cccc-1111-dddd2222eeee Contoso User
+ffffffff-5555-6666-7777-aaaaaaaaaaaa aaaabbbb-0000-cccc-1111-dddd2222eeee Contoso User
+dddddddd-3333-4444-5555-eeeeeeeeeeee aaaabbbb-0000-cccc-1111-dddd2222eeee Contoso User
 ```
 
 This command returns a list of SKUs.
 
 ### EXAMPLE 2: Gets a list of SKUs by TenantId
+
 ```powershell
-PS C:\> Get-EntraAccountSku -TenantId "d5aec55f-2d12-4442-8d2f-ccca95d4390e"
+Connect-Entra -Scopes 'Organization.Read.All'
+Get-EntraAccountSku -TenantId 'aaaabbbb-0000-cccc-1111-dddd2222eeee'
 ```
 
-```output
+```Output
 Id                                            AccountId                            AccountName   AppliesTo
 --                                            ---------                            -----------   -------
-95d4390e_b05e124f-c7cc-45a0-a6aa-8cf78c946968 d5aec55f-2d12-4442-8d2f-ccca95d4390e M365x99297270 User
-95d4390e_c7df2760-2c81-4ef7-b578-5b5392b571df d5aec55f-2d12-4442-8d2f-ccca95d4390e M365x99297270 User
-95d4390e_6fd2c87f-b296-42f0-b197-1e91e994b900 d5aec55f-2d12-4442-8d2f-ccca95d4390e M365x99297270 User
+eeeeeeee-4444-5555-6666-ffffffffffff aaaabbbb-0000-cccc-1111-dddd2222eeee Contoso User
+ffffffff-5555-6666-7777-aaaaaaaaaaaa aaaabbbb-0000-cccc-1111-dddd2222eeee Contoso User
+dddddddd-3333-4444-5555-eeeeeeeeeeee aaaabbbb-0000-cccc-1111-dddd2222eeee Contoso User
 ```
 
-This command returns a list of SKUs by TenantId.
+This command returns a list of SKUs for a tenant.
 
 ## Parameters
 
 ### -TenantId
+
 The unique ID of the tenant to perform the operation on.
 If this isn't provided then the value defaults to
 the tenant of the current user.
-This parameter is only applicable to partner users.
 
 ```yaml
 Type: Guid
@@ -92,7 +102,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationKeyCredential.md
@@ -18,6 +18,7 @@ schema: 2.0.0
 # Get-EntraApplicationKeyCredential
 
 ## Synopsis
+
 Gets the key credentials for an application.
 
 ## Syntax
@@ -29,31 +30,22 @@ Get-EntraApplicationKeyCredential
 ```
 
 ## Description
-The Get-EntraApplicationKeyCredential cmdlet gets the key credentials for an application.
+
+The `Get-EntraApplicationKeyCredential` cmdlet retrieves the key credentials for an application.
 
 ## Examples
 
 ### Example 1: Get key credentials
+
 ```powershell
-PS C:\> Get-EntraApplicationKeyCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84"
+Connect-Entra -Scopes 'Application.Read.All'
+Get-EntraApplicationKeyCredential -ObjectId '00001111-aaaa-2222-bbbb-3333cccc4444'
 ```
 
-```output
-CustomKeyIdentifier : {116, 101, 115, 116}
-EndDate             : 10/23/2024 11:36:56 AM
-KeyId               : 52ab6cca-bc59-4f06-8450-75a3d2b8e53b
-StartDate           : 11/22/2023 11:35:16 AM
-Type                : Symmetric
-Usage               : Sign
-Value               :
-
-CustomKeyIdentifier : {84, 101, 115, 116}
-EndDate             : 10/23/2024 9:46:49 AM
-KeyId               : 2e5143ee-9912-40c1-8c6a-a84f8124a6af
-StartDate           : 10/23/2023 9:46:48 AM
-Type                : Symmetric
-Usage               : Sign
-Value               :
+```Output
+CustomKeyIdentifier DisplayName     EndDateTime           Key KeyId                                StartDateTime         Type               Usage
+------------------- -----------     -----------           --- -----                                -------------         ----               -----
+{116, 101, 115, 116…} MyApp Cert 6/27/2024 11:49:17 AM     bbbbbbbb-1c1c-2d2d-3e3e-444444444444 6/27/2023 11:29:17 AM AsymmetricX509Cert Verify
 ```
 
 This command gets the key credentials for the specified application.
@@ -61,10 +53,11 @@ This command gets the key credentials for the specified application.
 ## Parameters
 
 ### -ObjectId
+
 Specifies a unique ID of an application in Microsoft Entra ID for which to get key credentials.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -76,7 +69,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
@@ -89,4 +83,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [New-EntraApplicationKeyCredential](New-EntraApplicationKeyCredential.md)
 
 [Remove-EntraApplicationKeyCredential](Remove-EntraApplicationKeyCredential.md)
-

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationLogo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationLogo.md
@@ -68,7 +68,7 @@ This example shows how to retrieve the application logo for an application that 
 
 ### -FileName
 
-If provided, the application logo is copied to the file who's name is provided in this parameter.
+If provided, the application logo is saved to the file using the specified file name.
 
 ```yaml
 Type: System.String
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 
 ### -FilePath
 
-If provided, the application logo is copied with a random filename to the file path that is specified in this parameter.
+If provided, the application logo is saved to the specified file path using a random file name.
 
 ```yaml
 Type: System.String
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 
 ### -View
 
-If set to $true, the application's logo is displayed in a new window on the screen.
+If set to $true, displays the application logo in a new window.
 
 ```yaml
 Type: System.Boolean

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationLogo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationLogo.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Get-EntraApplicationLogo
 
 ## Synopsis
+
 Retrieve the logo of an application.
 
 ## Syntax
@@ -33,13 +34,15 @@ Get-EntraApplicationLogo
 ```
 
 ## Description
+
 The Get-EntraApplicationLogo cmdlet retrieves the logo that is set for an application.
 
 ## Examples
 
 ### Example 1
+
 ```powershell
-PS C:\WINDOWS\system32> Get-EntraApplicationLogo -ObjectId 79592454-dea7-4660-9d91-f1768e5055ac
+Get-EntraApplicationLogo -ObjectId '00001111-aaaa-2222-bbbb-3333cccc4444'
 ```
 
 ```output
@@ -64,10 +67,11 @@ This example shows how to retrieve the application logo for an application that 
 ## Parameters
 
 ### -FileName
+
 If provided, the application logo is copied to the file who's name is provided in this parameter.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -79,10 +83,11 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
+
 If provided, the application logo is copied with a random filename to the file path that is specified in this parameter.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -94,10 +99,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 The ObjectID of the application for which the logo is to be retrieved.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -109,10 +115,11 @@ Accept wildcard characters: False
 ```
 
 ### -View
+
 If set to $true, the application's logo is displayed in a new window on the screen.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -124,16 +131,21 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 ### System.Boolean
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## Related Links
+
+[Set-EntraApplicationLogo](Set-EntraApplicationLogo.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactDirectReport.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactDirectReport.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Get-EntraContactDirectReport
 
 ## Synopsis
+
 Get the direct reports for a contact.
 
 ## Syntax
@@ -32,27 +33,31 @@ Get-EntraContactDirectReport
 ```
 
 ## Description
-The Get-EntraContactDirectReport cmdlet gets the direct reports for a contact.
+
+The `Get-EntraContactDirectReport` cmdlet gets the direct reports for an organizational contact.
 
 ## Examples
 
 ### Example 1: Get the direct reports of a contact
+
 ```powershell
-PS C:\> $Contact = Get-EntraContact -Top 1
-PS C:\> Get-EntraContactDirectReport -ObjectId $Contact.ObjectId
+Connect-Entra -Scopes 'OrgContact.Read.All'
+$Contact = Get-EntraContact -Top 1
+Get-EntraContactDirectReport -ObjectId $Contact.ObjectId
 ```
 
-The first command gets a contact by using the [Get-EntraContact](./Get-EntraContact.md) cmdlet, and then stores it in the $Contact variable.  
+This example shows how to retrieve direct reports for an organizational contact.
 
-The second command gets the direct reports for $Contact.
+You can use `Get-EntraContact` cmdlet to retrieve an organizational contact.
 
 ## Parameters
 
 ### -All
+
 List all pages.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -64,10 +69,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 Specifies the ID of a contact in Microsoft Entra ID.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -79,10 +85,11 @@ Accept wildcard characters: False
 ```
 
 ### -Top
+
 Specifies the maximum number of records to return.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -94,7 +101,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactThumbnailPhoto.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactThumbnailPhoto.md
@@ -16,7 +16,9 @@ schema: 2.0.0
 ---
 
 # Get-EntraContactThumbnailPhoto
+
 ## Synopsis
+
 Retrieves the thumbnail photo of a contact.
 
 ## Syntax
@@ -31,13 +33,16 @@ Get-EntraContactThumbnailPhoto
 ```
 
 ## Description
+
 Retrieves the thumbnail photo of a contact.
 
 ## Examples
 
 ### Example 1: Get the memberships of a contact
+
 ```powershell
-PS C:\> Get-EntraContactThumbnailPhoto -ObjectId b052db07-e7ec-4c0e-b481-a5ba550b9ee7
+Connect-Entra -Scopes 'Contacts.Read'
+Get-EntraContactThumbnailPhoto -ObjectId 'bbbbbbbb-1111-2222-3333-cccccccccccc'
 ```
 
 ```output
@@ -49,10 +54,10 @@ Height               : 390
 HorizontalResolution : 96
 VerticalResolution   : 96
 Flags                : 77840
-RawFormat            : [ImageFormat: b96b3cae-0728-11d3-9d7b-0000f81ef32e]
+RawFormat            : [ImageFormat: aaaa0000-bb11-2222-33cc-444444dddddd]
 PixelFormat          : Format24bppRgb
 Palette              : System.Drawing.Imaging.ColorPalette
-FrameDimensionsList  : {7462dc86-6180-4c7e-8e3f-ee7333a7a483}
+FrameDimensionsList  : {eeee4444-ff55-6666-77aa-888888bbbbbb}
 PropertyIdList       : {274, 305, 306, 36867...}
 PropertyItems        : {274, 305, 306, 36867...}
 ```
@@ -62,10 +67,11 @@ This example retrieves the thumbnail photo of the contact object specified with 
 ## Parameters
 
 ### -FileName
+
 When provided, the cmdlet writes a copy of the thumbnail photo to this filename.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -77,10 +83,11 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
+
 When provided, the cmdlet writes a copy of the thumbnail photo to this file path using a random filename.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -92,10 +99,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 The object ID of the contact for which the thumbnail photo is retrieved.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -107,10 +115,11 @@ Accept wildcard characters: False
 ```
 
 ### -View
+
 If this parameter value is set to $True, display the retrieved thumbnail photo in a new window.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -122,16 +131,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 System.Boolean
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## RELATED LINKS

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraCurrentSessionInfo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraCurrentSessionInfo.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Get-EntraCurrentSessionInfo
 
 ## Synopsis
+
 This cmdlet returns the current session state.
 
 ## Syntax
@@ -29,26 +30,28 @@ Get-EntraCurrentSessionInfo
 ```
 
 ## Description
-The Get-EntraCurrentSessionInfo cmdlet returns the current session state.
+
+The `Get-EntraCurrentSessionInfo` cmdlet returns the current session state.
 
 ## Examples
 
 ### Example 1: Get current session info
+
 ```powershell
-PS C:\> Get-EntraCurrentSessionInfo
+Get-EntraCurrentSessionInfo
 ```
 
 ```output
 ObjectId               :
-ClientId               : 8886ad7b-1795-4542-9808-c85859d97f23
-TenantId               : d5aec55f-2d12-4442-8d2f-ccca95d4390e
-Scopes                 : {Agreement.ReadWrite.All, Policy.ReadWrite.IdentityProtection, CustomSecAttributeDefinition.ReadWrite.All, TeamMember.Read.All...}
+ClientId               : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId               : bbbbcccc-1111-dddd-2222-eeee3333ffff
+Scopes                 : {User.Read.All, Policy.Read.IdentityProtection, Group.Read.All...}
 AuthType               : AppOnly
 TokenCredentialType    : ClientCertificate
-CertificateThumbprint  : 706EFE2C52F3CD36755AF6A959F4EA439677BCAD
+CertificateThumbprint  : AA11BB22CC33DD44EE55FF66AA77BB88CC99DD00
 CertificateSubjectName :
 Account                :
-AppName                : MG_graph_auth
+AppName                : My Entra App
 ContextScope           : Process
 Certificate            :
 PSHostVersion          : 5.1.22621.2506
@@ -62,14 +65,19 @@ This command gets the current session info.
 ## Parameters
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### None
+
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## Related Links
+
+[Get-EntraContext](Get-EntraContext.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncConfiguration.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Get-EntraDirSyncConfiguration
 
 ## Synopsis
+
 Gets the directory synchronization settings.
 
 ## Syntax
@@ -30,13 +31,15 @@ Get-EntraDirSyncConfiguration
 ```
 
 ## Description
-The Get-EntraDirSyncConfiguration cmdlet gets the directory synchronization settings.
+
+The `Get-EntraDirSyncConfiguration` cmdlet gets the directory synchronization settings.
 
 ## Examples
 
 ### Example 1: Get directory synchronization settings
+
 ```powershell
-PS C:\> Get-EntraDirSyncConfiguration 
+Get-EntraDirSyncConfiguration 
 ```
 
 ```output
@@ -48,8 +51,9 @@ AccidentalDeletionThreshold DeletionPreventionType
 This command gets directory synchronization settings.
 
 ### Example 2: Get directory synchronization settings by TenantId
+
 ```powershell
-PS C:\> Get-EntraDirSyncConfiguration -TenantId "d5aec55f-2d12-4442-8d2f-ccca95d4390e"
+Get-EntraDirSyncConfiguration -TenantId 'aaaabbbb-0000-cccc-1111-dddd2222eeee'
 ```
 
 ```output
@@ -63,12 +67,13 @@ This command gets directory synchronization settings by TenantId.
 ## Parameters
 
 ### -TenantId
-The unique ID of the tenant to perform the operation on. 
-If this isn't provided then it defaults to the tenant of the current user. 
+
+The unique ID of the tenant to perform the operation on.
+If this isn't provided then it defaults to the tenant of the current user.
 This parameter is only applicable to partner users.
 
 ```yaml
-Type: Guid
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -80,11 +85,13 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.Nullable`1[[System.Guid, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
 ## Outputs
 
 ## Notes

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncfeature.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncfeature.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Get-EntraDirSyncfeature
 
 ## Synopsis
+
 Used to check the status of identity synchronization features for a tenant.
 
 ## Syntax
@@ -31,8 +32,11 @@ Get-EntraDirSyncfeature
 ```
 
 ## Description
-The Get-EntraDirSyncfeature cmdlet is used to check the status of identity synchronization features for a tenant.
+
+The `Get-EntraDirSyncfeature` cmdlet checks the status of identity synchronization features for a tenant.
+
 Features that can be used with this cmdlet include:
+
 - **DeviceWriteback**
 - **DirectoryExtensions**
 - **DuplicateProxyAddressResiliency**
@@ -43,31 +47,51 @@ Features that can be used with this cmdlet include:
 - **UnifiedGroupWriteback**
 - **UserWriteback**
 
-The cmdlet can also be run without any feature being specified, in which case it returns a list of all features and whether they're enabled or disabled.
+The cmdlet can be run without specifying any features, in which case it returns a list of all features and their enabled or disabled status.
 
 ## Examples
 
 ### EXAMPLE 1: Return a list of all possible DirSync features and whether they're enabled (True) or disabled (False)
+
 ```powershell
-PS C:\> Get-EntraDirSyncfeature
+Connect-Entra -Scopes 'OnPremDirectorySynchronization.Read.All'
+Get-EntraDirSyncfeature
 ```
 
-```output
+```Output
 Enabled DirSyncFeature
 ------- --------------
   False BlockCloudObjectTakeoverThroughHardMatch
   False BlockSoftMatch
   False BypassDirSyncOverrides
+  False CloudPasswordPolicyForPasswordSyncedUsers
+  False ConcurrentCredentialUpdate
+   True ConcurrentOrgIdProvisioning
+  False DeviceWriteback
+  False DirectoryExtensions
+  False FopeConflictResolution
+  False GroupWriteBack
+  False PasswordSync
+  False PasswordWriteback
+   True QuarantineUponProxyAddressesConflict
+   True QuarantineUponUpnConflict
+   True SoftMatchOnUpn
+   True SynchronizeUpnForManagedUsers
+  False UnifiedGroupWriteback
+  False UserForcePasswordChangeOnLogon
+  False UserWriteback
 ```
 
 This command returns a list of all possible DirSync features and whether they're enabled (True) or disabled (False).
 
 ### EXAMPLE 2: Return whether PasswordSync is enabled for the tenant (True) or disabled (False)
+
 ```powershell
-PS C:\> Get-EntraDirSyncfeature -Feature PasswordSync
+Connect-Entra -Scopes 'OnPremDirectorySynchronization.Read.All'
+Get-EntraDirSyncfeature -Feature PasswordSync
 ```
 
-```output
+```Output
 Enabled DirSyncFeature
 ------- --------------
   False PasswordSync
@@ -78,6 +102,7 @@ This command returns whether PasswordSync is enabled for the tenant (True) or di
 ## Parameters
 
 ### -TenantId
+
 The unique ID of the tenant to perform the operation on.
 If this isn't provided then the value defaults to the tenant of the current user.
 This parameter is only applicable to partner users.
@@ -95,10 +120,11 @@ Accept wildcard characters: False
 ```
 
 ### -Feature
+
 The DirSync feature to get the status of.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -110,7 +136,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserThumbnailPhoto.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserThumbnailPhoto.md
@@ -18,6 +18,7 @@ schema: 2.0.0
 # Get-EntraUserThumbnailPhoto
 
 ## Synopsis
+
 Retrieve the thumbnail photo of a user.
 
 ## Syntax
@@ -32,24 +33,35 @@ Get-EntraUserThumbnailPhoto
 ```
 
 ## Description
+
 Retrieve the thumbnail photo of a user.
 
 ## Examples
 
 ### Example 1: Retrieve thumbnail photo by Id
+
 ```powershell
-PS C:\WINDOWS\system32> Get-EntraUserThumbnailPhoto -ObjectId df19e8e6-2ad7-453e-87f5-037f6529ae16
+Connect-Entra -Scopes 'User.Read' #Delegated Permission
+Connect-Entra -Scopes 'User.Read.All' #Application Permission
+Get-EntraUserThumbnailPhoto -ObjectId '00aa00aa-bb11-cc22-dd33-44ee44ee44ee'
 ```
 
-This example demonstrates how to retrieve the thumbnail photo of a user that is specified through the value of the ObejctId parameter.
+```Output
+Id      Height Width
+--      ------ -----
+default 292    278
+```
+
+This example demonstrates how to retrieve the thumbnail photo of a specified user.
 
 ## Parameters
 
 ### -FileName
+
 If specified, a copy of the thumbnail photo is written to the specified file name.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -61,10 +73,11 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
+
 If specified, a copy of the thumbnail photo is written to the specified file path with a random name.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -76,10 +89,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 The object ID of the user for which the thumbnail photo is retrieved.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -91,10 +105,11 @@ Accept wildcard characters: False
 ```
 
 ### -View
+
 If true, view the photo on the screen in a new window.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -106,16 +121,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 System.Boolean
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## Related Links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplication.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # New-EntraApplication
 
 ## Synopsis
+
 Creates (registers) a new application object.
 
 ## Syntax
@@ -48,50 +49,61 @@ New-EntraApplication
 ```
 
 ## Description
+
 Creates (registers) a new application object.
 
 ## Examples
 
 ### Example 1: Create an application
+
 ```powershell
-PS C:\> New-EntraApplication -DisplayName "My new application"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+New-EntraApplication -DisplayName 'My new application'
 ```
 
-```output
-DisplayName        Id                                   AppId                                SignInAudience PublisherDomain
------------        --                                   -----                                -------------- ---------------
-My new application 7b31c9a5-5ee8-4bc6-8c9f-c0f572ccb494 9149506f-6ac5-40c8-80ae-0bc05378da66 AzureADMyOrg   M365x99297270.mail.onmicrosoft.com
+```Output
+DisplayName Id                                   AppId                                SignInAudience PublisherDomain
+----------- --                                   -----                                -------------- ---------------
+My new application       dddd3333-ee44-5555-66ff-777777aaaaaa 22223333-cccc-4444-dddd-5555eeee6666 AzureADMyOrg   contoso.com
 ```
 
 This command creates an application in Microsoft Entra ID.
 
 ### Example 2: Create an application using IdentifierUris parameter
+
 ```powershell
-PS C:\> New-EntraApplication -DisplayName "My new application" -IdentifierUris "https://mynewapp.contoso.com"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+New-EntraApplication -DisplayName 'My new application' -IdentifierUris 'https://mynewapp.contoso.com'
 ```
 
-```output
-DisplayName        Id                                   AppId                                SignInAudience PublisherDomain
------------        --                                   -----                                -------------- ---------------
-My new application 7b31c9a5-5ee8-4bc6-8c9f-c0f572ccb494 9149506f-6ac5-40c8-80ae-0bc05378da66 AzureADMyOrg   M365x99297270.mail.onmicrosoft.com
+```Output
+DisplayName Id                                   AppId                                SignInAudience PublisherDomain
+----------- --                                   -----                                -------------- ---------------
+My new application       dddd3333-ee44-5555-66ff-777777aaaaaa 22223333-cccc-4444-dddd-5555eeee6666 AzureADMyOrg   contoso.com
 ```
 
 This command creates an application in Microsoft Entra ID.
 
 ### Example 3: Create an application using AddIns parameter
+
 ```powershell
-PS C:\> $addin = New-Object Microsoft.Open.MSGraph.Model.AddIn
-PS C:\> $addin.Type = 'testtype'
-PS C:\> $addinproperties = New-Object System.collections.Generic.List[Microsoft.Open.MSGraph.Model.KeyValue]
-PS C:\> $addinproperties.Add([Microsoft.Open.MSGraph.Model.KeyValue]@{ Key = "key"; Value = "value" })
-PS C:\> $addin.Properties = $addinproperties
-PS C:\> New-EntraApplication -DisplayName "My new application" -AddIns $addin
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+
+$addin = New-Object Microsoft.Open.MSGraph.Model.AddIn
+$addin.Type = 'testtype'
+$addinproperties = New-Object System.collections.Generic.List[Microsoft.Open.MSGraph.Model.KeyValue]
+$addinproperties.Add([Microsoft.Open.MSGraph.Model.KeyValue]@{ Key = "key"; Value = "value" })
+$addin.Properties = $addinproperties
+New-EntraApplication -DisplayName 'My new application' -AddIns $addin
 ```
 
-```output
-DisplayName        Id                                   AppId                                SignInAudience PublisherDomain
------------        --                                   -----                                -------------- ---------------
-My new application 7b31c9a5-5ee8-4bc6-8c9f-c0f572ccb494 9149506f-6ac5-40c8-80ae-0bc05378da66 AzureADMyOrg   M365x99297270.mail.onmicrosoft.com
+```Output
+DisplayName Id                                   AppId                                SignInAudience PublisherDomain
+----------- --                                   -----                                -------------- ---------------
+My new application       dddd3333-ee44-5555-66ff-777777aaaaaa 22223333-cccc-4444-dddd-5555eeee6666 AzureADMyOrg   contoso.com
 ```
 
 This command creates an application in Microsoft Entra ID.
@@ -99,8 +111,11 @@ This command creates an application in Microsoft Entra ID.
 ## Parameters
 
 ### -AddIns
+
 Defines custom behavior that a consuming service can use to call an app in specific contexts.
+
 For example, applications that can render file streams might set the addIns property for its "FileHandler" functionality.
+
 This lets services like Office 365 call the application in the context of a document the user is working on.
 
 ```yaml
@@ -116,6 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -Api
+
 Specifies settings for an application that implements a web API.
 
 ```yaml
@@ -131,6 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -AppRoles
+
 The collection of application roles that an application might declare.
 These roles can be assigned to users, groups, or service principals.
 
@@ -147,10 +164,11 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
+
 Specifies the display name of the application.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -162,10 +180,11 @@ Accept wildcard characters: False
 ```
 
 ### -GroupMembershipClaims
+
 Configures the groups claim issued in a user or OAuth 2.0 access token that the application expects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -177,10 +196,13 @@ Accept wildcard characters: False
 ```
 
 ### -IdentifierUris
+
 User-defined URIs that uniquely identify a Web application within its Microsoft Entra ID tenant, or within a verified custom domain (see "Domains" tab in the Azure classic portal) if the application is multitenant.
 
 The first element is populated from the Web application's "APP ID URI" field if updated via the Azure classic portal (or respective Microsoft Entra ID PowerShell cmdlet parameter).
+
 Extra URIs can be added via the application manifest; see Understanding the Microsoft Entra ID Application Manifest for details.
+
 This collection is also used to populate the Web application's servicePrincipalNames collection.
 
 ```yaml
@@ -196,7 +218,9 @@ Accept wildcard characters: False
 ```
 
 ### -InformationalUrl
+
 Basic profile information of the application such as app's marketing, support, terms of service and privacy statement URLs.
+
 The terms of service and privacy statement are surfaced to users through the user consent experience.
 
 ```yaml
@@ -212,10 +236,11 @@ Accept wildcard characters: False
 ```
 
 ### -IsDeviceOnlyAuthSupported
+
 Specifies if the application supports authentication using a device token.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -227,14 +252,17 @@ Accept wildcard characters: False
 ```
 
 ### -IsFallbackPublicClient
+
 Specifies the fallback application type as public client, such as an installed application running on a mobile device.
+
 The default value is false that means the fallback application type is confidential client such as web app.
-There are certain scenarios where Microsoft Entra ID can't determine the client application type (for example,
-ROPC flow where it's configured without specifying a redirect URI).
+
+There are certain scenarios where Microsoft Entra ID can't determine the client application type (for example, ROPC flow where it's configured without specifying a redirect URI).
+
 In those cases Microsoft Entra ID interprets the application type based on the value of this property.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -246,6 +274,7 @@ Accept wildcard characters: False
 ```
 
 ### -KeyCredentials
+
 The collection of key credentials associated with the application.
 
 ```yaml
@@ -261,6 +290,7 @@ Accept wildcard characters: False
 ```
 
 ### -OptionalClaims
+
 Application developers can configure optional claims in their Microsoft Entra ID apps to specify which claims they want in tokens sent to their application by the Microsoft security token service.
 
 ```yaml
@@ -276,6 +306,7 @@ Accept wildcard characters: False
 ```
 
 ### -ParentalControlSettings
+
 Specifies parental control settings for an application.
 
 ```yaml
@@ -291,6 +322,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordCredentials
+
 The collection of password credentials associated with the application.
 
 ```yaml
@@ -306,6 +338,7 @@ Accept wildcard characters: False
 ```
 
 ### -PublicClient
+
 Specifies whether this application is a public client (such as an installed application running on a mobile device).
 Default is false.
 
@@ -325,7 +358,9 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredResourceAccess
+
 Specifies resources that this application requires access to and the set of OAuth permission scopes and application roles that it needs under each of those resources.
+
 This preconfiguration of required resource access drives the consent experience.
 
 ```yaml
@@ -341,10 +376,11 @@ Accept wildcard characters: False
 ```
 
 ### -SignInAudience
+
 Specifies what Microsoft accounts are supported for the current application.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -356,6 +392,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tags
+
 Custom strings that can be used to categorize and identify the application.
 
 ```yaml
@@ -371,12 +408,15 @@ Accept wildcard characters: False
 ```
 
 ### -TokenEncryptionKeyId
+
 Specifies the keyId of a public key from the keyCredentials collection.
+
 When configured, Microsoft Entra ID encrypts all the tokens it emits by using the key this property points to.
+
 The application code that receives the encrypted token must use the matching private key to decrypt the token before it can be used for the signed-in user.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -388,6 +428,7 @@ Accept wildcard characters: False
 ```
 
 ### -Web
+
 Specifies settings for a web application.
 
 ```yaml
@@ -403,29 +444,48 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### Boolean
+
 ### Microsoft.Open.MSGraph.Model.ApiApplication
+
 ### Microsoft.Open.MSGraph.Model.InformationalUrl
+
 ### Microsoft.Open.MSGraph.Model.OptionalClaims
+
 ### Microsoft.Open.MSGraph.Model.ParentalControlSettings
+
 ### Microsoft.Open.MSGraph.Model.PublicClientApplication
+
 ### Microsoft.Open.MSGraph.Model.WebApplication
+
 ### String
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.Add-in]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.AppRole]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.KeyCredential]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.PasswordCredential]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.RequiredResourceAccess]
+
 ### System.Collections.Generic.List`1[System.String]
+
 ### System. Nullable`1[System.Boolean]
+
 ## Outputs
 
 ### Microsoft.Open.MSGraph.Model.MsApplication
+
 ## Notes
+
+- See more details - <https://learn.microsoft.com/graph/api/application-post-applications>
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationKeyCredential.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # New-EntraApplicationKeyCredential
 
 ## Synopsis
+
 Creates a key credential for an application.
 
 ## Syntax
@@ -36,54 +37,85 @@ New-EntraApplicationKeyCredential
 ```
 
 ## Description
-The New-EntraApplicationKeyCredential cmdlet creates a key credential for an application.
+
+The `New-EntraApplicationKeyCredential` cmdlet creates a key credential for an application.
+
+An application can use this command along with `Remove-EntraApplicationKeyCredential` to automate the rolling of its expiring keys.
+
+As part of the request validation, proof of possession of an existing key is verified before the action can be performed.
 
 ## Examples
 
 ### Example 1: Create a new application key credential
+
 ```powershell
-PS C:\> $AppID = (Get-EntraApplication -Top 1).Objectid
-PS C:\> New-EntraApplicationKeyCredential -ObjectId $AppId -CustomKeyIdentifier "Test" -StartDate "11/7/2016" -Type "Symmetric" -Usage "Sign" -Value "123"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+
+$AppId = (Get-EntraApplication -Top 1).Objectid
+$params = @{
+    ObjectId = $AppId
+    CustomKeyIdentifier = 'EntraPowerShellKey'
+    StartDate = '11/7/2016'
+    Type = 'Symmetric'
+    Usage = 'Sign'
+    Value = '<my-value>'
+}
+
+New-EntraApplicationKeyCredential @params
 ```
 
-```output
+```Output
 CustomKeyIdentifier : {84, 101, 115, 116}
 EndDate             : 11/7/2017 12:00:00 AM
-KeyId               : a5845538-3f67-402d-a03e-36d768f1441e
+KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
 StartDate           : 11/7/2016 12:00:00 AM
 Type                : Symmetric
 Usage               : Sign
 Value               : {49, 50, 51}
 ```
 
-The first command gets the ID of an application by using the [Get-EntraApplication](./Get-EntraApplication.md) cmdlet.
-The command stores it in the $AppId variable.  
+This example shows how to create an application key credential.
 
-The second command creates the application key credential for the application identified by $AppId.
+You can use the `Get-EntraApplication` cmdlet to retrieve the application Object ID.
 
 ### Example 2: Use a certificate to add an application key credential
-```
-PS C:\> $cer = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 #create a new certificate object
-PS C:\> $cer.Import("C:\Users\PFuller\Desktop\abc.cer") 
-PS C:\> $bin = $cer.GetRawCertData()
-PS C:\> $base64Value = [System.Convert]::ToBase64String($bin)
-PS C:\> $bin = $cer.GetCertHash()
-PS C:\> $base64Thumbprint = [System.Convert]::ToBase64String($bin)
-PS C:\> $keyid = [System.Guid]::NewGuid().ToString() 
-PS C:\> New-EntraApplicationKeyCredential -ObjectId 009d786a-3503-4217-b8ab-db03d71c179a -CustomKeyIdentifier  $base64Thumbprint  -Type AsymmetricX509Cert -Usage Verify -Value $base64Value  -StartDate $cer.GetEffectiveDateString() -EndDate cer.GetExpirationDateString()
+
+```powershell
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+
+$cer = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 #create a new certificate object
+$cer.Import('C:\Users\PFuller\Desktop\abc.cer') 
+$bin = $cer.GetRawCertData()
+$base64Value = [System.Convert]::ToBase64String($bin)
+$bin = $cer.GetCertHash()
+$base64Thumbprint = [System.Convert]::ToBase64String($bin)
+$keyid = [System.Guid]::NewGuid().ToString() 
+
+$params = @{
+    ObjectId = '22223333-cccc-4444-dddd-5555eeee6666'
+    CustomKeyIdentifier = $base64Thumbprint
+    Type = 'AsymmetricX509Cert'
+    Usage = 'Verify'
+    Value = $base64Value
+    StartDate = $cer.GetEffectiveDateString()
+    EndDate = $cer.GetExpirationDateString()
+}
+
+New-EntraApplicationKeyCredential @params
 ```
 
-The first seven commands create values for the application key credential and store them in variables.  
-
-The final command uses a certificate to add an application key credential.
+This example shows how to create an application key credential.
 
 ## Parameters
 
 ### -CustomKeyIdentifier
+
 Specifies a custom key ID.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -95,10 +127,11 @@ Accept wildcard characters: False
 ```
 
 ### -EndDate
+
 Specifies the time when the key becomes invalid as a DateTime object.
 
 ```yaml
-Type: DateTime
+Type: System.DateTime
 Parameter Sets: (All)
 Aliases:
 
@@ -110,10 +143,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 Specifies a unique ID of an application in Microsoft Entra ID.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -125,10 +159,11 @@ Accept wildcard characters: False
 ```
 
 ### -StartDate
+
 Specifies the time when the key becomes valid as a DateTime object.
 
 ```yaml
-Type: DateTime
+Type: System.DateTime
 Parameter Sets: (All)
 Aliases:
 
@@ -140,6 +175,7 @@ Accept wildcard characters: False
 ```
 
 ### -Type
+
 Specifies the type of the key.
 
 ```yaml
@@ -155,7 +191,11 @@ Accept wildcard characters: False
 ```
 
 ### -Usage
+
 Specifies the key usage.
+
+- `AsymmetricX509Cert`: The usage must be `Verify`.
+- `X509CertAndPassword`: The usage must be `Sign`.
 
 ```yaml
 Type: KeyUsage
@@ -170,10 +210,11 @@ Accept wildcard characters: False
 ```
 
 ### -Value
+
 Specifies the value for the key.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -185,7 +226,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
@@ -200,6 +242,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-EntraApplicationKeyCredential](Get-EntraApplicationKeyCredential.md)
 
 [Remove-EntraApplicationKeyCredential](Remove-EntraApplicationKeyCredential.md)
-
-[This cmdlet uses the ADAL library in Microsoft Entra ID. To learn more about ADAL, please follow this link:](https://www.cloudidentity.com/blog/2013/09/12/active-directory-authentication-library-adal-v1-for-net-general-availability/)
-

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationPasswordCredential.md
@@ -60,7 +60,12 @@ This command creates new password credential for specified application.
 ```powershell
 Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
 Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
-New-EntraApplicationPasswordCredential -ObjectId 'tttttttt-0000-2222-0000-aaaaaaaaaaaa' -CustomKeyIdentifier 'demoPassword'
+$params = @{
+    ObjectId = 'tttttttt-0000-2222-0000-aaaaaaaaaaaa'
+    CustomKeyIdentifier = 'demoPassword'
+}
+
+New-EntraApplicationPasswordCredential @params
 ```
 
 ```output
@@ -76,7 +81,12 @@ This command creates new password credential for specified application.
 ```powershell
 Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
 Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
-New-EntraApplicationPasswordCredential -ObjectId 'tttttttt-0000-2222-0000-aaaaaaaaaaaa' -StartDate (get-date).AddYears(0)
+$params = @{
+    ObjectId = 'tttttttt-0000-2222-0000-aaaaaaaaaaaa'
+    StartDate = (Get-Date).AddYears(0)
+}
+
+New-EntraApplicationPasswordCredential @params
 ```
 
 ```output

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationKeyCredential.md
@@ -18,6 +18,7 @@ schema: 2.0.0
 # Remove-EntraApplicationKeyCredential
 
 ## Synopsis
+
 Removes a key credential from an application.
 
 ## Syntax
@@ -30,25 +31,37 @@ Remove-EntraApplicationKeyCredential
 ```
 
 ## Description
-The Remove-EntraApplicationKeyCredential cmdlet removes a key credential from an application.
+
+The `Remove-EntraApplicationKeyCredential` cmdlet removes a key credential from an application.
+
+An application can use this command along with `New-EntraApplicationKeyCredential` to automate the rolling of its expiring keys.
 
 ## Examples
 
 ### Example 1: Remove a key credential
-```
-PS C:\> Remove-EntraApplicationKeyCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -KeyId "6aa971c6-3040-45df-87ed-581c8c09ff2b"
+
+```powershell
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+
+$params = @{
+    ObjectId = '33334444-dddd-5555-eeee-6666ffff7777'
+    KeyId = 'aaaaaaaa-0b0b-1c1c-2d2d-333333333333'
+}
+
+Remove-EntraApplicationKeyCredential @params
 ```
 
 This command removes the specified key credential from the specified application.
 
 ## Parameters
 
-
 ### -KeyId
+
 Specifies a custom key ID.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -60,10 +73,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 Specifies a unique ID of an application in Microsoft Entra ID.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -75,7 +89,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationOwner.md
@@ -32,7 +32,7 @@ Remove-EntraApplicationOwner
 
 ## Description
 
-The Remove-EntraApplicationOwner cmdlet removes an owner from an application in Microsoft Entra ID.
+The `Remove-EntraApplicationOwner` cmdlet removes an owner from an application in Microsoft Entra ID.
 
 ## Examples
 
@@ -40,7 +40,12 @@ The Remove-EntraApplicationOwner cmdlet removes an owner from an application in 
 
 ```powershell
 Connect-Entra -Scopes 'Application.ReadWrite.All'
-Remove-EntraApplicationOwner -ObjectId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -OwnerId 'bbbbbbbb-1111-2222-3333-cccccccccccc'
+$params = @{
+    ObjectId = 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'
+    OwnerId = 'bbbbbbbb-1111-2222-3333-cccccccccccc'
+}
+
+Remove-EntraApplicationOwner @params
 ```
 
 This command removes the specified owner from the specified application.

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplication.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Set-EntraApplication
 
 ## Synopsis
+
 Updates the properties of an application object.
 
 ## Syntax
@@ -48,41 +49,82 @@ Set-EntraApplication
 ```
 
 ## Description
+
 Updates the properties of an application object.
 
 ## Examples
 
 ### Example 1: Update an application
+
 ```powershell
-PS C:\> Set-EntraApplication -ObjectId fcd37fb8-449c-45af-92fc-5448c671fd30 -DisplayName "My new application"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+$params = @{
+    ObjectId = '11112222-bbbb-3333-cccc-4444dddd5555'
+    DisplayName = 'My new application'
+}
+
+Set-EntraApplication @params
 ```
 
 This command updates an application in Microsoft Entra ID.
 
 ### Example 2: Update an application using IdentifierUris parameter
+
 ```powershell
-PS C:\> Set-EntraApplication -ObjectId fcd37fb8-449c-45af-92fc-5448c671fd30 -IdentifierUris "https://mynewapp.contoso.com"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+$params = @{
+    ObjectId = '11112222-bbbb-3333-cccc-4444dddd5555'
+    IdentifierUris = 'https://mynewapp.contoso.com'
+}
+
+Set-EntraApplication @params
 ```
 
 This command updates an application in Microsoft Entra ID.
 
 ### Example 3: Update an application using GroupMembershipClaims parameter
+
 ```powershell
-PS C:\> Set-EntraApplication -ObjectId fcd37fb8-449c-45af-92fc-5448c671fd30 -GroupMembershipClaims "SecurityGroup"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+$params = @{
+    ObjectId = '11112222-bbbb-3333-cccc-4444dddd5555'
+    GroupMembershipClaims = 'SecurityGroup'
+}
+
+Set-EntraApplication @params
 ```
 
 This command updates an application in Microsoft Entra ID.
 
 ### Example 4: Update an application using IsDeviceOnlyAuthSupported parameter
+
 ```powershell
-PS C:\> Set-EntraApplication -ObjectId fcd37fb8-449c-45af-92fc-5448c671fd30 -IsDeviceOnlyAuthSupported $false
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+$params = @{
+    ObjectId = '11112222-bbbb-3333-cccc-4444dddd5555'
+    IsDeviceOnlyAuthSupported = $false
+}
+
+Set-EntraApplication @params
 ```
 
 This command updates an application in Microsoft Entra ID.
 
 ### Example 5: Update an application using Tags parameter
+
 ```powershell
-PS C:\> Set-EntraApplication -ObjectId fcd37fb8-449c-45af-92fc-5448c671fd30 -Tags "mytag"
+Connect-Entra -Scopes 'Application.ReadWrite.All' #Delegated Permission
+Connect-Entra -Scopes 'Application.ReadWrite.OwnedBy' #Application Permission
+$params = @{
+    ObjectId = '11112222-bbbb-3333-cccc-4444dddd5555'
+    Tags = 'mytag'
+}
+
+Set-EntraApplication @params
 ```
 
 This command updates an application in Microsoft Entra ID.
@@ -90,6 +132,7 @@ This command updates an application in Microsoft Entra ID.
 ## Parameters
 
 ### -Api
+
 Specifies settings for an application that implements a web API.
 
 ```yaml
@@ -105,6 +148,7 @@ Accept wildcard characters: False
 ```
 
 ### -AppRoles
+
 The collection of application roles that an application might declare.
 These roles can be assigned to users, groups, or service principals.
 
@@ -121,10 +165,11 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
+
 Specifies the display name.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -136,10 +181,11 @@ Accept wildcard characters: False
 ```
 
 ### -GroupMembershipClaims
+
 Configures the groups claim issued in a user or OAuth 2.0 access token that the application expects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -151,6 +197,7 @@ Accept wildcard characters: False
 ```
 
 ### -IdentifierUris
+
 Specifies identifier URIs.
 
 ```yaml
@@ -166,6 +213,7 @@ Accept wildcard characters: False
 ```
 
 ### -InformationalUrl
+
 Basic profile information of the application such as app's marketing, support, terms of service and privacy statement URLs.
 The terms of service and privacy statement are surfaced to users through the user consent experience.
 
@@ -182,10 +230,11 @@ Accept wildcard characters: False
 ```
 
 ### -IsDeviceOnlyAuthSupported
+
 Specifies if the application supports authentication using a device token.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -197,14 +246,18 @@ Accept wildcard characters: False
 ```
 
 ### -IsFallbackPublicClient
+
 Specifies the fallback application type as public client, such as an installed application running on a mobile device.
-The default value is false that means the fallback application type is confidential client such as web app.
+
+The default value is `false` that means the fallback application type is confidential client such as web app.
+
 There are certain scenarios where Microsoft Entra ID can't determine the client application type (for example,
 ROPC flow where it's configured without specifying a redirect URI).
+
 In those cases Microsoft Entra ID interprets the application type based on the value of this property.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -216,6 +269,7 @@ Accept wildcard characters: False
 ```
 
 ### -KeyCredentials
+
 Specifies key credentials.
 
 ```yaml
@@ -231,10 +285,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 Specifies the ID of an application in Microsoft Entra ID.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -246,6 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -OptionalClaims
+
 Application developers can configure optional claims in their Microsoft Entra ID apps to specify which claims they want in tokens sent to their application by the Microsoft security token service.
 
 ```yaml
@@ -261,6 +317,7 @@ Accept wildcard characters: False
 ```
 
 ### -ParentalControlSettings
+
 Specifies parental control settings for an application.
 
 ```yaml
@@ -276,6 +333,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordCredentials
+
 The collection of password credentials associated with the application
 
 ```yaml
@@ -291,6 +349,7 @@ Accept wildcard characters: False
 ```
 
 ### -PublicClient
+
 Specifies whether this application is a public client (such as an installed application running on a mobile device).
 Default is false.
 
@@ -307,7 +366,9 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredResourceAccess
+
 Specifies resources that this application requires access to and the set of OAuth permission scopes and application roles that it needs under each of those resources.
+
 This preconfiguration of required resource access drives the consent experience.
 
 ```yaml
@@ -323,10 +384,11 @@ Accept wildcard characters: False
 ```
 
 ### -SignInAudience
+
 Specifies what Microsoft accounts are supported for the current application.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -338,6 +400,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tags
+
 Custom strings that can be used to categorize and identify the application.
 
 ```yaml
@@ -353,12 +416,15 @@ Accept wildcard characters: False
 ```
 
 ### -TokenEncryptionKeyId
+
 Specifies the keyId of a public key from the keyCredentials collection.
+
 When configured, Microsoft Entra ID encrypts all the tokens it emits by using the key this property points to.
+
 The application code that receives the encrypted token must use the matching private key to decrypt the token before it can be used for the signed-in user.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -370,6 +436,7 @@ Accept wildcard characters: False
 ```
 
 ### -Web
+
 Specifies settings for a web application.
 
 ```yaml
@@ -385,25 +452,41 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### Boolean
+
 ### Microsoft.Open.MSGraph.Model.ApiApplication
+
 ### Microsoft.Open.MSGraph.Model.InformationalUrl
+
 ### Microsoft.Open.MSGraph.Model.OptionalClaims
+
 ### Microsoft.Open.MSGraph.Model.ParentalControlSettings
+
 ### Microsoft.Open.MSGraph.Model.PublicClientApplication
+
 ### Microsoft.Open.MSGraph.Model.WebApplication
+
 ### String
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.Add-in]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.AppRole]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.KeyCredential]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.PasswordCredential]
+
 ### System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.RequiredResourceAccess]
+
 ### System.Collections.Generic.List`1[System.String]
+
 ### System.Nullable`1[System.Boolean]
+
 ## Outputs
 
 ## Notes

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplicationLogo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplicationLogo.md
@@ -59,7 +59,12 @@ This cmdlet is used to set the logo for an application.
 
 ```powershell
 Connect-Entra -Scopes 'Application.ReadWrite.All'
-Set-EntraApplicationLogo -ObjectId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -FilePath 'D:\applogo.jpg'
+$params = @{
+    ObjectId = 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'
+    FilePath = 'D:\applogo.jpg'
+}
+
+Set-EntraApplicationLogo @params
 ```
 
 This cmdlet sets the application logo for the application specified by the ObjectID parameter to the image specified with the Filepath parameter.

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncConfiguration.md
@@ -126,7 +126,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-- See additional details - <https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update>
+- For additional details see [Update onPremisesDirectorySynchronization](/graph/api/onpremisesdirectorysynchronization-update).
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncConfiguration.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Set-EntraDirSyncConfiguration
 
 ## Synopsis
+
 Modifies the directory synchronization settings.
 
 ## Syntax
@@ -32,31 +33,41 @@ Set-EntraDirSyncConfiguration
 ```
 
 ## Description
-The Set-EntraDirSyncConfiguration cmdlet modifies the directory synchronization settings.
+
+The `Set-EntraDirSyncConfiguration` cmdlet modifies the directory synchronization settings.
 
 ## Examples
 
 ### Example 1: Set directory synchronization settings
+
 ```powershell
-PS C:\> Set-EntraDirSyncConfiguration -AccidentalDeletionThreshold 600 -Force
+Set-EntraDirSyncConfiguration -AccidentalDeletionThreshold 600 -Force
 ```
 
 This command sets directory synchronization settings.
 
-### Example 2: Set directory synchronization settings by TenantId
+### Example 2: Set directory synchronization settings for a Tenant
+
 ```powershell
-PS C:\> Set-EntraDirSyncConfiguration -AccidentalDeletionThreshold 600 -TenantId "d5aec55f-2d12-4442-8d2f-ccca95d4390e" -Force
+$params = @{
+    AccidentalDeletionThreshold = 600
+    TenantId = 'bbbbcccc-1111-dddd-2222-eeee3333ffff'
+    Force = $true
+}
+
+Set-EntraDirSyncConfiguration @params
 ```
 
-This command sets directory synchronization settings by TenantId.
+This command sets directory synchronization settings.
 
 ## Parameters
 
 ### -AccidentalDeletionThreshold
-Specifies the accidental deletion threshold.
+
+Specifies the accidental deletion prevention configuration for a tenant.
 
 ```yaml
-Type: UInt32
+Type: System.UInt32
 Parameter Sets: (All)
 Aliases:
 
@@ -68,10 +79,11 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -83,10 +95,11 @@ Accept wildcard characters: False
 ```
 
 ### -TenantId
+
 Specifies the unique ID of the tenant on which to perform the operation. The default value is the tenant of the current user. This parameter applies only to partner users.
 
 ```yaml
-Type: Guid
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -98,7 +111,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
@@ -109,7 +123,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## Outputs
 
 ### System.Object
+
 ## Notes
+
+- See additional details - <https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update>
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
@@ -170,7 +170,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-- See additional details - <https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update>
+- For additional details see [Update onPremisesDirectorySynchronization](/graph/api/onpremisesdirectorysynchronization-update).
 - See feature list - <https://learn.microsoft.com/graph/api/resources/onpremisesdirectorysynchronizationfeature>
 
 ## Related Links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Set-EntraDirSyncFeature
 
 ## Synopsis
+
 Used to set identity synchronization features for a tenant.
 
 ## Syntax
@@ -33,18 +34,16 @@ Set-EntraDirSyncFeature
 ```
 
 ## Description
-The Set-EntraDirSyncFeature cmdlet sets identity synchronization features for a tenant.  
+
+The `Set-EntraDirSyncFeature` cmdlet sets identity synchronization features for a tenant.  
 
 You can use the following synchronization features with this cmdlet:  
+
 - **EnableSoftMatchOnUpn**: Soft match is the process used to link an object being synced from on-premises for the first time with one that already exists in the cloud. When this feature is enabled, soft match is attempted using the standard logic, based on the primary SMTP address. If a match isn't found based on primary SMTP, then a match is attempted based on UserPrincipalName. Once this feature is enabled, it can't be disabled.
-- **PasswordSync**
+- **PasswordSync**: Used to indicate on-premise password synchronization.
 - **SynchronizeUpnForManagedUsers**: Allows for the synchronization of UserPrincipalName updates from on-premises for managed (nonfederated) users that are assigned a license. These updates are blocked if this feature isn't enabled. Once this feature is enabled, it can't be disabled.
 - **BlockSoftMatch**: When this feature is enabled, it blocks the soft match feature. Customers are encouraged to enable this feature and keep it enabled until soft matching is required again for their tenancy. This flag should be enabled again after any soft matching is completed and is no longer needed.
-- **BlockCloudObjectTakeoverThroughHardMatch**: When this feature isn't enabled, and
-    -  an object is synced for which an object with a matching source anchor already exists in Microsoft Entra ID and,
-    - that object in Microsoft Entra ID doesn't have DirSyncEnabled set to "true", then    
-    the default behavior would be to hard match the cloud object with the on premises object and set the DirSyncEnabled flag of the Cloud object to "true". <br><br>
-    When enabling this feature, the cloud object is no longer matched and the DirSyncEnabled flag isn't set to "true". Instead, an error is thrown: Error Code: `InvalidHardMatch`, Error Message: `Another cloud created object with the same source anchor already exists in Microsoft Entra ID`.
+- **BlockCloudObjectTakeoverThroughHardMatch**: Used to block cloud object takeover via source anchor hard match.
 
 Enabling some of these features, such as EnableSoftMatchOnUpn and SynchronizationUpnForManagedUsers, is a permanent operation.
 You can't disable these features once they're enabled.
@@ -52,22 +51,43 @@ You can't disable these features once they're enabled.
 ## Examples
 
 ### Example 1: Enable a feature for the tenant
+
 ```powershell
-PS C:\> Set-EntraDirSyncFeature -Feature EnableSoftMatchOnUpn -Enable $True
+Connect-Entra -Scopes 'OnPremDirectorySynchronization.ReadWrite.All'
+$params = @{
+    Feature = 'EnableSoftMatchOnUpn'
+    Enable = $True
+}
+
+Set-EntraDirSyncFeature @params
 ```
 
 This command enables the SoftMatchOnUpn feature for the tenant.
 
 ### Example 2: Block Soft Matching for the tenant
+
 ```powershell
-PS C:\> Set-EntraDirSyncFeature -Feature BlockSoftMatch -Enable $True
+Connect-Entra -Scopes 'OnPremDirectorySynchronization.ReadWrite.All'
+$params = @{
+    Feature = 'BlockSoftMatch'
+    Enable = $True
+}
+
+Set-EntraDirSyncFeature @params
 ```
 
 This command enables the BlockSoftMatch feature for the tenant - effectively blocking the Soft Matching feature in the tenant.
 
 ### Example 3: Block Cloud object takeover through Hard Matching for the tenant
+
 ```powershell
-PS C:\> Set-EntraDirSyncFeature -Feature BlockCloudObjectTakeoverThroughHardMatch -Enable $True
+Connect-Entra -Scopes 'OnPremDirectorySynchronization.ReadWrite.All'
+$params = @{
+    Feature = 'BlockCloudObjectTakeoverThroughHardMatch'
+    Enable = $True
+}
+
+Set-EntraDirSyncFeature @params
 ```
 
 This command enables the BlockCloudObjectTakeoverThroughHardMatch feature for the tenant - effectively blocking the Hard Match object takeover.
@@ -75,10 +95,11 @@ This command enables the BlockCloudObjectTakeoverThroughHardMatch feature for th
 ## Parameters
 
 ### -Feature
+
 The DirSync feature to turn on or off.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -90,10 +111,11 @@ Accept wildcard characters: False
 ```
 
 ### -Enable
+
 Indicates whether the specified features are turned on for the company.
 
 ```yaml
-Type: Boolean
+Type: System.Boolean
 Parameter Sets: (All)
 Aliases:
 
@@ -105,12 +127,13 @@ Accept wildcard characters: False
 ```
 
 ### -TenantId
+
 The unique ID of the tenant to perform the operation on.
 If this isn't provided then the value defaults to the tenant of the current user.
 This parameter is only applicable to partner users.
 
 ```yaml
-Type: Guid
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -122,10 +145,11 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -137,13 +161,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ## Outputs
 
 ## Notes
+
+- See additional details - <https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update>
+- See feature list - <https://learn.microsoft.com/graph/api/resources/onpremisesdirectorysynchronizationfeature>
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
@@ -171,7 +171,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Notes
 
 - For additional details see [Update onPremisesDirectorySynchronization](/graph/api/onpremisesdirectorysynchronization-update).
-- See feature list - <https://learn.microsoft.com/graph/api/resources/onpremisesdirectorysynchronizationfeature>
+- For the feature list see the [onPremisesDirectorySynchronizationFeature resource type](/graph/api/resources/onpremisesdirectorysynchronizationfeature).
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPartnerInformation.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPartnerInformation.md
@@ -19,6 +19,7 @@ schema: 2.0.0
 # Set-EntraPartnerInformation
 
 ## Synopsis
+
 Sets company information for partners.
 
 ## Syntax
@@ -35,49 +36,67 @@ Set-EntraPartnerInformation
  [-TenantId <Guid>] 
  [<CommonParameters>]
 ```
+
 ## Description
-The Set-EntraPartnerInformation cmdlet is used by partners to set partner-specific properties.
+
+The `Set-EntraPartnerInformation` cmdlet is used by partners to set partner-specific properties.
 These properties can view by all tenants that the partner has access to.
 
 ## Examples
 
 ### Example 1: Update the help URL
+
 ```powershell
-PS C:\> Set-EntraPartnerInformation -PartnerHelpUrl "http://www.help.contoso.com"
+Set-EntraPartnerInformation -PartnerHelpUrl 'http://www.help.contoso.com'
 ```
+
 This command updates the help URL for this partner.
 
 ### Example 2: Update the Support URL
+
 ```powershell
-PS C:\> Set-EntraPartnerInformation -PartnerSupportUrl "http://www.test1.com"
+Set-EntraPartnerInformation -PartnerSupportUrl 'http://www.test1.com'
 ```
+
 This command updates the Support URL for this partner.
 
 ### Example 3: Update the Commerce URL
+
 ```powershell
-PS C:\> Set-EntraPartnerInformation -PartnerCommerceUrl "http://www.test1.com" 
+Set-EntraPartnerInformation -PartnerCommerceUrl 'http://www.test1.com'
 ```
+
 This command updates the Commerce URL for this partner.
 
 ### Example 4: Update the SupportEmails
+
 ```powershell
-PS C:\> Set-EntraPartnerInformation -PartnerSupportEmails "contoso@example.com" 
+Set-EntraPartnerInformation -PartnerSupportEmails 'contoso@example.com' 
 ```
+
 This command updates the SupportEmails for this partner.
 
 ### Example 5: Update the SupportTelephones
+
 ```powershell
-PS C:\> Set-EntraPartnerInformation -PartnerSupportTelephones "2342" -TenantId "b73cc049-a025-4441-ba3a-8826d9a68ecc"
+$params = @{
+    PartnerSupportTelephones = '234234234'
+    TenantId = 'bbbbcccc-1111-dddd-2222-eeee3333ffff'
+}
+
+Set-EntraPartnerInformation @params
 ```
+
 This command updates the SupportTelephones for this partner.
 
 ## Parameters
 
 ### -PartnerCommerceUrl
+
 Specifies the URL for the partner's commerce website.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -89,10 +108,11 @@ Accept wildcard characters: False
 ```
 
 ### -PartnerHelpUrl
+
 Specifies the URL for the partner's Help website.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -104,6 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -PartnerSupportEmails
+
 Specifies the support email address for the partner.
 
 ```yaml
@@ -119,6 +140,7 @@ Accept wildcard characters: False
 ```
 
 ### -PartnerSupportTelephones
+
 Specifies the support telephone numbers for the partner.
 
 ```yaml
@@ -134,10 +156,11 @@ Accept wildcard characters: False
 ```
 
 ### -PartnerSupportUrl
+
 Specifies the URL for the partner's support website.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -149,12 +172,13 @@ Accept wildcard characters: False
 ```
 
 ### -TenantId
+
 Specifies the unique ID of the tenant on which to perform the operation.
 The default value is the tenant of the current user.
 This parameter applies only to partner users.
 
 ```yaml
-Type: Guid
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -166,6 +190,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompanyType
+
 Specifies the partner's company type.
 
 ```yaml
@@ -181,11 +206,12 @@ Accept wildcard characters: False
 ```
 
 ### -PartnerCompanyName
+
 Specifies the partner's company name.
 
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -197,7 +223,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
@@ -206,4 +233,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## Notes
 
 ## Related Links
+
 [Get-EntraPartnerInformation](Get-EntraPartnerInformation.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTenantDetail.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTenantDetail.md
@@ -191,7 +191,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-- See more details - <https://learn.microsoft.com/graph/api/organization-update>
+- For more details see [Update organization](/graph/api/organization-update).
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTenantDetail.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTenantDetail.md
@@ -18,6 +18,7 @@ schema: 2.0.0
 # Set-EntraTenantDetail
 
 ## Synopsis
+
 Set contact details for a tenant.
 
 ## Syntax
@@ -33,49 +34,71 @@ Set-EntraTenantDetail
 ```
 
 ## Description
+
 This cmdlet is used to set various contact details for a tenant.
+
+For delegated scenarios, the signed-in user must have at least one of the following Microsoft Entra roles.
+
+- Application Administrator
 
 ## Examples
 
 ### Example 1: Set contact details for a tenant
+
 ```powershell
-PS C:\WINDOWS\system32> Set-EntraTenantDetail -MarketingNotificationEmails "amy@contoso.com","henry@contoso.com" -SecurityComplianceNotificationMails "john@contoso.com","mary@contoso.com" -SecurityComplianceNotificationPhones "1-555-625-9999", "1-555-233-5544" -TechnicalNotificationMails "peter@contoso.com"
+Connect-Entra -Scopes 'Organization.ReadWrite.All'
+$params = @{
+    MarketingNotificationEmails = @('amy@contoso.com', 'henry@contoso.com')
+    SecurityComplianceNotificationMails = @('john@contoso.com', 'mary@contoso.com')
+    SecurityComplianceNotificationPhones = @('1-555-625-9999', '1-555-233-5544')
+    TechnicalNotificationMails = 'peter@contoso.com'
+}
+
+Set-EntraTenantDetail @params
 ```
 
 This example demonstrates how to set various contact details for a tenant.
 
 ### Example 2: Set MarketingNotificationEmails for a tenant
+
 ```powershell
-PS C:\WINDOWS\system32> Set-EntraTenantDetail -MarketingNotificationEmails "amy@contoso.com","henry@contoso.com" 
+Connect-Entra -Scopes 'Organization.ReadWrite.All'
+Set-EntraTenantDetail -MarketingNotificationEmails 'amy@contoso.com','henry@contoso.com' 
 ```
 
 This example demonstrates how to set MarketingNotificationEmails detail for a tenant.
 
 ### Example 3: Set SecurityComplianceNotificationMails for a tenant
+
 ```powershell
-PS C:\WINDOWS\system32> Set-EntraTenantDetail -SecurityComplianceNotificationMails "john@contoso.com","mary@contoso.com" 
+Connect-Entra -Scopes 'Organization.ReadWrite.All'
+Set-EntraTenantDetail -SecurityComplianceNotificationMails 'john@contoso.com','mary@contoso.com' 
 ```
 
 This example demonstrates how to set SecurityComplianceNotificationMails detail for a tenant.
 
 ### Example 4: Set -SecurityComplianceNotificationPhones for a tenant
+
 ```powershell
-PS C:\WINDOWS\system32> Set-EntraTenantDetail -SecurityComplianceNotificationPhones "1-555-625-9999", "1-555-233-5544" 
+Connect-Entra -Scopes 'Organization.ReadWrite.All'
+Set-EntraTenantDetail -SecurityComplianceNotificationPhones '1-555-625-9999', '1-555-233-5544' 
 ```
 
 This example demonstrates how to set MarketingNotificationEmails detail for a tenant.
 
 ### Example 5: Set TechnicalNotificationMails for a tenant
+
 ```powershell
-PS C:\WINDOWS\system32> Set-EntraTenantDetail -TechnicalNotificationMails "peter@contoso.com"
+Connect-Entra -Scopes 'Organization.ReadWrite.All'
+Set-EntraTenantDetail -TechnicalNotificationMails 'peter@contoso.com'
 ```
 
 This example demonstrates how to set TechnicalNotificationMails detail for a tenant.
 
-
 ## Parameters
 
 ### -MarketingNotificationEmails
+
 The email address that is used to send marketing notification emails.
 
 ```yaml
@@ -91,6 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -SecurityComplianceNotificationMails
+
 The email address that is used to send security compliance emails.
 
 ```yaml
@@ -106,6 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -SecurityComplianceNotificationPhones
+
 The phone number(s) that are used for security compliance.
 
 ```yaml
@@ -121,7 +146,8 @@ Accept wildcard characters: False
 ```
 
 ### -TechnicalNotificationMails
-The email addres(es) that are used for technical notification emails.
+
+The email addresses that are used for technical notification emails.
 
 ```yaml
 Type: System.Collections.Generic.List`1[System.String]
@@ -136,6 +162,7 @@ Accept wildcard characters: False
 ```
 
 ### -PrivacyProfile
+
 Represents a company's privacy profile, which includes a privacy statement URL and a contact person for questions regarding the privacy statement.
 
 ```yaml
@@ -151,15 +178,20 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### None
+
 ## Outputs
 
 ### System.Object
+
 ## Notes
+
+- See more details - <https://learn.microsoft.com/graph/api/organization-update>
 
 ## Related Links
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserThumbnailPhoto.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserThumbnailPhoto.md
@@ -18,11 +18,13 @@ schema: 2.0.0
 # Set-EntraUserThumbnailPhoto
 
 ## Synopsis
+
 Set the thumbnail photo for a user.
 
 ## Syntax
 
 ### File (Default)
+
 ```powershell
 Set-EntraUserThumbnailPhoto 
  [-ObjectId <String>] 
@@ -31,6 +33,7 @@ Set-EntraUserThumbnailPhoto
 ```
 
 ### Stream
+
 ```powershell
 Set-EntraUserThumbnailPhoto 
  -FileStream <Stream> 
@@ -39,6 +42,7 @@ Set-EntraUserThumbnailPhoto
 ```
 
 ### ByteArray
+
 ```powershell
 Set-EntraUserThumbnailPhoto 
  [-ObjectId <String>] 
@@ -47,14 +51,24 @@ Set-EntraUserThumbnailPhoto
 ```
 
 ## Description
+
 This cmdlet is used to set the thumbnail photo for a user.
+
+Updating any user's photo in the organization requires the User.ReadWrite.All permission. Updating only the signed-in user's photo requires the User.ReadWrite permission.
 
 ## Examples
 
-### Example 1: Sets the thumbnail photo.
+### Example 1: Sets the thumbnail photo
 
 ```powershell
-PS C:\WINDOWS\system32> Set-EntraUserThumbnailPhoto -ObjectId ba6752c4-6a2e-4be5-a23d-67d8d5980796 -FilePath D:\UserThumbnailPhoto.jpg
+Connect-Entra -Scopes 'User.ReadWrite' #Delegated Permission
+Connect-Entra -Scopes 'User.ReadWrite.All' #Application Permission
+$params = @{
+    ObjectId = 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'
+    FilePath = 'D:\UserThumbnailPhoto.jpg'
+}
+
+Set-EntraUserThumbnailPhoto @params
 ```
 
 This example sets the thumbnail photo of the user specified with the ObjectId parameter to the image specified with the FilePath parameter.
@@ -62,10 +76,11 @@ This example sets the thumbnail photo of the user specified with the ObjectId pa
 ## Parameters
 
 ### -FilePath
+
 The file path of the image to be uploaded as the user thumbnail photo.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: File
 Aliases:
 
@@ -77,10 +92,11 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectId
+
 The Object ID of the user for which the user thumbnail photo is set.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -92,16 +108,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 System.IO.Stream System.Byte\[\]
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## Related Links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraSignedInUserPassword.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraSignedInUserPassword.md
@@ -98,6 +98,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-- See more details - <https://learn.microsoft.com/graph/api/user-changepassword>
+- For more details see [changePassword](/graph/api/user-changepassword).
 
 ## RELATED LINKS

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraSignedInUserPassword.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraSignedInUserPassword.md
@@ -18,6 +18,7 @@ schema: 2.0.0
 # Update-EntraSignedInUserPassword
 
 ## Synopsis
+
 Updates the password for the signed-in user.
 
 ## Syntax
@@ -30,16 +31,25 @@ Update-EntraSignedInUserPassword
 ```
 
 ## Description
-The Update-EntraSignedInUserPassword cmdlet updates the password for the signed-in user in Microsoft Entra ID.
+
+The `Update-EntraSignedInUserPassword` cmdlet updates the password for the signed-in user in Microsoft Entra ID.
+
+Allow users to update their own passwords. Any user can update their password without needing to be in an administrator role.
 
 ## Examples
 
 ### Example 1: Update a password
 
 ```powershell
-PS C:\>$CurrentPassword = ConvertTo-SecureString 'Test@1234' -AsPlainText -Force
-PS C:\>$NewPassword = ConvertTo-SecureString 'Test@1234' -AsPlainText -Force
-PS C:\>Update-EntraSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword $NewPassword
+Connect-Entra -Scopes 'Directory.AccessAsUser.All'
+$CurrentPassword = ConvertTo-SecureString '<strong-password>' -AsPlainText -Force
+$NewPassword = ConvertTo-SecureString '<strong-password>' -AsPlainText -Force
+$params = @{
+    CurrentPassword = $CurrentPassword
+    NewPassword = $NewPassword
+}
+
+Update-EntraSignedInUserPassword @params
 ```
 
 This command updates the password for the signed-in user.
@@ -47,6 +57,7 @@ This command updates the password for the signed-in user.
 ## Parameters
 
 ### -CurrentPassword
+
 Specifies the current password of the signed-in user.
 
 ```yaml
@@ -61,9 +72,8 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-
-
 ### -NewPassword
+
 Specifies the new password for the signed-in user.
 
 ```yaml
@@ -79,12 +89,15 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ## Outputs
 
 ## Notes
+
+- See more details - <https://learn.microsoft.com/graph/api/user-changepassword>
 
 ## RELATED LINKS


### PR DESCRIPTION
In this PR, I have added:
- Scopes for the cmdlet.
- Enriched description with additional information from API.
- Removed command prompt.

### Cmdlets in scope:
- Set-EntraDirSyncConfiguration
- Set-EntraDirSyncFeature
- Set-EntraMSApplication
- Set-EntraMSApplicationLogo
- Add-EntraEnvironment
- Convert-EntraFederatedUser
- Enable-EntraDirectoryRole
- Get-EntraContactDirectReport
- Get-EntraContactThumbnailPhoto
- Get-EntraCurrentSessionInfo
- Get-EntraDirSyncConfiguration
- Get-EntraDirSyncfeature
- Get-EntraAccountSku
- Get-EntraApplicationKeyCredential
- New-EntraApplicationKeyCredential
- New-EntraMSApplication
- Get-EntraUserThumbnailPhoto
- Remove-EntraApplicationKeyCredential
- Remove-EntraMSApplication
- Remove-EntraMSApplicationOwner
- Set-EntraUserThumbnailPhoto
- Update-EntraSignedInUserPassword
- Set-EntraTenantDetail