### PR TITLE
[POC] Testing powershell formatting - Work in Progress

### DIFF
--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUser.ps1
@@ -135,6 +135,7 @@ ErrorCode: Request_ResourceNotFound"
                 $propertyValue = $_.Value
                 $userType | Add-Member -MemberType NoteProperty -Name $propertyName -Value $propertyValue -Force
             }
+            $userType.PSTypeNames.Insert(0, "EntraBeta.Users")
             $userList += $userType
         }
         $userList 

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserSponsor.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserSponsor.ps1
@@ -94,6 +94,7 @@ function Get-EntraBetaUserSponsor {
                     $propertyValue = $_.Value
                     $memberType | Add-Member -MemberType NoteProperty -Name $propertyName -Value $propertyValue -Force
                 }
+                $memberType.PSTypeNames.Insert(0, "EntraBeta.Users")
                 $memberList += $memberType
             }
             return $memberList

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Users.format.ps1xml
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Users.format.ps1xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>EntraBetaUsersTableViewTemplate</Name>
+      <ViewSelectedBy>
+        <TypeName>EntraBeta.Users</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize/>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Display Name</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Id</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Description</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>displayName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>id</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>description</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>


### PR DESCRIPTION
Description
This is a small POC PR which introduces using .psmx1 formating file to improve console display for our commands. It defines a table view by default, that shows the most common user properties (Display Name, ID, and Description) when working with User objects returned by "Microsoft.EntraBeta.Users" commands.

Changes

Added Users.format.ps1xml with table view definition
Modified relevant functions to apply custom type name to returned objects

Testing

Verified format is applied correctly to objects from Get-EntraBetaUser, Get-EntraBetaUserSponsor command
Tested in PowerShell 5.1 and PowerShell 7.3
Confirmed format works in both console and ISE

Implementation Details
The format file uses a custom type name approach with:

EntraBeta.Users type applied to user objects

Formatting Strategy Approach.

Group related Objects with similar properties.

For example, under the ‘Microsoft.Entra.Beta.Users’ module, different commands such as Get-EntraBetaUser, Get-EntraBetaUserSponsor, Get-EntraBetaDeletedUser return different objects which share similar properties like Id, Name, Description. We can group these related objects by inserting a similar custom type name to each of the command response, For example:

$object.PSTypeNames.Insert(0, "EntraBeta.UserSponsor.Users")

This technique allows us to create a custom format file which targets functions which return different response objects but still share similar properties.
