### PR TITLE
Fix RequiredResourceAccess cannot be an array issue in Set-AzureADMSApplication

### DIFF
--- a/module/Entra/customizations/Set-EntraApplication.ps1
+++ b/module/Entra/customizations/Set-EntraApplication.ps1
@@ -104,7 +104,7 @@
         if($null -ne $PSBoundParameters["RequiredResourceAccess"])
         {
             $TmpValue = $PSBoundParameters["RequiredResourceAccess"]
-                        $Value = $TmpValue | ConvertTo-Json 
+            $Value = $TmpValue | ForEach-Object { $_ | ConvertTo-Json }
             $params["RequiredResourceAccess"] = $Value
         }
         if($null -ne $PSBoundParameters["PublicClient"])


### PR DESCRIPTION
# Why we have this PR
When using `Set-EntraApplication -ApplicationId $application.Id -RequiredResourceAccess $requiredResourceAccess`, the `$requiredResourceAccess` could be an array. For example:
```powershell
$requiredResourceAccess = @(
    @{resourceAppId = '00000003-0000-0000-c000-000000000000'
        resourceAccess = @(
        @{
            id = 'c79f8feb-a9db-4090-85f9-90d820caa0eb'
            type = 'Scope'
        },
        @{
            id = '9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30'
            type = 'Role'
        })
    },
    @{resourceAppId = '11111111-0000-0000-c000-000000000000'
        resourceAccess = @(
        @{
            id = '11111111-a9db-4090-85f9-90d820caa0eb'
            type = 'Scope'
        },
        @{
            id = '11111111-52b0-4cc2-bd40-abcf44ac3a30'
            type = 'Role'
        })
    }
)
Set-EntraApplication -ApplicationId $application.Id -RequiredResourceAccess $requiredResourceAccess
```

In current logic, the input array will be converted into a single json string. However, the `Set-EntraApplication` is actually calling `Update-MgApplication` command, which requires input `-RequiredResourceAccess <IMicrosoftGraphRequiredResourceAccess[]>`. [Reference here](https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.applications/update-mgapplication?view=graph-powershell-1.0). This single string cannot be converted into `IMicrosoftGraphRequiredResourceAccess[]`, causing the following error:
![image](https://github.com/user-attachments/assets/a70de407-27dc-4816-a41c-c014fd3f8496)


# How to fix in the PR
We convert the parameter into string[], each json string can be converted into `IMicrosoftGraphRequiredResourceAccess` correctly.