### PR TITLE
Use ExecutionContext to get current module

### DIFF
--- a/module/Entra/AdditionalFunctions/Get-EntraContext.ps1
+++ b/module/Entra/AdditionalFunctions/Get-EntraContext.ps1
@@ -54,10 +54,7 @@ function Get-EntraContext {
 
         $response = Get-MgContext @params
 
-        $module = Get-Module -Name Microsoft.Graph.Entra.Beta -ErrorAction SilentlyContinue
-        if ($null -eq $module) {
-            $module = Get-Module -Name Microsoft.Graph.Entra -ErrorAction SilentlyContinue
-        }
+        $module = $ExecutionContext.SessionState.Module
 
         if ($null -ne $module) {
             $entraPSVersion = $module.Version.ToString()

--- a/module/Entra/AdditionalFunctions/New-EntraCustomHeaders.ps1
+++ b/module/Entra/AdditionalFunctions/New-EntraCustomHeaders.ps1
@@ -21,7 +21,7 @@ function New-EntraCustomHeaders {
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Graph.Entra | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/AdditionalFunctions/Get-EntraContext.ps1
+++ b/module/EntraBeta/AdditionalFunctions/Get-EntraContext.ps1
@@ -54,10 +54,7 @@ function Get-EntraContext {
 
         $response = Get-MgContext @params
 
-        $module = Get-Module -Name Microsoft.Graph.Entra.Beta -ErrorAction SilentlyContinue
-        if ($null -eq $module) {
-            $module = Get-Module -Name Microsoft.Graph.Entra -ErrorAction SilentlyContinue
-        }
+        $module = $ExecutionContext.SessionState.Module
 
         if ($null -ne $module) {
             $entraPSVersion = $module.Version.ToString()

--- a/module/EntraBeta/AdditionalFunctions/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/AdditionalFunctions/New-EntraBetaCustomHeaders.ps1
@@ -19,7 +19,7 @@ function New-EntraBetaCustomHeaders {
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Graph.Entra.Beta | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue


### PR DESCRIPTION
Grab current module from SessionState instead of using `Get-Module`. The latter is prone to error and breaks if multiple versions are imported simultaneously.