### PR TITLE
Fix typo in common-functions.ps1

### DIFF
--- a/build/common-functions.ps1
+++ b/build/common-functions.ps1
@@ -92,7 +92,7 @@ function Update-ModuleVersion {
 	[cmdletbinding()]
 	param(
 		[switch] $Minor,
-		[switch] $Mayor,
+		[switch] $Major,
 		[switch] $Build
 	)
 
@@ -111,7 +111,7 @@ function Update-ModuleVersion {
 		$v.Minor++
 	}
 
-	if ($Mayor.IsPresent) {
+	if ($Major.IsPresent) {
 		$v.Major++
 	}
 


### PR DESCRIPTION
Fixed "Major" typo as "Mayor"