### PR TITLE
Fix to the Enable-EntraAzureADAlias not being added to Groups submodule

### DIFF
--- a/module/Entra/Microsoft.Entra/Groups/Enable-EntraAzureADAlias.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/Enable-EntraAzureADAlias.ps1
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------ 
 #  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
 #  Licensed under the MIT License.  See License in the project root for license information. 
-#--------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------ 
 function Enable-EntraAzureADAlias {
    Set-Alias -Name Select-AzureADGroupIdsContactIsMemberOf -Value Select-EntraGroupIdsContactIsMemberOf -Scope Global -Force
    Set-Alias -Name Get-AzureADMSDeletedGroup -Value Get-EntraDeletedGroup -Scope Global -Force
@@ -63,3 +63,5 @@ function Enable-EntraAzureADAlias {
    Set-Alias -Name Set-AzureADApplicationProxyConnector -Value Get-EntraUnsupportedCommand -Scope Global -Force
 
 }
+
+


### PR DESCRIPTION
Fix to inject Enable-EntraAzureADAlias into the Microsoft.Entra.Groups.psm1 sub-module file. 
