### PR TITLE
Use return for better UX

### DIFF
--- a/samples/identify-assignment-policies-without-approval.ps1
+++ b/samples/identify-assignment-policies-without-approval.ps1
@@ -25,7 +25,7 @@ try{
     Write-Host "Successfully imported $($Policies.Count) policies"
 }catch{
     Write-Error "Error importing policies: $_"
-    exit
+    return
 }
 
 Write-Host "Starting to analyze policies"
@@ -38,7 +38,7 @@ foreach($Policy in $Policies){
             }
             catch {
                 Write-Error "Error getting policy details: $_"
-                exit
+                return
             }
 
         }


### PR DESCRIPTION
Update **identify-assignment-policies-without-approval.ps1** to use a `return` statement after errors instead of `exit` after errors. This will allow the user to see the error and troubleshoot as necessary.