### PR TITLE
Add Microsoft.Entra.*.Authentication to sub-modules as a requiredModule

### DIFF
--- a/module/Entra/config/ModuleMetadata.json
+++ b/module/Entra/config/ModuleMetadata.json
@@ -17,6 +17,7 @@
     "Microsoft.Graph.Reports"
   ],
   "requiredModulesVersion": "2.25.0",
+  "requiredAuthModuleVersion":"1.0.3",
   "compatibleEditions": [
     "Core",
     "Desktop"

--- a/module/Entra/config/dependencyMapping.json
+++ b/module/Entra/config/dependencyMapping.json
@@ -1,10 +1,10 @@
 {
-    "Microsoft.Entra.Users":["Microsoft.Graph.Users","Microsoft.Graph.Users.Actions","Microsoft.Graph.Users.Functions"],
+    "Microsoft.Entra.Users":["Microsoft.Graph.Users","Microsoft.Graph.Users.Actions","Microsoft.Graph.Users.Functions","Microsoft.Entra.Authentication"],
     "Microsoft.Entra.Authentication":["Microsoft.Graph.Authentication"],
-    "Microsoft.Entra.Groups":["Microsoft.Graph.Groups"],
-    "Microsoft.Entra.DirectoryManagement":["Microsoft.Graph.Identity.DirectoryManagement"],
-    "Microsoft.Entra.Governance":["Microsoft.Graph.Identity.Governance"],
-    "Microsoft.Entra.SignIns":["Microsoft.Graph.Identity.SignIns"],
-    "Microsoft.Entra.Applications":["Microsoft.Graph.Applications"],
-    "Microsoft.Entra.Reports":["Microsoft.Graph.Reports"]
+    "Microsoft.Entra.Groups":["Microsoft.Graph.Groups","Microsoft.Entra.Authentication"],
+    "Microsoft.Entra.DirectoryManagement":["Microsoft.Graph.Identity.DirectoryManagement","Microsoft.Entra.Authentication"],
+    "Microsoft.Entra.Governance":["Microsoft.Graph.Identity.Governance","Microsoft.Entra.Authentication"],
+    "Microsoft.Entra.SignIns":["Microsoft.Graph.Identity.SignIns","Microsoft.Entra.Authentication"],
+    "Microsoft.Entra.Applications":["Microsoft.Graph.Applications","Microsoft.Entra.Authentication"],
+    "Microsoft.Entra.Reports":["Microsoft.Graph.Reports","Microsoft.Entra.Authentication"]
 }

--- a/module/EntraBeta/config/ModuleMetadata.json
+++ b/module/EntraBeta/config/ModuleMetadata.json
@@ -17,6 +17,7 @@
     "Microsoft.Graph.Beta.Reports"
   ],
   "requiredModulesVersion": "2.25.0",
+  "requiredAuthModuleVersion":"1.0.3",
   "compatibleEditions": [
     "Core",
     "Desktop"

--- a/module/EntraBeta/config/dependencyMapping.json
+++ b/module/EntraBeta/config/dependencyMapping.json
@@ -1,10 +1,10 @@
 {
-    "Microsoft.Entra.Beta.Users":["Microsoft.Graph.Beta.Users","Microsoft.Graph.Beta.Users.Actions","Microsoft.Graph.Beta.Users.Functions"],
+    "Microsoft.Entra.Beta.Users":["Microsoft.Graph.Beta.Users","Microsoft.Graph.Beta.Users.Actions","Microsoft.Graph.Beta.Users.Functions","Microsoft.Entra.Beta.Authentication"],
     "Microsoft.Entra.Beta.Authentication":["Microsoft.Graph.Authentication"],
-    "Microsoft.Entra.Beta.Groups":["Microsoft.Graph.Beta.Groups"],
-    "Microsoft.Entra.Beta.DirectoryManagement":["Microsoft.Graph.Beta.Identity.DirectoryManagement"],
-    "Microsoft.Entra.Beta.Governance":["Microsoft.Graph.Beta.Identity.Governance"],
-    "Microsoft.Entra.Beta.SignIns":["Microsoft.Graph.Beta.Identity.SignIns"],
-    "Microsoft.Entra.Beta.Applications":["Microsoft.Graph.Beta.Applications"],
-    "Microsoft.Entra.Beta.Reports":["Microsoft.Graph.Beta.Reports"]
+    "Microsoft.Entra.Beta.Groups":["Microsoft.Graph.Beta.Groups","Microsoft.Entra.Beta.Authentication"],
+    "Microsoft.Entra.Beta.DirectoryManagement":["Microsoft.Graph.Beta.Identity.DirectoryManagement","Microsoft.Entra.Beta.Authentication"],
+    "Microsoft.Entra.Beta.Governance":["Microsoft.Graph.Beta.Identity.Governance","Microsoft.Entra.Beta.Authentication"],
+    "Microsoft.Entra.Beta.SignIns":["Microsoft.Graph.Beta.Identity.SignIns","Microsoft.Entra.Beta.Authentication"],
+    "Microsoft.Entra.Beta.Applications":["Microsoft.Graph.Beta.Applications","Microsoft.Entra.Beta.Authentication"],
+    "Microsoft.Entra.Beta.Reports":["Microsoft.Graph.Beta.Reports","Microsoft.Entra.Beta.Authentication"]
 }

--- a/src/EntraModuleBuilder.ps1
+++ b/src/EntraModuleBuilder.ps1
@@ -479,7 +479,11 @@ $($requiredModulesEntries -join ",`n")
             
             if ($dependencyMapping.ContainsKey($keyModuleName)) {
                 foreach ($dependency in $dependencyMapping[$keyModuleName]) {
-                    $requiredModules += @{ ModuleName = $dependency; RequiredVersion = $content.requiredModulesVersion }
+                    if($dependency -eq 'Microsoft.Entra.Authentication' -or $dependency -eq 'Microsoft.Entra.Beta.Authentication'){
+                        $requiredModules += @{ ModuleName = $dependency; RequiredVersion = $content.requiredAuthModuleVersion }
+                    }else{
+                        $requiredModules += @{ ModuleName = $dependency; RequiredVersion = $content.requiredModulesVersion }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add Microsoft.Entra.*.Authentication module as a requiredModule to obviate the need to explicitly install Microsoft.Entra.*.Authentication for a user to be able to use any of the Authentication sub-module cmdlets.