### PR TITLE
Specify required version for dependent modules

### DIFF
--- a/src/CompatibilityAdapterBuilder.ps1
+++ b/src/CompatibilityAdapterBuilder.ps1
@@ -422,7 +422,7 @@ public $($object.GetType().Name)()
         $functions = $this.ModuleMap.CommandsList + "Enable-EntraAzureADAlias" + "Get-EntraUnsupportedCommand"
         $requiredModules = @()
         foreach($module in $content.requiredModules){
-            $requiredModules += @{ModuleName = $module; ModuleVersion = $content.requiredModulesVersion}
+            $requiredModules += @{ModuleName = $module; RequiredVersion = $content.requiredModulesVersion}
         }
         $moduleSettings = @{
             Path = $manisfestPath


### PR DESCRIPTION
Currently we specifiy dependent modules in the psd1 files as follows
```powershell
# Modules that must be imported into the global environment prior to importing this module
RequiredModules = @(@{ModuleName = 'Microsoft.Graph.Users'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Users.Actions'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Users.Functions'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Groups'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Identity.DirectoryManagement'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Identity.Governance'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Identity.SignIns'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Applications'; ModuleVersion = '2.15.0'; }, 
               @{ModuleName = 'Microsoft.Graph.Reports'; ModuleVersion = '2.15.0'; })
```

According to these [docs](https://learn.microsoft.com/en-us/powershell/gallery/concepts/publishing-guidelines?view=powershellget-3.x#manage-dependencies),
- When using `ModuleVersion`, it will load the newest version available with a minimum of the version specified.
- When using `RequiredVersion`, it will load the specific version.