### PR TITLE
CertificateUserIDs module

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -40,6 +40,10 @@
       {
         "file": "test\\Entra\\Users\\New-EntraUser.Tests.ps1",
         "_justification": "Unit test file has a sample Password used in mocking."
+      },
+      {
+        "file": "test\\Entra\\Users\\Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1",
+        "_justification": "Unit test file has a sample certificate with only public keys used in mocking."
       }
     ]
 }

--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -139,6 +139,7 @@ Import-Module .\bin\Microsoft.Entra.Applications.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.DirectoryManagement.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Governance.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Users.psd1 -Force
+Import-Module .\bin\Microsoft.Entra.Utilities.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Groups.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Reports.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.SignIns.psd1 -Force

--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -60,6 +60,7 @@ Import-Module .\bin\Microsoft.Entra.Applications.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.DirectoryManagement.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Governance.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Users.psd1 -Force
+Import-Module .\bin\Microsoft.Entra.Utilities.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Groups.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.Reports.psd1 -Force
 Import-Module .\bin\Microsoft.Entra.SignIns.psd1 -Force

--- a/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
+++ b/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
@@ -41,7 +41,6 @@
 #>
 
 function Get-EntraUserCertificateUserIdsFromCertificate {
-    [CmdletBinding(HelpUri = 'https://azuread.github.io/MSIdentityTools/commands/Get-MsIdCBACertificateUserIdFromCertificate')]
     param (
         [Parameter(Mandatory = $false)]    
         [string]$Path,

--- a/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
+++ b/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
@@ -196,7 +196,12 @@ function Get-EntraUserCertificateUserIdsFromCertificate {
 
     function Main
     {
-        $cert = Get-Certificate -filePath $Path
+        $cert = $Certificate
+        if ($null -eq $cert)
+        {
+            $cert = Get-Certificate -filePath $Path
+        }
+
         $mappings = Get-CertificateUserIds -cert $cert
         
         if ($CertificateMapping -eq "")

--- a/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
+++ b/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
@@ -1,3 +1,7 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 <#
 .SYNOPSIS
     Generates an object representing all the values contained in a certificate file that can be used in Entra ID for configuring CertificateUserIDs in Certificate-Based Authentication.

--- a/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
+++ b/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
@@ -1,0 +1,212 @@
+<#
+.SYNOPSIS
+    Generates an object representing all the values contained in a certificate file that can be used in Entra ID for configuring CertificateUserIDs in Certificate-Based Authentication.
+
+.DESCRIPTION
+    Retrieves and returns an object with the properties 'PrincipalName', 'RFC822Name', 'IssuerAndSubject', 'Subject', 'SKI', 'SHA1PublicKey', and 'IssuerAndSerialNumber' from a certificate file for use in CertificateUserIDs configuration in Certificate-Based Authentication, according to the guidelines outlined in the Microsoft documentation for certificate-based authentication
+
+.PARAMETER Path
+    The path to the certificate file. The file can be in .cer or .pem format.
+
+.PARAMETER CertificateMapping
+    The certificate mapping property to retrieve. Valid values are PrincipalName, RFC822Name, IssuerAndSubject, Subject, SKI, SHA1PublicKey, and IssuerAndSerialNumber.
+
+.EXAMPLE
+    PS > Get-EntraUserCertificateUserIdsFromCertificate -Path "C:\path\to\certificate.cer"
+
+    This command retrieves all the possible certificate mappings and returns an object to represent them.
+
+.EXAMPLE
+    PS > Get-EntraUserCertificateUserIdsFromCertificate -Path "C:\path\to\certificate.cer" -CertificateMapping Subject
+
+    This command retrieves and returns the PrincipalName property.
+
+.OUTPUTS
+    Returns an object containing the certificateUserIDs that can be used with the givin certificate.
+
+    @{
+        PrincipalName = "X509:<PN>bob@woodgrove.com"
+        RFC822Name = "X509:<RFC822>user@woodgrove.com"
+        IssuerAndSubject = "X509:<I>DC=com,DC=contoso,CN=CONTOSO-DC-CA<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest"
+        Subject = "X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest"
+        SKI = "X509:<SKI>aB1cD2eF3gH4iJ5kL6mN7oP8qR"
+        SHA1PublicKey = "X509:<SHA1-PUKEY>cD2eF3gH4iJ5kL6mN7oP8qR9sT"
+        IssuerAndSerialNumber = "X509:<I>DC=com,DC=contoso,CN=CONTOSO-DC-CA<SR>eF3gH4iJ5kL6mN7oP8qR9sT0uV"
+    }
+
+#>
+
+function Get-EntraUserCertificateUserIdsFromCertificate {
+    [CmdletBinding(HelpUri = 'https://azuread.github.io/MSIdentityTools/commands/Get-MsIdCBACertificateUserIdFromCertificate')]
+    param (
+        [Parameter(Mandatory = $false)]    
+        [string]$Path,
+        [Parameter(Mandatory = $false)]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("PrincipalName", "RFC822Name", "IssuerAndSubject", "Subject", "SKI", "SHA1PublicKey", "IssuerAndSerialNumber")]
+        [string]$CertificateMapping
+    )
+
+    function Get-Certificate {
+        param (
+            [string]$filePath
+        )
+        if ($filePath.EndsWith(".cer")) {
+            return [System.Security.Cryptography.X509Certificates.X509Certificate]::new($filePath)
+        } elseif ($filePath.EndsWith(".pem")) {
+            $pemContent = Get-Content -Path $filePath -Raw
+            $pemContent = $pemContent -replace "-----BEGIN CERTIFICATE-----", ""
+            $pemContent = $pemContent -replace "-----END CERTIFICATE-----", ""
+            $pemContent = $pemContent -replace  "(\r\n|\n|\r)", ""
+            $pemBytes = [Convert]::FromBase64String($pemContent)
+            $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($pemBytes)
+
+            return $certificate
+        } else {
+            throw "Unsupported certificate format. Please provide a .cer or .pem file."
+        }
+    }
+
+    function Get-DistinguishedNameAsString {
+        param (
+            [System.Security.Cryptography.X509Certificates.X500DistinguishedName]$distinguishedName
+        )
+
+        $dn = $distinguishedName.Decode([System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags]::UseNewLines -bor [System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags]::DoNotUsePlusSign)
+        
+        $dn = $dn -replace "(\r\n|\n|\r)", ","
+        return $dn.TrimEnd(',')
+    }
+
+    function Get-SerialNumberAsLittleEndianHexString {
+        param (
+            [System.Security.Cryptography.X509Certificates.X509Certificate2]$cert
+        )
+
+        $littleEndianSerialNumber = $cert.GetSerialNumber()
+
+        if ($littleEndianSerialNumber.Length -eq 0)
+        {
+            return ""
+        }
+
+        [System.Array]::Reverse($littleEndianSerialNumber)
+        $hexString = -join ($littleEndianSerialNumber | ForEach-Object { $_.ToString("x2") })
+        return $hexString
+    }
+
+    function Get-SubjectKeyIdentifier {
+        param (
+            [System.Security.Cryptography.X509Certificates.X509Certificate2]$cert
+        )
+        foreach ($extension in $cert.Extensions) {
+            if ($extension.Oid.Value -eq "2.5.29.14") {
+                $ski = New-Object System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension -ArgumentList $extension, $false
+                return $ski.SubjectKeyIdentifier
+            }
+        }
+
+        return ""
+    }
+
+    # Function to generate certificate mapping fields
+    function Get-CertificateMappingFields {
+        param (
+            [System.Security.Cryptography.X509Certificates.X509Certificate2]$cert
+        )
+        $subject = Get-DistinguishedNameAsString -distinguishedName $cert.SubjectName
+        $issuer = Get-DistinguishedNameAsString -distinguishedName $cert.IssuerName
+        $serialNumber = Get-SerialNumberAsLittleEndianHexString -cert $cert
+        $thumbprint = $cert.Thumbprint
+        $principalName = $cert.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::UpnName, $false)
+        $emailName = $cert.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::EmailName, $false)
+        $subjectKeyIdentifier = Get-SubjectKeyIdentifier -cert $cert
+        $sha1PublicKey = $cert.GetCertHashString()
+
+        return @{
+            "SubjectName" = $subject
+            "IssuerName" = $issuer
+            "SerialNumber" = $serialNumber
+            "Thumbprint" = $thumbprint
+            "PrincipalName" = $principalName
+            "EmailName" = $emailName
+            "SubjectKeyIdentifier" = $subjectKeyIdentifier
+            "Sha1PublicKey" = $sha1PublicKey
+        }
+    }
+
+    function Get-CertificateUserIds {
+        param (
+            [System.Security.Cryptography.X509Certificates.X509Certificate2]$cert
+        )
+
+        $mappingFields = Get-CertificateMappingFields -cert $cert
+
+        $certUserIDs = @{
+            "PrincipalName" = ""
+            "RFC822Name" = ""
+            "IssuerAndSubject" = "" 
+            "Subject" = ""
+            "SKI" = ""
+            "SHA1PublicKey" = "" 
+            "IssuerAndSerialNumber" = ""
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($mappingFields.PrincipalName)) 
+        {
+            $certUserIDs.PrincipalName = "X509:<PN>$($mappingFields.PrincipalName)"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($mappingFields.EmailName)) 
+        {
+            $certUserIDs.RFC822Name = "X509:<RFC822>$($mappingFields.EmailName)"
+        }
+
+        if ((-not [string]::IsNullOrWhiteSpace($mappingFields.IssuerName)) -and (-not [string]::IsNullOrWhiteSpace($mappingFields.SubjectName))) 
+        {
+            $certUserIDs.IssuerAndSubject = "X509:<I>$($mappingFields.IssuerName)<S>$($mappingFields.SubjectName)"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($mappingFields.SubjectName)) 
+        {
+            $certUserIDs.Subject = "X509:<S>$($mappingFields.SubjectName)"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($mappingFields.SubjectKeyIdentifier)) 
+        {
+            $certUserIDs.SKI = "X509:<SKI>$($mappingFields.SubjectKeyIdentifier)"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($mappingFields.Sha1PublicKey)) 
+        {
+            $certUserIDs.SHA1PublicKey = "X509:<SHA1-PUKEY>$($mappingFields.Sha1PublicKey)"
+        }
+
+        if ((-not [string]::IsNullOrWhiteSpace($mappingFields.IssuerName)) -and (-not [string]::IsNullOrWhiteSpace($mappingFields.SerialNumber))) 
+        {
+            $certUserIDs.IssuerAndSerialNumber = "X509:<I>$($mappingFields.IssuerName)<SR>$($mappingFields.SerialNumber)"
+        }
+
+        return $certUserIDs
+    }
+
+    function Main
+    {
+        $cert = Get-Certificate -filePath $Path
+        $mappings = Get-CertificateUserIds -cert $cert
+        
+        if ($CertificateMapping -eq "")
+        {
+            return $mappings
+        }
+        else
+        {
+            $value = $mappings[$CertificateMapping]
+            return "$($value)"
+        }
+    }
+
+    # Call main function
+    return Main
+}

--- a/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
+++ b/module/Entra/Microsoft.Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.ps1
@@ -12,6 +12,9 @@
 .PARAMETER Path
     The path to the certificate file. The file can be in .cer or .pem format.
 
+.PARAMETER Certificate
+    An X509Certificate2 object
+
 .PARAMETER CertificateMapping
     The certificate mapping property to retrieve. Valid values are PrincipalName, RFC822Name, IssuerAndSubject, Subject, SKI, SHA1PublicKey, and IssuerAndSerialNumber.
 

--- a/module/Entra/config/moduleMapping.json
+++ b/module/Entra/config/moduleMapping.json
@@ -262,5 +262,6 @@
   "Set-EntraDirectoryRoleDefinition": "Governance",
   "Update-EntraUserFromFederated": "Users",
   "Get-EntraDomainServiceConfigurationRecord":"DirectoryManagement",
-  "Get-EntraUserAuthenticationRequirement":"SignIns"
+  "Get-EntraUserAuthenticationRequirement":"SignIns",
+  "Get-EntraUserCertificateUserIdsFromCertificate":"Utilities"
 }

--- a/module/docs/entra-powershell-v1.0/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.md
+++ b/module/docs/entra-powershell-v1.0/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.md
@@ -56,6 +56,16 @@ Get-MsIdCBACertificateUserIdFromCertificate C:\path\to\certificate.cer -Certific
 X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
 ```
 
+### EXAMPLE 3
+```powershell
+$certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $certBytes
+Get-MsIdCBACertificateUserIdFromCertificate -Certificate $certificate -CertificateMapping Subject
+```
+
+```Output
+X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
+```
+
 ## PARAMETERS
 ### -Path
 
@@ -72,6 +82,20 @@ Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
+### -Certificate
+Certificate from which the certificateUserIDs mappings will be extracted
+
+```yaml
+Type: System.Security.Cryptography.X509Certificates.X509Certificate2
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
 
 ### -CertificateMapping
 One of the values `PrincipalName`, `RFC822Name`, `IssuerAndSubject`, `Subject`, `SKI`, `SHA1PublicKey`, and `IssuerAndSerialNumber`.
@@ -83,7 +107,7 @@ Parameter Sets: {PrincipalName | RFC822Name | IssuerAndSubject | Subject | SKI |
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False

--- a/module/docs/entra-powershell-v1.0/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.md
+++ b/module/docs/entra-powershell-v1.0/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.md
@@ -21,7 +21,7 @@ Generates an object representing all the values contained in a certificate file 
 
 ## SYNTAX
 ```syntax
-Get-MsIdCBACertificateUserIdFromCertificate [-Path] <string> [[-CertificateMapping] <string>] [<CommonParameters>]
+Get-MsIdCBACertificateUserIdFromCertificate [-Path] <string> [[-Certificate] <System.Security.Cryptography.X509Certificates.X509Certificate2> [-CertificateMapping] <string>] [<CommonParameters>]
 ```
 ## DESCRIPTION
 

--- a/module/docs/entra-powershell-v1.0/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.md
+++ b/module/docs/entra-powershell-v1.0/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.md
@@ -1,0 +1,106 @@
+---
+title: Get-EntraUserCertificateUserIdsFromCertificate
+description: Creates an object with all values from a certificate file for configuring CertificateUserIDs in Entra ID
+ms.topic: reference
+ms.date: 03/25/2025
+ms.author: tdumitrescu
+manager: vimrang
+author: thadumi
+ms.reviewer: stevemutungi
+external help file: Microsoft.Entra.Utilities-Help.xml
+Module Name: Microsoft.Entra.Utilities
+online version: https://learn.microsoft.com/powershell/module/Microsoft.Entra.Utilities/Get-EntraUserCertificateUserIdsFromCertificate
+
+schema: 2.0.0
+---
+
+# Get-EntraUserCertificateUserIdsFromCertificate
+
+## SYNOPSIS
+Generates an object representing all the values contained in a certificate file that can be used in Entra ID for configuring CertificateUserIDs in Certificate-Based Authentication.
+
+## SYNTAX
+```syntax
+Get-MsIdCBACertificateUserIdFromCertificate [-Path] <string> [[-CertificateMapping] <string>] [<CommonParameters>]
+```
+## DESCRIPTION
+
+Returns an object containing the certificateUserIDs configurations for Certificate-Based Authentication based on the given certificate file. The properties in the object are constructed according to the guidelines outlined in the Microsoft [documentation](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-certificate-based-authentication-certificateuserids
+) for certificate-based authentication.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-MsIdCBACertificateUserIdFromCertificate C:\path\to\certificate.cer
+```
+
+```Output
+Name                           Value
+----                           -----
+Subject                        X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
+IssuerAndSerialNumber          X509:<I>DC=com,DC=contoso,CN=CONTOSO-DC-CA<SR>eF3gH4iJ5kL6mN7oP8qR9sT0uV
+RFC822Name                     X509:<RFC822>user@woodgrove.com
+SHA1PublicKey                  X509:<SHA1-PUKEY>cD2eF3gH4iJ5kL6mN7oP8qR9sT
+IssuerAndSubject               X509:<I>DC=com,DC=contoso,CN=CONTOSO-DC-CA<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
+SKI                            X509:<SKI>aB1cD2eF3gH4iJ5kL6mN7oP8qR
+PrincipalName                  X509:<PN>bob@woodgrove.com
+```
+
+### EXAMPLE 2
+```powershell
+Get-MsIdCBACertificateUserIdFromCertificate C:\path\to\certificate.cer -CertificateMapping Subject
+```
+
+```Output
+X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
+```
+
+## PARAMETERS
+### -Path
+
+Path to the certificate file, it can be either a cer or pem file.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -CertificateMapping
+One of the values `PrincipalName`, `RFC822Name`, `IssuerAndSubject`, `Subject`, `SKI`, `SHA1PublicKey`, and `IssuerAndSerialNumber`.
+The meaning of each value is describe in the official documentation of [certificateUserIds](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-certificate-based-authentication-certificateuserids). 
+
+```yaml
+Type: System.String
+Parameter Sets: {PrincipalName | RFC822Name | IssuerAndSubject | Subject | SKI | SHA1PublicKey | IssuerAndSerialNumber}
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://aka.ms/aadcba](https://aka.ms/aadcba)
+[certificateUserIds](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-certificate-based-authentication-certificateuserids)
+

--- a/src/EntraModuleBuilder.ps1
+++ b/src/EntraModuleBuilder.ps1
@@ -76,7 +76,11 @@ Set-StrictMode -Version 5
     Log-Message "[EntraModuleBuilder] Creating .psm1 file: $psm1FilePath"
 
     $psm1Content = $this.headerText + "`n"  # Add a newline after the header
-    $ps1Files = Get-ChildItem -Path $currentDirPath -Filter "*.ps1"
+
+    # Get-ChildItem returns different types depending on the number of items it finds.
+    # When there is only one item, it returns a single object rather than an array
+    # Using @() we force the result to be treated as an array, even if there is only one item.
+    $ps1Files = @(Get-ChildItem -Path $currentDirPath -Filter "*.ps1")
 
     if ($ps1Files.Count -eq 0) {
         Log-Message "[EntraModuleBuilder] Warning: No .ps1 files found in directory $currentDirPath" -Level 'ERROR'

--- a/test/Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1
+++ b/test/Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1
@@ -1,0 +1,10 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {  
+    if ((Get-Module -Name Microsoft.Entra.Utilities) -eq $null) {
+        Import-Module Microsoft.Entra.Utilities      
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+}

--- a/test/Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1
+++ b/test/Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1
@@ -8,3 +8,27 @@ BeforeAll {
     }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 }
+
+Describe "Get-EntraUserCertificateUserIdsFromCertificate" {
+    Context "Test for Get-EntraUserCertificateUserIdsFromCertificate" {
+        $base64cert = "MIIC3jCCAcagAwIBAgIQHoyXQUS/hpZEI/pkZAgtijANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDDAdDb250b3NvMB4XDTI1MDMyNTE1NDU1OFoXDTI2MDMyNTE2MDQzNlowcjETMBEGCgmSJomT8ixkARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2NvbnRvc28xFDASBgoJkiaJk/IsZAEZFgRjb3JwMRUwEwYDVQQLDAxVc2VyQWNjb3VudHMxFTATBgNVBAMMDENvbnRvc28gVXNlcjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDbRNBDrUoZ9JjsBkroyjzTe+Zag7TMU4WZFyvqtgctn6dQ/+zuk/hOg2xwU0JmooRDhwG+SS3dGGE1a1Uh9I4OjgZowgZcwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMCMDAGA1UdEQQpMCegJQYKKwYBBAGCNxQCA6AXDBVjb250b3NvQG1pY3Jvc29mdC5jb20wHwYDVR0jBBgwFoAUrY5aFcJq36PMV50MNR4KIFfTSscwHQYDVR0OBBYEFMb06Wyq2EZANh+ftfdPYwgkfLi0MA0GCSqGSIb3DQEBBQUAA4IBAQBQ5ULQEJT0xvGt7b27dQGmYzMzW3V9JCS7qYeAxYefYV1cGuwP3ZHh++sGyah0fIQQCtM+9Fu+VmHdinJ0478cR/oD4luK67FNFJLk0Q3H3RDvesZa/JYQEbdEgRoaMJWCYqrpQNdCwIlBL+8CrHMyXfYxnYuFGJfdl8NmmLXok44Dqo7d9Zw6MFyxMDWx8C6QWJjZcls6UQggoawWKTll2V+tK+l7UwRRcpGmnVmnlyD6Vpo9exi+Axddi3a6WOQ5asn6il0sJVGicyZS658toQw0fj+UvZuD7rtegxuL/s/v3m3Sx1iEcIyB1HsdwZCJ5ZlxvbQvB/Sz5yU7Yo/Y"
+        $certBytes = [Convert]::FromBase64String($base64cert)
+        $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList (,[byte[]]$certBytes)
+
+        It "Should return the certificateUserIDs" {
+            $result = Get-EntraUserCertificateUserIdsFromCertificate -Certificate $certificate
+
+            $result.IssuerAndSerialNumber | Should -Match "X509:<I>CN=Contoso<SR>1e8c974144bf86964423fa6464082d8a"
+            $result.SHA1PublicKey | Should -Match "X509:<SHA1-PUKEY>34BE02DCEE9ECDF8BC5C16595A73F1B201875FEA"
+            $result.IssuerAndSubject | Should -Match "X509:<I>CN=Contoso<S>DC=com,DC=contoso,DC=corp,OU=UserAccounts,CN=Contoso User"
+            $result.SKI | Should -Match "X509:<SKI>C6F4E96CAAD84640361F9FB5F74F6308247CB8B4"
+            $result.PrincipalName | Should -Match "X509:<PN>contoso@microsoft.com"
+            $result.Subject | Should -Match "X509:<S>DC=com,DC=contoso,DC=corp,OU=UserAccounts,CN=Contoso User"
+        }
+
+        It "Should return the IssuerAndSerialNumber mapping when the CertificateMapping IssuerAndSerialNumber is provided" {
+            $result = Get-EntraUserCertificateUserIdsFromCertificate -Certificate $certificate -CertificateMapping IssuerAndSerialNumber
+            $result.IssuerAndSerialNumber | Should -Match "X509:<I>CN=Contoso<SR>1e8c974144bf86964423fa6464082d8a"
+        }
+    }
+}

--- a/test/Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1
+++ b/test/Entra/Utilities/Get-EntraUserCertificateUserIdsFromCertificate.Tests.ps1
@@ -27,6 +27,10 @@ Describe "Get-EntraUserCertificateUserIdsFromCertificate" {
         }
 
         It "Should return the IssuerAndSerialNumber mapping when the CertificateMapping IssuerAndSerialNumber is provided" {
+            $base64cert = "MIIC3jCCAcagAwIBAgIQHoyXQUS/hpZEI/pkZAgtijANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDDAdDb250b3NvMB4XDTI1MDMyNTE1NDU1OFoXDTI2MDMyNTE2MDQzNlowcjETMBEGCgmSJomT8ixkARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2NvbnRvc28xFDASBgoJkiaJk/IsZAEZFgRjb3JwMRUwEwYDVQQLDAxVc2VyQWNjb3VudHMxFTATBgNVBAMMDENvbnRvc28gVXNlcjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDbRNBDrUoZ9JjsBkroyjzTe+Zag7TMU4WZFyvqtgctn6dQ/+zuk/hOg2xwU0JmooRDhwG+SS3dGGE1a1Uh9I4OjgZowgZcwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMCMDAGA1UdEQQpMCegJQYKKwYBBAGCNxQCA6AXDBVjb250b3NvQG1pY3Jvc29mdC5jb20wHwYDVR0jBBgwFoAUrY5aFcJq36PMV50MNR4KIFfTSscwHQYDVR0OBBYEFMb06Wyq2EZANh+ftfdPYwgkfLi0MA0GCSqGSIb3DQEBBQUAA4IBAQBQ5ULQEJT0xvGt7b27dQGmYzMzW3V9JCS7qYeAxYefYV1cGuwP3ZHh++sGyah0fIQQCtM+9Fu+VmHdinJ0478cR/oD4luK67FNFJLk0Q3H3RDvesZa/JYQEbdEgRoaMJWCYqrpQNdCwIlBL+8CrHMyXfYxnYuFGJfdl8NmmLXok44Dqo7d9Zw6MFyxMDWx8C6QWJjZcls6UQggoawWKTll2V+tK+l7UwRRcpGmnVmnlyD6Vpo9exi+Axddi3a6WOQ5asn6il0sJVGicyZS658toQw0fj+UvZuD7rtegxuL/s/v3m3Sx1iEcIyB1HsdwZCJ5ZlxvbQvB/Sz5yU7Yo/Y"
+            $certBytes = [Convert]::FromBase64String($base64cert)
+            $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList (,[byte[]]$certBytes)
+
             $result = Get-EntraUserCertificateUserIdsFromCertificate -Certificate $certificate -CertificateMapping IssuerAndSerialNumber
             $result.IssuerAndSerialNumber | Should -Match "X509:<I>CN=Contoso<SR>1e8c974144bf86964423fa6464082d8a"
         }


### PR DESCRIPTION
### Changes proposed in this pull request

We are introducing a new submodule to generate certificateUserIDs. The primary goal is to help customers automate the process of creating the necessary values for mapping certificates to user accounts. This function simplifies the creation of values from a given certificate that can be mapped to certificateUserIDs.

Microsoft Entra ID has strict formatting requirements for certificateUserIDs, which can often lead to errors when administrators attempt to do this manually. By following Entra ID's logic, this module ensures that the generated certificateUserIDs are accurate, giving customers greater confidence in validating their correctness.


Examples of the usage of the module 
```powershell
Get-EntraUserCertificateUserIdsFromCertificate C:\path\to\certificate.cer
```
Output
```Output
Name                           Value
----                           -----
Subject                        X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
IssuerAndSerialNumber          X509:<I>DC=com,DC=contoso,CN=CONTOSO-DC-CA<SR>eF3gH4iJ5kL6mN7oP8qR9sT0uV
RFC822Name                     X509:<RFC822>user@woodgrove.com
SHA1PublicKey                  X509:<SHA1-PUKEY>cD2eF3gH4iJ5kL6mN7oP8qR9sT
IssuerAndSubject               X509:<I>DC=com,DC=contoso,CN=CONTOSO-DC-CA<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
SKI                            X509:<SKI>aB1cD2eF3gH4iJ5kL6mN7oP8qR
PrincipalName                  X509:<PN>bob@woodgrove.com
```
Output
```powershell
 Get-MsIdCBACertificateUserIdFromCertificate C:\path\to\certificate.cer -CertificateMapping Subject
```
```Output
X509:<S>DC=com,DC=contoso,OU=UserAccounts,CN=mfatest
```


### Other links
https://learn.microsoft.com/en-us/entra/identity/authentication/concept-certificate-based-authentication-certificateuserids