### PR TITLE
Update manifest generation to remove * and replace with @()

### DIFF
--- a/src/CompatibilityAdapterBuilder.ps1
+++ b/src/CompatibilityAdapterBuilder.ps1
@@ -429,6 +429,8 @@ public $($object.GetType().Name)()
             GUID = $($content.guid)
             ModuleVersion = "$($content.version)"
             FunctionsToExport = $functions
+            CmdletsToExport=@()
+            AliasesToExport=@()
             Author =  $($content.authors)
             CompanyName = $($content.owners)
             FileList = $files


### PR DESCRIPTION
Replace wildcard (*) with empty Array @() in the manifest generation.

This is effected in line 426 through to line 443. This is what's used to auto-generate the .psd1 (manifest file)...It will look like this (snapshot of the .psd1 file) the build to auto-generate the module manifest file.
![manifest_update](https://github.com/user-attachments/assets/d09f4aaf-f853-46a2-81c8-6ca90221b1b9)

manifest_update

Before we'd be having CmdletsToExport="" and AliasesToExport="" in the .psd1 file.

As seen from the screen shot, the manifest generator already provides some hints on the comments above each of the two above.