### PR TITLE
[Modularize] Improvements to use ExecutionContext automatic variables

### DIFF
--- a/module/Entra/Microsoft.Entra/Applications/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.Applications | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/Authentication/Get-EntraContext.ps1
+++ b/module/Entra/Microsoft.Entra/Authentication/Get-EntraContext.ps1
@@ -8,6 +8,7 @@ function Get-EntraContext {
 
     PROCESS {
         $params = @{}
+        $entraPSModuleName = "Microsoft.Entra"
         if ($null -ne $PSBoundParameters["ErrorAction"]) {
             $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
         }
@@ -54,12 +55,8 @@ function Get-EntraContext {
 
         $response = Get-MgContext @params
 
-        # $module = Get-Module -Name Microsoft.Entra.Authentication -ErrorAction SilentlyContinue
+        $module = $ExecutionContext.SessionState.Module       
 
-        Write-Host ("ExecutionContext: {0}" -f $ExecutionContext | Format-List -Property *)
-        $module = $ExecutionContext.SessionState.Module
-        Write-Host ("Module: {0}" -f $module)
-        $entraPSModuleName = "Microsoft.Entra"
         $response | Add-Member -MemberType NoteProperty -Name "EntraPSModuleName" -Value $entraPSModuleName -Force
 
         if ($null -ne $module) {

--- a/module/Entra/Microsoft.Entra/Authentication/Get-EntraContext.ps1
+++ b/module/Entra/Microsoft.Entra/Authentication/Get-EntraContext.ps1
@@ -56,7 +56,7 @@ function Get-EntraContext {
 
         # $module = Get-Module -Name Microsoft.Entra.Authentication -ErrorAction SilentlyContinue
 
-        Write-Host ("ExecutionContext: {0}" -f $ExecutionContext)
+        Write-Host ("ExecutionContext: {0}" -f $ExecutionContext | Format-List -Property *)
         $module = $ExecutionContext.SessionState.Module
         Write-Host ("Module: {0}" -f $module)
         $entraPSModuleName = "Microsoft.Entra"

--- a/module/Entra/Microsoft.Entra/Authentication/Get-EntraContext.ps1
+++ b/module/Entra/Microsoft.Entra/Authentication/Get-EntraContext.ps1
@@ -54,7 +54,11 @@ function Get-EntraContext {
 
         $response = Get-MgContext @params
 
-        $module = Get-Module -Name Microsoft.Entra.Authentication -ErrorAction SilentlyContinue
+        # $module = Get-Module -Name Microsoft.Entra.Authentication -ErrorAction SilentlyContinue
+
+        Write-Host ("ExecutionContext: {0}" -f $ExecutionContext)
+        $module = $ExecutionContext.SessionState.Module
+        Write-Host ("Module: {0}" -f $module)
         $entraPSModuleName = "Microsoft.Entra"
         $response | Add-Member -MemberType NoteProperty -Name "EntraPSModuleName" -Value $entraPSModuleName -Force
 

--- a/module/Entra/Microsoft.Entra/Authentication/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/Authentication/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.Authentication | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.DirectoryManagement | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/Governance/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.Governance | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/Groups/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.Groups | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/Reports/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/Reports/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.Reports | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/SignIns/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/SignIns/New-EntraCustomHeaders.ps1
@@ -17,11 +17,11 @@ function New-EntraCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.SignIns | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/Entra/Microsoft.Entra/Users/New-EntraCustomHeaders.ps1
+++ b/module/Entra/Microsoft.Entra/Users/New-EntraCustomHeaders.ps1
@@ -21,7 +21,7 @@ function New-EntraCustomHeaders {
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-Module Microsoft.Entra.Users | Select-Object version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.Applications | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Authentication/Get-EntraContext.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Authentication/Get-EntraContext.ps1
@@ -8,6 +8,7 @@ function Get-EntraContext {
 
     PROCESS {
         $params = @{}
+        $entraPSModuleName = "Microsoft.Entra.Beta"
         if ($null -ne $PSBoundParameters["ErrorAction"]) {
             $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
         }
@@ -54,8 +55,8 @@ function Get-EntraContext {
 
         $response = Get-MgContext @params
 
-        $module = Get-Module -Name Microsoft.Entra.Beta.Authentication -ErrorAction SilentlyContinue
-        $entraPSModuleName = "Microsoft.Entra.Beta"
+        $module = $ExecutionContext.SessionState.Module
+
         $response | Add-Member -MemberType NoteProperty -Name "EntraPSModuleName" -Value $entraPSModuleName -Force
 
         if ($null -ne $module) {

--- a/module/EntraBeta/Microsoft.Entra.Beta/Authentication/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Authentication/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.Authentication | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.DirectoryManagement | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Governance/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Governance/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.Governance | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.Groups | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.NetworkAccess | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Reports/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Reports/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.Reports | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/SignIns/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/SignIns/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.SignIns | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/New-EntraBetaCustomHeaders.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/New-EntraBetaCustomHeaders.ps1
@@ -15,11 +15,11 @@ function New-EntraBetaCustomHeaders {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-		$Command
+        $Command
     )
     
     $psVersion = $global:PSVersionTable.PSVersion
-    $entraVersion = (Get-module Microsoft.Entra.Beta.Users | select version).Version.ToString()
+    $entraVersion = $ExecutionContext.SessionState.Module.Version.ToString()
     $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion $Command"
     $customHeaders = New-Object 'system.collections.generic.dictionary[string,string]'
     $customHeaders["User-Agent"] = $userAgentHeaderValue


### PR DESCRIPTION
Improvements to use ExecutionContext automatic variables:
- In Custom headers.
- `Get-EntraContext` command.

Based on PR suggestion - https://github.com/microsoftgraph/entra-powershell/pull/1318/

Attribution: @fflaten