### PR TITLE
Remove trailing period on titles resulting in build warnings

### DIFF
--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaConditionalAccessPolicy.md
@@ -1,5 +1,5 @@
 ---
-title: Get-EntraBetaConditionalAccessPolicy.
+title: Get-EntraBetaConditionalAccessPolicy
 description: This article provides details on the Get-EntraBetaConditionalAccessPolicy command.
 
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalCreatedObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalCreatedObject.md
@@ -1,5 +1,5 @@
 ---
-title: Get-EntraBetaServicePrincipalCreatedObject.
+title: Get-EntraBetaServicePrincipalCreatedObject
 description: This article provides details on the Get-EntraBetaServicePrincipalCreatedObject command.
 
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationKey.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationKey.md
@@ -1,5 +1,5 @@
 ---
-title: New-EntraBetaApplicationKey.
+title: New-EntraBetaApplicationKey
 description: This article provides details on the New-EntraBetaApplicationKey command.
 
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaSignedInUserPassword.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaSignedInUserPassword.md
@@ -1,5 +1,5 @@
 ---
-title: Update-EntraBetaSignedInUserPassword.
+title: Update-EntraBetaSignedInUserPassword
 description: This article provides details on the Update-EntraBetaSignedInUserPassword command.
 
 ms.topic: reference

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraScopedRoleMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraScopedRoleMembership.md
@@ -1,5 +1,5 @@
 ---
-title: Get-EntraScopedRoleMembership.
+title: Get-EntraScopedRoleMembership
 description: This article provides details on the Get-EntraScopedRoleMembership command.
 
 ms.topic: reference


### PR DESCRIPTION
Removed a trailing period character at the end of the title name leading to build warning.