### PR TITLE
Get-EntraAuditSignInLogs - Cleanup how we create query options

### DIFF
--- a/module/Entra/AdditionalFunctions/Get-EntraAuditSignInLogs.ps1
+++ b/module/Entra/AdditionalFunctions/Get-EntraAuditSignInLogs.ps1
@@ -21,16 +21,17 @@ function Get-EntraAuditSignInLogs {
         $topCount = $null
         $baseUri = 'https://graph.microsoft.com/v1.0/auditLogs/signIns'
         $params["Method"] = "GET"
-        $params["Uri"] = "$baseUri"+"?"
+        $params["Uri"] = "$baseUri"
+        $query = $null
 
         if($null -ne $PSBoundParameters["Top"])
         {
             $topCount = $PSBoundParameters["Top"]
             if ($topCount -gt 999) {
-                $params["Uri"] += "&`$top=999"
+                $query += "&`$top=999"
             }
             else{
-                $params["Uri"] += "&`$top=$topCount"
+                $query += "&`$top=$topCount"
             }
         }
 
@@ -42,8 +43,14 @@ function Get-EntraAuditSignInLogs {
         if($null -ne $PSBoundParameters["Filter"])
         {
             $Filter = $PSBoundParameters["Filter"]
-            $f = '$Filter'
-            $params["Uri"] += "&$f=$Filter"
+            $f = '$filter'
+            $query += "&$f=$Filter"
+        }
+
+        if($null -ne $query)
+        {
+            $query = "?" + $query.TrimStart("&")
+            $params["Uri"] += $query
         }
 
         Write-Debug("============================ TRANSFORMATIONS ============================")


### PR DESCRIPTION
Cmdlet work as expected however the urls created are not clean

**Get-EntraAuditSignInLogs**
Extra "?" at the end
<img width="683" alt="image" src="https://github.com/user-attachments/assets/d6f4b706-10e6-4447-adbd-3c0f23f4fb70">

**Get-EntraAuditSignInLogs -Top 2**
"&" immediately after "?"

<img width="736" alt="image" src="https://github.com/user-attachments/assets/b43f3bfd-0668-43fc-bddf-c34c83f18259">

## Generated Urls after this fix
<img width="711" alt="image" src="https://github.com/user-attachments/assets/07c0b369-b098-4dff-921f-d209a0dae23c">

<img width="766" alt="image" src="https://github.com/user-attachments/assets/4e90c20e-5bde-4e6c-b713-98f1ca8f2fd8">


