### PR TITLE
Remove-EntraUserSponsor - Remove Entra user sponsor cmdlet

### DIFF
--- a/module/Entra/Microsoft.Entra/Users/Remove-EntraUserSponsor.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Remove-EntraUserSponsor.ps1
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------ 
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
+#  Licensed under the MIT License.  See License in the project root for license information. 
+# ------------------------------------------------------------------------------ 
+function Remove-EntraUserSponsor {
+    [CmdletBinding(DefaultParameterSetName = '')]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String] $UserId,
+
+        [Alias('DirectoryObjectId')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String] $SponsorId
+    )
+
+    PROCESS {
+        $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
+        $params = @{}
+        
+        $params["Uri"] = "https://graph.microsoft.com/v1.0/users/$UserId/sponsors/$SponsorId/`$ref"
+        $params["Method"] = "DELETE"
+
+        Write-Debug("============================ TRANSFORMATIONS ============================")
+        $params.Keys | ForEach-Object {"$_ : $($params[$_])" } | Write-Debug
+        Write-Debug("=========================================================================`n")
+
+        Invoke-GraphRequest -Headers $customHeaders -Uri $($params.Uri) -Method $($params.Method)
+    }
+}

--- a/module/Entra/Microsoft.Entra/Users/Remove-EntraUserSponsor.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Remove-EntraUserSponsor.ps1
@@ -5,11 +5,11 @@
 function Remove-EntraUserSponsor {
     [CmdletBinding(DefaultParameterSetName = '')]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The unique identifier (User ID) of the user whose sponsor you want to remove.")]
         [System.String] $UserId,
 
         [Alias('DirectoryObjectId')]
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The User Sponsor ID to be removed.")]
         [System.String] $SponsorId
     )
 

--- a/module/Entra/Microsoft.Entra/Users/Remove-EntraUserSponsor.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Remove-EntraUserSponsor.ps1
@@ -24,6 +24,7 @@ function Remove-EntraUserSponsor {
         $params.Keys | ForEach-Object {"$_ : $($params[$_])" } | Write-Debug
         Write-Debug("=========================================================================`n")
 
-        Invoke-GraphRequest -Headers $customHeaders -Uri $($params.Uri) -Method $($params.Method)
+        $response = Invoke-GraphRequest -Headers $customHeaders -Uri $($params.Uri) -Method $($params.Method)
+        $response
     }
 }

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Remove-EntraBetaUserSponsor.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Remove-EntraBetaUserSponsor.ps1
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------ 
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
+#  Licensed under the MIT License.  See License in the project root for license information. 
+# ------------------------------------------------------------------------------ 
+function Remove-EntraBetaUserSponsor {
+    [CmdletBinding(DefaultParameterSetName = '')]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String] $UserId,
+
+        [Alias('DirectoryObjectId')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String] $SponsorId
+    )
+
+    PROCESS {
+        $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
+        $params = @{}
+        
+        $params["Uri"] = "https://graph.microsoft.com/beta/users/$UserId/sponsors/$SponsorId/`$ref"
+        $params["Method"] = "DELETE"
+
+        Write-Debug("============================ TRANSFORMATIONS ============================")
+        $params.Keys | ForEach-Object {"$_ : $($params[$_])" } | Write-Debug
+        Write-Debug("=========================================================================`n")
+
+        Invoke-GraphRequest -Headers $customHeaders -Uri $($params.Uri) -Method $($params.Method)
+    }
+}

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Remove-EntraBetaUserSponsor.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Remove-EntraBetaUserSponsor.ps1
@@ -5,11 +5,11 @@
 function Remove-EntraBetaUserSponsor {
     [CmdletBinding(DefaultParameterSetName = '')]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The unique identifier (User ID) of the user whose sponsor you want to remove.")]
         [System.String] $UserId,
 
         [Alias('DirectoryObjectId')]
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The User Sponsor ID to be removed.")]
         [System.String] $SponsorId
     )
 

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Remove-EntraBetaUserSponsor.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Remove-EntraBetaUserSponsor.ps1
@@ -24,6 +24,7 @@ function Remove-EntraBetaUserSponsor {
         $params.Keys | ForEach-Object {"$_ : $($params[$_])" } | Write-Debug
         Write-Debug("=========================================================================`n")
 
-        Invoke-GraphRequest -Headers $customHeaders -Uri $($params.Uri) -Method $($params.Method)
+        $response = Invoke-GraphRequest -Headers $customHeaders -Uri $($params.Uri) -Method $($params.Method)
+        $response
     }
 }

--- a/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
+++ b/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
@@ -1,6 +1,6 @@
 ---
 title: Remove-EntraBetaUserSponsor
-description:  This article provides details on the Remove-EntraUserSponsor command.
+description:  This article provides details on the Remove-EntraBetaUserSponsor command.
 
 
 ms.topic: reference
@@ -30,7 +30,7 @@ Remove-EntraBetaUserSponsor
 
 ## Description
 
-The `Remove-EntraBetaUserSponsor` cmdlet removes a sponsor relationship from a user. Sponsors are users and groups that are responsible for a guest's privileges in the tenant and for keeping the guest's information and access up to date. This cmdlet removes that sponsorship relationship. Specify `UserId` and `SponsorId` parameters to remove a user extension.
+The `Remove-EntraBetaUserSponsor` cmdlet removes a sponsor relationship from a user. Sponsors are users and groups that are responsible for a guest's privileges in the tenant and for keeping the guest's information and access up to date. This cmdlet removes that sponsorship relationship. Specify `UserId` and `SponsorId` parameters to remove a user sponsor.
 
 ## Examples
 

--- a/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
+++ b/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
@@ -1,0 +1,91 @@
+---
+title: Remove-EntraBetaUserSponsor
+description:  This article provides details on the Remove-EntraUserSponsor command.
+
+
+ms.topic: reference
+ms.date: 02/24/2025
+ms.author: eunicewaweru
+ms.reviewer: stevemutungi
+manager: CelesteDG
+author: msewaweru
+
+schema: 2.0.0
+---
+
+# Remove-EntraBetaUserSponsor
+
+## Synopsis
+
+Removes a sponsor from a user.
+
+## Syntax
+
+```powershell
+Remove-EntraBetaUserSponsor
+ -UserId <String>
+ -SponsorId <String>
+ [<CommonParameters>]
+```
+
+## Description
+
+The `Remove-EntraBetaUserSponsor` cmdlet removes a sponsor relationship from a user. Sponsors are users and groups that are responsible for a guest's privileges in the tenant and for keeping the guest's information and access up to date. This cmdlet removes that sponsorship relationship. Specify `UserId` and `SponsorId` parameters to remove a user extension.
+
+## Examples
+
+### Example 1: Remove a user sponsor
+
+```powershell
+Connect-Entra -Scopes 'User.ReadWrite.All'
+Remove-EntraBetaUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId cccccccc-2222-3333-4444-dddddddddddd
+```
+
+This example demonstrates how to remove a user sponsor.
+
+- `UserId` parameter specifies the UserId or User Principal Name of the User.
+- `SponsorId` parameter specifies the ID of the sponsor to remove.
+
+## Parameters
+
+### -UserId
+
+Specifies the ID (as a UserPrincipalName or UserId) of a user in Microsoft Entra ID.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -SponsorId
+
+Specifies the ID of the sponsor (user or group) to be removed.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases: DirectoryObjectId
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
+
+## Outputs
+
+## Notes
+
+## Related Links

--- a/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
+++ b/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
@@ -38,8 +38,7 @@ The `Remove-EntraBetaUserSponsor` cmdlet removes a sponsor relationship from a u
 
 ```powershell
 Connect-Entra -Scopes 'User.ReadWrite.All'
-$sponsor = Get-EntraBetaUserSponsor -UserId 'SawyerM@contoso.com' -Top 1 |
-Select-Object Id, DisplayName, '@odata.type', CreatedDateTime | Format-Table -AutoSize
+$sponsor = Get-EntraBetaUserSponsor -UserId 'SawyerM@contoso.com' -Top 1
 Remove-EntraBetaUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId $sponsor.Id
 ```
 

--- a/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
+++ b/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
@@ -38,7 +38,9 @@ The `Remove-EntraBetaUserSponsor` cmdlet removes a sponsor relationship from a u
 
 ```powershell
 Connect-Entra -Scopes 'User.ReadWrite.All'
-Remove-EntraBetaUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId cccccccc-2222-3333-4444-dddddddddddd
+$sponsor = Get-EntraBetaUserSponsor -UserId 'SawyerM@contoso.com' -Top 1 |
+Select-Object Id, DisplayName, '@odata.type', CreatedDateTime | Format-Table -AutoSize
+Remove-EntraBetaUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId $sponsor.Id
 ```
 
 This example demonstrates how to remove a user sponsor.

--- a/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
+++ b/module/docs/entra-powershell-beta/Users/Remove-EntraBetaUserSponsor.md
@@ -34,7 +34,18 @@ The `Remove-EntraBetaUserSponsor` cmdlet removes a sponsor relationship from a u
 
 ## Examples
 
-### Example 1: Remove a user sponsor
+### Example 1: Remove a user sponsor via pipelining
+
+```powershell
+Connect-Entra -Scopes 'User.ReadWrite.All'
+Get-EntraBetaUserSponsor -UserId 'SawyerM@contoso.com' | Where-Object { $_.displayName -eq 'Adele Vance (Fabrikam)' } | Remove-EntraBetaUserSponsor
+```
+
+This example demonstrates how to remove a user sponsor.
+
+- `UserId` parameter specifies the UserId or User Principal Name of the User.
+
+### Example 2: Remove a user sponsor
 
 ```powershell
 Connect-Entra -Scopes 'User.ReadWrite.All'

--- a/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
+++ b/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
@@ -1,0 +1,91 @@
+---
+title: Remove-EntraUserSponsor
+description:  This article provides details on the Remove-EntraUserSponsor command.
+
+
+ms.topic: reference
+ms.date: 02/24/2025
+ms.author: eunicewaweru
+ms.reviewer: stevemutungi
+manager: CelesteDG
+author: msewaweru
+
+schema: 2.0.0
+---
+
+# Remove-EntraUserSponsor
+
+## Synopsis
+
+Removes a sponsor from a user.
+
+## Syntax
+
+```powershell
+Remove-EntraUserSponsor
+ -UserId <String>
+ -SponsorId <String>
+ [<CommonParameters>]
+```
+
+## Description
+
+The `Remove-EntraUserSponsor` cmdlet removes a sponsor relationship from a user. Sponsors are users and groups that are responsible for a guest's privileges in the tenant and for keeping the guest's information and access up to date. This cmdlet removes that sponsorship relationship. Specify `UserId` and `SponsorId` parameters to remove a user extension.
+
+## Examples
+
+### Example 1: Remove a user sponsor
+
+```powershell
+Connect-Entra -Scopes 'User.ReadWrite.All'
+Remove-EntraUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId cccccccc-2222-3333-4444-dddddddddddd
+```
+
+This example demonstrates how to remove a user sponsor.
+
+- `UserId` parameter specifies the UserId or User Principal Name of the User.
+- `SponsorId` parameter specifies the ID of the sponsor to remove.
+
+## Parameters
+
+### -UserId
+
+Specifies the ID (as a UserPrincipalName or UserId) of a user in Microsoft Entra ID.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -SponsorId
+
+Specifies the ID of the sponsor (user or group) to be removed.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases: DirectoryObjectId
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
+
+## Outputs
+
+## Notes
+
+## Related Links

--- a/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
+++ b/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
@@ -38,7 +38,9 @@ The `Remove-EntraUserSponsor` cmdlet removes a sponsor relationship from a user.
 
 ```powershell
 Connect-Entra -Scopes 'User.ReadWrite.All'
-Remove-EntraUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId cccccccc-2222-3333-4444-dddddddddddd
+$sponsor = Get-EntraUserSponsor -UserId 'SawyerM@contoso.com' -Top 1 |
+Select-Object Id, DisplayName, '@odata.type', CreatedDateTime | Format-Table -AutoSize
+Remove-EntraUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId $sponsor.Id
 ```
 
 This example demonstrates how to remove a user sponsor.

--- a/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
+++ b/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
@@ -34,7 +34,18 @@ The `Remove-EntraUserSponsor` cmdlet removes a sponsor relationship from a user.
 
 ## Examples
 
-### Example 1: Remove a user sponsor
+### Example 1: Remove a user sponsor via pipelining
+
+```powershell
+Connect-Entra -Scopes 'User.ReadWrite.All'
+Get-EntraUserSponsor -UserId 'SawyerM@contoso.com' | Where-Object { $_.displayName -eq 'Adele Vance (Fabrikam)' } | Remove-EntraUserSponsor
+```
+
+This example demonstrates how to remove a user sponsor.
+
+- `UserId` parameter specifies the UserId or User Principal Name of the User.
+
+### Example 2: Remove a user sponsor
 
 ```powershell
 Connect-Entra -Scopes 'User.ReadWrite.All'

--- a/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
+++ b/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
@@ -38,8 +38,7 @@ The `Remove-EntraUserSponsor` cmdlet removes a sponsor relationship from a user.
 
 ```powershell
 Connect-Entra -Scopes 'User.ReadWrite.All'
-$sponsor = Get-EntraUserSponsor -UserId 'SawyerM@contoso.com' -Top 1 |
-Select-Object Id, DisplayName, '@odata.type', CreatedDateTime | Format-Table -AutoSize
+$sponsor = Get-EntraUserSponsor -UserId 'SawyerM@contoso.com' -Top 1
 Remove-EntraUserSponsor -UserId 'SawyerM@Contoso.com' -SponsorId $sponsor.Id
 ```
 

--- a/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
+++ b/module/docs/entra-powershell-v1.0/Users/Remove-EntraUserSponsor.md
@@ -30,7 +30,7 @@ Remove-EntraUserSponsor
 
 ## Description
 
-The `Remove-EntraUserSponsor` cmdlet removes a sponsor relationship from a user. Sponsors are users and groups that are responsible for a guest's privileges in the tenant and for keeping the guest's information and access up to date. This cmdlet removes that sponsorship relationship. Specify `UserId` and `SponsorId` parameters to remove a user extension.
+The `Remove-EntraUserSponsor` cmdlet removes a sponsor relationship from a user. Sponsors are users and groups that are responsible for a guest's privileges in the tenant and for keeping the guest's information and access up to date. This cmdlet removes that sponsorship relationship. Specify `UserId` and `SponsorId` parameters to remove a user sponsor.
 
 ## Examples
 

--- a/test/Entra/Users/Remove-EntraUserSponsor.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUserSponsor.Tests.ps1
@@ -1,0 +1,52 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {  
+    if ((Get-Module -Name Microsoft.Entra.Users) -eq $null) {
+        Import-Module Microsoft.Entra.Users        
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Users
+}
+
+Describe "Remove-EntraUserSponsor" {
+    Context "Test for Remove-EntraUserSponsor" {
+        It "Should fail when UserId is empty string value" {
+            { Remove-EntraUserSponsor -UserId "" -SponsorId "sponsor123" } | 
+                Should -Throw "Cannot bind argument to parameter 'UserId' because it is an empty string."
+        }
+
+        It "Should fail when UserId is empty" {
+            { Remove-EntraUserSponsor -UserId } | 
+                Should -Throw "Missing an argument for parameter 'UserId'. Specify a parameter of type 'System.String' and try again."
+        }
+
+        It "Should fail when SponsorId is empty string value" {
+            { Remove-EntraUserSponsor -UserId "user123" -SponsorId "" } | 
+                Should -Throw "Cannot bind argument to parameter 'SponsorId' because it is an empty string."
+        }
+
+        It "Should fail when SponsorId is empty" {
+            { Remove-EntraUserSponsor -UserId "user123" -SponsorId } | 
+                Should -Throw "Missing an argument for parameter 'SponsorId'. Specify a parameter of type 'System.String' and try again."
+        }
+
+        It "Should call Invoke-GraphRequest with correct parameters" {
+            $userId = "00aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            $sponsorId = "10aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            
+            Remove-EntraUserSponsor -UserId $userId -SponsorId $sponsorId
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 1 -Exactly
+        }
+
+        It "Should accept DirectoryObjectId as alias for SponsorId" {
+            $userId = "00aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            $dirObjectId = "10aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            
+            Remove-EntraUserSponsor -UserId $userId -DirectoryObjectId $dirObjectId
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 1 -Exactly
+        }
+    }
+}

--- a/test/EntraBeta/Users/Remove-EntraBetaUserSponsor.Tests.ps1
+++ b/test/EntraBeta/Users/Remove-EntraBetaUserSponsor.Tests.ps1
@@ -1,0 +1,52 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {  
+    if((Get-Module -Name Microsoft.Entra.Beta.Users) -eq $null){
+        Import-Module Microsoft.Entra.Beta.Users    
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.Users
+}
+
+Describe "Remove-EntraBetaUserSponsor" {
+    Context "Test for Remove-EntraBetaUserSponsor" {
+        It "Should fail when UserId is empty string value" {
+            { Remove-EntraBetaUserSponsor -UserId "" -SponsorId "sponsor123" } | 
+                Should -Throw "Cannot bind argument to parameter 'UserId' because it is an empty string."
+        }
+
+        It "Should fail when UserId is empty" {
+            { Remove-EntraBetaUserSponsor -UserId } | 
+                Should -Throw "Missing an argument for parameter 'UserId'. Specify a parameter of type 'System.String' and try again."
+        }
+
+        It "Should fail when SponsorId is empty string value" {
+            { Remove-EntraBetaUserSponsor -UserId "user123" -SponsorId "" } | 
+                Should -Throw "Cannot bind argument to parameter 'SponsorId' because it is an empty string."
+        }
+
+        It "Should fail when SponsorId is empty" {
+            { Remove-EntraBetaUserSponsor -UserId "user123" -SponsorId } | 
+                Should -Throw "Missing an argument for parameter 'SponsorId'. Specify a parameter of type 'System.String' and try again."
+        }
+
+        It "Should call Invoke-GraphRequest with correct parameters" {
+            $userId = "00aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            $sponsorId = "10aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            
+            Remove-EntraBetaUserSponsor -UserId $userId -SponsorId $sponsorId
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 1 -Exactly
+        }
+
+        It "Should accept DirectoryObjectId as alias for SponsorId" {
+            $userId = "00aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            $dirObjectId = "10aa00aa-bb11-cc22-dd33-44ee44ee44e"
+            
+            Remove-EntraBetaUserSponsor -UserId $userId -DirectoryObjectId $dirObjectId
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 1 -Exactly
+        }
+    }
+}

--- a/test/EntraBeta/Users/Remove-EntraBetaUserSponsor.Tests.ps1
+++ b/test/EntraBeta/Users/Remove-EntraBetaUserSponsor.Tests.ps1
@@ -38,7 +38,7 @@ Describe "Remove-EntraBetaUserSponsor" {
             $sponsorId = "10aa00aa-bb11-cc22-dd33-44ee44ee44e"
             
             Remove-EntraBetaUserSponsor -UserId $userId -SponsorId $sponsorId
-            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 1 -Exactly
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 1 -Exactly
         }
 
         It "Should accept DirectoryObjectId as alias for SponsorId" {
@@ -46,7 +46,7 @@ Describe "Remove-EntraBetaUserSponsor" {
             $dirObjectId = "10aa00aa-bb11-cc22-dd33-44ee44ee44e"
             
             Remove-EntraBetaUserSponsor -UserId $userId -DirectoryObjectId $dirObjectId
-            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 1 -Exactly
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 1 -Exactly
         }
     }
 }


### PR DESCRIPTION
Adds a new cmdlet to remove sponsor relationships from users in Microsoft Entra ID. This cmdlet makes a DELETE request to the Microsoft Graph API and returns a 204 No Content response on successful deletion.
