### PR TITLE
Fix: Replace en dash with hyphen in Group functions

### DIFF
--- a/module/Entra/Microsoft.Entra/Groups/New-EntraGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/New-EntraGroup.ps1
@@ -1,41 +1,41 @@
-# ------------------------------------------------------------------------------ 
-#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
-#  Licensed under the MIT License.  See License in the project root for license information. 
-# ------------------------------------------------------------------------------ 
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
 function New-EntraGroup {
     [CmdletBinding(DefaultParameterSetName = 'ByGroupIdentityParameters')]
-    param (                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "Specifies whether the group is a security group.")]
+    param (
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'Specifies whether the group is a security group.')]
         [Alias('SecurityEnabledGroup')]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Nullable`1[System.Boolean]] $SecurityEnabled,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "Specifies whether the group is mail-enabled.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'Specifies whether the group is mail-enabled.')]
         [Alias('MailEnabledGroup')]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $MailEnabled,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Description of the group.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Description of the group.')]
         [System.String] $Description,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Specifies the group type and its membership.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Specifies the group type and its membership.')]
         [Alias('GroupType')]
         [System.Collections.Generic.List`1[System.String]] $GroupTypes,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "A unique mail alias for the group (max 64 characters). It must use ASCII characters (0–127).")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'A unique mail alias for the group (max 64 characters). It must use ASCII characters (0-127).')]
         [ValidateNotNullOrEmpty()]
         [System.String] $MailNickname,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Indicates whether this group can be assigned to a Microsoft Entra role.")]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Indicates whether this group can be assigned to a Microsoft Entra role.')]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $IsAssignableToRole,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Sets the group join policy and content visibility. Options are: Private, Public, or HiddenMembership.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Sets the group join policy and content visibility. Options are: Private, Public, or HiddenMembership.')]
         [System.String] $Visibility,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "Display name of the group.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'Display name of the group.')]
         [ValidateNotNullOrEmpty()]
         [ValidateLength(1, 256)]
         [System.String] $DisplayName
@@ -50,75 +50,75 @@ function New-EntraGroup {
         }
     }
 
-    PROCESS {    
+    PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
-    
-        if ($null -ne $PSBoundParameters["OutVariable"]) {
-            $params["OutVariable"] = $PSBoundParameters["OutVariable"]
+
+        if ($null -ne $PSBoundParameters['OutVariable']) {
+            $params['OutVariable'] = $PSBoundParameters['OutVariable']
         }
-        if ($null -ne $PSBoundParameters["SecurityEnabled"]) {
-            $params["SecurityEnabled"] = $PSBoundParameters["SecurityEnabled"]
+        if ($null -ne $PSBoundParameters['SecurityEnabled']) {
+            $params['SecurityEnabled'] = $PSBoundParameters['SecurityEnabled']
         }
-        if ($null -ne $PSBoundParameters["MailEnabled"]) {
-            $params["MailEnabled"] = $PSBoundParameters["MailEnabled"]
+        if ($null -ne $PSBoundParameters['MailEnabled']) {
+            $params['MailEnabled'] = $PSBoundParameters['MailEnabled']
         }
-        if ($null -ne $PSBoundParameters["Description"]) {
-            $params["Description"] = $PSBoundParameters["Description"]
+        if ($null -ne $PSBoundParameters['Description']) {
+            $params['Description'] = $PSBoundParameters['Description']
         }
-        if ($PSBoundParameters.ContainsKey("Debug")) {
-            $params["Debug"] = $PSBoundParameters["Debug"]
+        if ($PSBoundParameters.ContainsKey('Debug')) {
+            $params['Debug'] = $PSBoundParameters['Debug']
         }
-        if ($null -ne $PSBoundParameters["PipelineVariable"]) {
-            $params["PipelineVariable"] = $PSBoundParameters["PipelineVariable"]
+        if ($null -ne $PSBoundParameters['PipelineVariable']) {
+            $params['PipelineVariable'] = $PSBoundParameters['PipelineVariable']
         }
-        if ($null -ne $PSBoundParameters["InformationVariable"]) {
-            $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
+        if ($null -ne $PSBoundParameters['InformationVariable']) {
+            $params['InformationVariable'] = $PSBoundParameters['InformationVariable']
         }
-        if ($null -ne $PSBoundParameters["GroupTypes"]) {
-            $params["GroupTypes"] = $PSBoundParameters["GroupTypes"]
+        if ($null -ne $PSBoundParameters['GroupTypes']) {
+            $params['GroupTypes'] = $PSBoundParameters['GroupTypes']
         }
-        if ($null -ne $PSBoundParameters["MailNickname"]) {
-            $params["MailNickname"] = $PSBoundParameters["MailNickname"]
+        if ($null -ne $PSBoundParameters['MailNickname']) {
+            $params['MailNickname'] = $PSBoundParameters['MailNickname']
         }
-        if ($null -ne $PSBoundParameters["OutBuffer"]) {
-            $params["OutBuffer"] = $PSBoundParameters["OutBuffer"]
+        if ($null -ne $PSBoundParameters['OutBuffer']) {
+            $params['OutBuffer'] = $PSBoundParameters['OutBuffer']
         }
-        if ($null -ne $PSBoundParameters["WarningVariable"]) {
-            $params["WarningVariable"] = $PSBoundParameters["WarningVariable"]
+        if ($null -ne $PSBoundParameters['WarningVariable']) {
+            $params['WarningVariable'] = $PSBoundParameters['WarningVariable']
         }
-        if ($PSBoundParameters.ContainsKey("Verbose")) {
-            $params["Verbose"] = $PSBoundParameters["Verbose"]
+        if ($PSBoundParameters.ContainsKey('Verbose')) {
+            $params['Verbose'] = $PSBoundParameters['Verbose']
         }
-        if ($null -ne $PSBoundParameters["IsAssignableToRole"]) {
-            $params["IsAssignableToRole"] = $PSBoundParameters["IsAssignableToRole"]
+        if ($null -ne $PSBoundParameters['IsAssignableToRole']) {
+            $params['IsAssignableToRole'] = $PSBoundParameters['IsAssignableToRole']
         }
-        if ($null -ne $PSBoundParameters["ErrorVariable"]) {
-            $params["ErrorVariable"] = $PSBoundParameters["ErrorVariable"]
+        if ($null -ne $PSBoundParameters['ErrorVariable']) {
+            $params['ErrorVariable'] = $PSBoundParameters['ErrorVariable']
         }
-        if ($null -ne $PSBoundParameters["ErrorAction"]) {
-            $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
+        if ($null -ne $PSBoundParameters['ErrorAction']) {
+            $params['ErrorAction'] = $PSBoundParameters['ErrorAction']
         }
-        if ($null -ne $PSBoundParameters["Visibility"]) {
-            $params["Visibility"] = $PSBoundParameters["Visibility"]
+        if ($null -ne $PSBoundParameters['Visibility']) {
+            $params['Visibility'] = $PSBoundParameters['Visibility']
         }
-        if ($null -ne $PSBoundParameters["InformationAction"]) {
-            $params["InformationAction"] = $PSBoundParameters["InformationAction"]
+        if ($null -ne $PSBoundParameters['InformationAction']) {
+            $params['InformationAction'] = $PSBoundParameters['InformationAction']
         }
-        if ($null -ne $PSBoundParameters["WarningAction"]) {
-            $params["WarningAction"] = $PSBoundParameters["WarningAction"]
+        if ($null -ne $PSBoundParameters['WarningAction']) {
+            $params['WarningAction'] = $PSBoundParameters['WarningAction']
         }
-        if ($null -ne $PSBoundParameters["ProgressAction"]) {
-            $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
+        if ($null -ne $PSBoundParameters['ProgressAction']) {
+            $params['ProgressAction'] = $PSBoundParameters['ProgressAction']
         }
-        if ($null -ne $PSBoundParameters["DisplayName"]) {
-            $params["DisplayName"] = $PSBoundParameters["DisplayName"]
+        if ($null -ne $PSBoundParameters['DisplayName']) {
+            $params['DisplayName'] = $PSBoundParameters['DisplayName']
         }
 
-        Write-Debug("============================ TRANSFORMATIONS ============================")
+        Write-Debug('============================ TRANSFORMATIONS ============================')
         $params.Keys | ForEach-Object { "$_ : $($params[$_])" } | Write-Debug
         Write-Debug("=========================================================================`n")
-    
+
         $response = New-MgGroup @params -Headers $customHeaders
         $response | ForEach-Object {
             if ($null -ne $_) {
@@ -129,4 +129,3 @@ function New-EntraGroup {
         $response
     }
 }
-

--- a/module/Entra/Microsoft.Entra/Groups/Set-EntraGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/Set-EntraGroup.ps1
@@ -1,43 +1,43 @@
-# ------------------------------------------------------------------------------ 
-#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
-#  Licensed under the MIT License.  See License in the project root for license information. 
-# ------------------------------------------------------------------------------ 
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
 function Set-EntraGroup {
     [CmdletBinding(DefaultParameterSetName = 'UpdateGroupByGroupId')]
-    param (                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Specifies whether the group is a security group.")]
+    param (
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Specifies whether the group is a security group.')]
         [Alias('SecurityEnabledGroup')]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $SecurityEnabled,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Specifies whether the group is mail-enabled.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Specifies whether the group is mail-enabled.')]
         [Alias('MailEnabledGroup')]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $MailEnabled,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Description of the group.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Description of the group.')]
         [System.String] $Description,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Specifies the group type and its membership.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Specifies the group type and its membership.')]
         [System.Collections.Generic.List`1[System.String]] $GroupTypes,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "A unique mail alias for the group (max 64 characters). It must use ASCII characters (0–127).")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'A unique mail alias for the group (max 64 characters). It must use ASCII characters (0-127).')]
         [System.String] $MailNickname,
 
-        [Alias('Id')]            
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Unique ID of the group. Should be a valid GUID value.")]
+        [Alias('Id')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = 'Unique ID of the group. Should be a valid GUID value.')]
         [ValidateNotNullOrEmpty()]
         [Guid] $GroupId,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Indicates whether this group can be assigned to a Microsoft Entra role.")]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Indicates whether this group can be assigned to a Microsoft Entra role.')]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $IsAssignableToRole,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Indicates whether this group can be assigned to a Microsoft Entra role.")]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Indicates whether this group can be assigned to a Microsoft Entra role.')]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.String] $Visibility,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Display name of the group.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Display name of the group.')]
         [ValidateLength(1, 256)]
         [System.String] $DisplayName
     )
@@ -51,78 +51,78 @@ function Set-EntraGroup {
         }
     }
 
-    PROCESS {    
+    PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
-    
-        if ($null -ne $PSBoundParameters["OutVariable"]) {
-            $params["OutVariable"] = $PSBoundParameters["OutVariable"]
+
+        if ($null -ne $PSBoundParameters['OutVariable']) {
+            $params['OutVariable'] = $PSBoundParameters['OutVariable']
         }
-        if ($null -ne $PSBoundParameters["SecurityEnabled"]) {
-            $params["SecurityEnabled"] = $PSBoundParameters["SecurityEnabled"]
+        if ($null -ne $PSBoundParameters['SecurityEnabled']) {
+            $params['SecurityEnabled'] = $PSBoundParameters['SecurityEnabled']
         }
-        if ($null -ne $PSBoundParameters["MailEnabled"]) {
-            $params["MailEnabled"] = $PSBoundParameters["MailEnabled"]
+        if ($null -ne $PSBoundParameters['MailEnabled']) {
+            $params['MailEnabled'] = $PSBoundParameters['MailEnabled']
         }
-        if ($null -ne $PSBoundParameters["Description"]) {
-            $params["Description"] = $PSBoundParameters["Description"]
+        if ($null -ne $PSBoundParameters['Description']) {
+            $params['Description'] = $PSBoundParameters['Description']
         }
-        if ($PSBoundParameters.ContainsKey("Debug")) {
-            $params["Debug"] = $PSBoundParameters["Debug"]
+        if ($PSBoundParameters.ContainsKey('Debug')) {
+            $params['Debug'] = $PSBoundParameters['Debug']
         }
-        if ($null -ne $PSBoundParameters["PipelineVariable"]) {
-            $params["PipelineVariable"] = $PSBoundParameters["PipelineVariable"]
+        if ($null -ne $PSBoundParameters['PipelineVariable']) {
+            $params['PipelineVariable'] = $PSBoundParameters['PipelineVariable']
         }
-        if ($null -ne $PSBoundParameters["InformationVariable"]) {
-            $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
+        if ($null -ne $PSBoundParameters['InformationVariable']) {
+            $params['InformationVariable'] = $PSBoundParameters['InformationVariable']
         }
-        if ($null -ne $PSBoundParameters["GroupTypes"]) {
-            $params["GroupTypes"] = $PSBoundParameters["GroupTypes"]
+        if ($null -ne $PSBoundParameters['GroupTypes']) {
+            $params['GroupTypes'] = $PSBoundParameters['GroupTypes']
         }
-        if ($null -ne $PSBoundParameters["MailNickname"]) {
-            $params["MailNickname"] = $PSBoundParameters["MailNickname"]
+        if ($null -ne $PSBoundParameters['MailNickname']) {
+            $params['MailNickname'] = $PSBoundParameters['MailNickname']
         }
-        if ($null -ne $PSBoundParameters["OutBuffer"]) {
-            $params["OutBuffer"] = $PSBoundParameters["OutBuffer"]
+        if ($null -ne $PSBoundParameters['OutBuffer']) {
+            $params['OutBuffer'] = $PSBoundParameters['OutBuffer']
         }
-        if ($null -ne $PSBoundParameters["WarningVariable"]) {
-            $params["WarningVariable"] = $PSBoundParameters["WarningVariable"]
+        if ($null -ne $PSBoundParameters['WarningVariable']) {
+            $params['WarningVariable'] = $PSBoundParameters['WarningVariable']
         }
-        if ($PSBoundParameters.ContainsKey("Verbose")) {
-            $params["Verbose"] = $PSBoundParameters["Verbose"]
+        if ($PSBoundParameters.ContainsKey('Verbose')) {
+            $params['Verbose'] = $PSBoundParameters['Verbose']
         }
-        if ($null -ne $PSBoundParameters["GroupId"]) {
-            $params["GroupId"] = $PSBoundParameters["GroupId"]
+        if ($null -ne $PSBoundParameters['GroupId']) {
+            $params['GroupId'] = $PSBoundParameters['GroupId']
         }
-        if ($null -ne $PSBoundParameters["IsAssignableToRole"]) {
-            $params["IsAssignableToRole"] = $PSBoundParameters["IsAssignableToRole"]
+        if ($null -ne $PSBoundParameters['IsAssignableToRole']) {
+            $params['IsAssignableToRole'] = $PSBoundParameters['IsAssignableToRole']
         }
-        if ($null -ne $PSBoundParameters["ErrorVariable"]) {
-            $params["ErrorVariable"] = $PSBoundParameters["ErrorVariable"]
+        if ($null -ne $PSBoundParameters['ErrorVariable']) {
+            $params['ErrorVariable'] = $PSBoundParameters['ErrorVariable']
         }
-        if ($null -ne $PSBoundParameters["ErrorAction"]) {
-            $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
+        if ($null -ne $PSBoundParameters['ErrorAction']) {
+            $params['ErrorAction'] = $PSBoundParameters['ErrorAction']
         }
-        if ($null -ne $PSBoundParameters["Visibility"]) {
-            $params["Visibility"] = $PSBoundParameters["Visibility"]
+        if ($null -ne $PSBoundParameters['Visibility']) {
+            $params['Visibility'] = $PSBoundParameters['Visibility']
         }
-        if ($null -ne $PSBoundParameters["InformationAction"]) {
-            $params["InformationAction"] = $PSBoundParameters["InformationAction"]
+        if ($null -ne $PSBoundParameters['InformationAction']) {
+            $params['InformationAction'] = $PSBoundParameters['InformationAction']
         }
-        if ($null -ne $PSBoundParameters["WarningAction"]) {
-            $params["WarningAction"] = $PSBoundParameters["WarningAction"]
+        if ($null -ne $PSBoundParameters['WarningAction']) {
+            $params['WarningAction'] = $PSBoundParameters['WarningAction']
         }
-        if ($null -ne $PSBoundParameters["ProgressAction"]) {
-            $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
+        if ($null -ne $PSBoundParameters['ProgressAction']) {
+            $params['ProgressAction'] = $PSBoundParameters['ProgressAction']
         }
-        if ($null -ne $PSBoundParameters["DisplayName"]) {
-            $params["DisplayName"] = $PSBoundParameters["DisplayName"]
+        if ($null -ne $PSBoundParameters['DisplayName']) {
+            $params['DisplayName'] = $PSBoundParameters['DisplayName']
         }
 
-        Write-Debug("============================ TRANSFORMATIONS ============================")
+        Write-Debug('============================ TRANSFORMATIONS ============================')
         $params.Keys | ForEach-Object { "$_ : $($params[$_])" } | Write-Debug
         Write-Debug("=========================================================================`n")
-    
+
         $response = Update-MgGroup @params -Headers $customHeaders
         $response | ForEach-Object {
             if ($null -ne $_) {
@@ -133,4 +133,3 @@ function Set-EntraGroup {
         $response
     }
 }
-

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/New-EntraBetaGroup.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/New-EntraBetaGroup.ps1
@@ -1,48 +1,48 @@
-# ------------------------------------------------------------------------------ 
-#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
-#  Licensed under the MIT License.  See License in the project root for license information. 
-# ------------------------------------------------------------------------------ 
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
 function New-EntraBetaGroup {
     [CmdletBinding(DefaultParameterSetName = 'ByGroupIdentityParameters')]
-    param (                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Specifies the group type and its membership.")]
+    param (
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Specifies the group type and its membership.')]
         [System.Collections.Generic.List`1[System.String]] $GroupTypes,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Sets the group join policy and content visibility. Options are: Private, Public, or HiddenMembership.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Sets the group join policy and content visibility. Options are: Private, Public, or HiddenMembership.')]
         [System.String] $Visibility,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Description of the group.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Description of the group.')]
         [System.String] $Description,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Indicates whether this group can be assigned to a Microsoft Entra role.")]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Indicates whether this group can be assigned to a Microsoft Entra role.')]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $IsAssignableToRole,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "Display name of the group.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'Display name of the group.')]
         [ValidateNotNullOrEmpty()]
         [ValidateLength(1, 256)]
         [System.String] $DisplayName,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "The rule that determines members for this group if the group is a dynamic group (groupTypes contains DynamicMembership).")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'The rule that determines members for this group if the group is a dynamic group (groupTypes contains DynamicMembership).')]
         [System.String] $MembershipRule,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "Specifies whether the group is mail-enabled.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'Specifies whether the group is mail-enabled.')]
         [Alias('MailEnabledGroup')]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $MailEnabled,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "Specifies whether the group is a security group.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'Specifies whether the group is a security group.')]
         [Alias('SecurityEnabledGroup')]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Nullable`1[System.Boolean]] $SecurityEnabled,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", Mandatory = $true, HelpMessage = "A unique mail alias for the group (max 64 characters). It must use ASCII characters (0–127).")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', Mandatory = $true, HelpMessage = 'A unique mail alias for the group (max 64 characters). It must use ASCII characters (0-127).')]
         [ValidateNotNullOrEmpty()]
         [System.String] $MailNickname,
-                
-        [Parameter(ParameterSetName = "ByGroupIdentityParameters", HelpMessage = "Shows if dynamic membership processing is active or paused. Values: On or Paused.")]
+
+        [Parameter(ParameterSetName = 'ByGroupIdentityParameters', HelpMessage = 'Shows if dynamic membership processing is active or paused. Values: On or Paused.')]
         [System.String] $MembershipRuleProcessingState
     )
 
@@ -55,81 +55,81 @@ function New-EntraBetaGroup {
         }
     }
 
-    PROCESS {    
+    PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
-    
-        if ($null -ne $PSBoundParameters["GroupTypes"]) {
-            $params["GroupTypes"] = $PSBoundParameters["GroupTypes"]
+
+        if ($null -ne $PSBoundParameters['GroupTypes']) {
+            $params['GroupTypes'] = $PSBoundParameters['GroupTypes']
         }
-        if ($null -ne $PSBoundParameters["ProgressAction"]) {
-            $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
+        if ($null -ne $PSBoundParameters['ProgressAction']) {
+            $params['ProgressAction'] = $PSBoundParameters['ProgressAction']
         }
-        if ($null -ne $PSBoundParameters["Visibility"]) {
-            $params["Visibility"] = $PSBoundParameters["Visibility"]
+        if ($null -ne $PSBoundParameters['Visibility']) {
+            $params['Visibility'] = $PSBoundParameters['Visibility']
         }
-        if ($PSBoundParameters.ContainsKey("Debug")) {
-            $params["Debug"] = $PSBoundParameters["Debug"]
+        if ($PSBoundParameters.ContainsKey('Debug')) {
+            $params['Debug'] = $PSBoundParameters['Debug']
         }
-        if ($null -ne $PSBoundParameters["OutBuffer"]) {
-            $params["OutBuffer"] = $PSBoundParameters["OutBuffer"]
+        if ($null -ne $PSBoundParameters['OutBuffer']) {
+            $params['OutBuffer'] = $PSBoundParameters['OutBuffer']
         }
-        if ($null -ne $PSBoundParameters["ErrorAction"]) {
-            $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
+        if ($null -ne $PSBoundParameters['ErrorAction']) {
+            $params['ErrorAction'] = $PSBoundParameters['ErrorAction']
         }
-        if ($null -ne $PSBoundParameters["WarningVariable"]) {
-            $params["WarningVariable"] = $PSBoundParameters["WarningVariable"]
+        if ($null -ne $PSBoundParameters['WarningVariable']) {
+            $params['WarningVariable'] = $PSBoundParameters['WarningVariable']
         }
-        if ($null -ne $PSBoundParameters["WarningAction"]) {
-            $params["WarningAction"] = $PSBoundParameters["WarningAction"]
+        if ($null -ne $PSBoundParameters['WarningAction']) {
+            $params['WarningAction'] = $PSBoundParameters['WarningAction']
         }
-        if ($null -ne $PSBoundParameters["Description"]) {
-            $params["Description"] = $PSBoundParameters["Description"]
+        if ($null -ne $PSBoundParameters['Description']) {
+            $params['Description'] = $PSBoundParameters['Description']
         }
-        if ($null -ne $PSBoundParameters["IsAssignableToRole"]) {
-            $params["IsAssignableToRole"] = $PSBoundParameters["IsAssignableToRole"]
+        if ($null -ne $PSBoundParameters['IsAssignableToRole']) {
+            $params['IsAssignableToRole'] = $PSBoundParameters['IsAssignableToRole']
         }
-        if ($null -ne $PSBoundParameters["DisplayName"]) {
-            $params["DisplayName"] = $PSBoundParameters["DisplayName"]
+        if ($null -ne $PSBoundParameters['DisplayName']) {
+            $params['DisplayName'] = $PSBoundParameters['DisplayName']
         }
-        if ($null -ne $PSBoundParameters["OutVariable"]) {
-            $params["OutVariable"] = $PSBoundParameters["OutVariable"]
+        if ($null -ne $PSBoundParameters['OutVariable']) {
+            $params['OutVariable'] = $PSBoundParameters['OutVariable']
         }
-        if ($null -ne $PSBoundParameters["MembershipRule"]) {
-            $params["MembershipRule"] = $PSBoundParameters["MembershipRule"]
+        if ($null -ne $PSBoundParameters['MembershipRule']) {
+            $params['MembershipRule'] = $PSBoundParameters['MembershipRule']
         }
-        if ($PSBoundParameters.ContainsKey("Verbose")) {
-            $params["Verbose"] = $PSBoundParameters["Verbose"]
+        if ($PSBoundParameters.ContainsKey('Verbose')) {
+            $params['Verbose'] = $PSBoundParameters['Verbose']
         }
-        if ($null -ne $PSBoundParameters["MailEnabled"]) {
-            $params["MailEnabled"] = $PSBoundParameters["MailEnabled"]
+        if ($null -ne $PSBoundParameters['MailEnabled']) {
+            $params['MailEnabled'] = $PSBoundParameters['MailEnabled']
         }
-        if ($null -ne $PSBoundParameters["SecurityEnabled"]) {
-            $params["SecurityEnabled"] = $PSBoundParameters["SecurityEnabled"]
+        if ($null -ne $PSBoundParameters['SecurityEnabled']) {
+            $params['SecurityEnabled'] = $PSBoundParameters['SecurityEnabled']
         }
-        if ($null -ne $PSBoundParameters["MailNickname"]) {
-            $params["MailNickname"] = $PSBoundParameters["MailNickname"]
+        if ($null -ne $PSBoundParameters['MailNickname']) {
+            $params['MailNickname'] = $PSBoundParameters['MailNickname']
         }
-        if ($null -ne $PSBoundParameters["PipelineVariable"]) {
-            $params["PipelineVariable"] = $PSBoundParameters["PipelineVariable"]
+        if ($null -ne $PSBoundParameters['PipelineVariable']) {
+            $params['PipelineVariable'] = $PSBoundParameters['PipelineVariable']
         }
-        if ($null -ne $PSBoundParameters["InformationVariable"]) {
-            $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
+        if ($null -ne $PSBoundParameters['InformationVariable']) {
+            $params['InformationVariable'] = $PSBoundParameters['InformationVariable']
         }
-        if ($null -ne $PSBoundParameters["InformationAction"]) {
-            $params["InformationAction"] = $PSBoundParameters["InformationAction"]
+        if ($null -ne $PSBoundParameters['InformationAction']) {
+            $params['InformationAction'] = $PSBoundParameters['InformationAction']
         }
-        if ($null -ne $PSBoundParameters["ErrorVariable"]) {
-            $params["ErrorVariable"] = $PSBoundParameters["ErrorVariable"]
+        if ($null -ne $PSBoundParameters['ErrorVariable']) {
+            $params['ErrorVariable'] = $PSBoundParameters['ErrorVariable']
         }
-        if ($null -ne $PSBoundParameters["MembershipRuleProcessingState"]) {
-            $params["MembershipRuleProcessingState"] = $PSBoundParameters["MembershipRuleProcessingState"]
+        if ($null -ne $PSBoundParameters['MembershipRuleProcessingState']) {
+            $params['MembershipRuleProcessingState'] = $PSBoundParameters['MembershipRuleProcessingState']
         }
 
-        Write-Debug("============================ TRANSFORMATIONS ============================")
+        Write-Debug('============================ TRANSFORMATIONS ============================')
         $params.Keys | ForEach-Object { "$_ : $($params[$_])" } | Write-Debug
         Write-Debug("=========================================================================`n")
-    
+
         $response = New-MgBetaGroup @params -Headers $customHeaders
         $response | ForEach-Object {
             if ($null -ne $_) {
@@ -140,4 +140,3 @@ function New-EntraBetaGroup {
         $response
     }
 }
-

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/Set-EntraBetaGroup.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/Set-EntraBetaGroup.ps1
@@ -1,50 +1,50 @@
-# ------------------------------------------------------------------------------ 
-#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  
-#  Licensed under the MIT License.  See License in the project root for license information. 
-# ------------------------------------------------------------------------------ 
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
 function Set-EntraBetaGroup {
     [CmdletBinding(DefaultParameterSetName = 'UpdateGroupByGroupId')]
-    param (                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Specifies the group type and its membership.")]
+    param (
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Specifies the group type and its membership.')]
         [System.Collections.Generic.List`1[System.String]] $GroupTypes,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Indicates whether this group can be assigned to a Microsoft Entra role.")]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Indicates whether this group can be assigned to a Microsoft Entra role.')]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.String] $Visibility,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Description of the group.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Description of the group.')]
         [System.String] $Description,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Indicates whether this group can be assigned to a Microsoft Entra role.")]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Indicates whether this group can be assigned to a Microsoft Entra role.')]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $IsAssignableToRole,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Display name of the group.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Display name of the group.')]
         [ValidateLength(1, 256)]
         [System.String] $DisplayName,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "The rule that determines members for this group if the group is a dynamic group (groupTypes contains DynamicMembership).")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'The rule that determines members for this group if the group is a dynamic group (groupTypes contains DynamicMembership).')]
         [System.String] $MembershipRule,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Specifies whether the group is mail-enabled.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Specifies whether the group is mail-enabled.')]
         [Alias('MailEnabledGroup')]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $MailEnabled,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Specifies whether the group is a security group.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Specifies whether the group is a security group.')]
         [Alias('SecurityEnabledGroup')]
-        [ValidateSet("true", "false", IgnoreCase = $true)]
+        [ValidateSet('true', 'false', IgnoreCase = $true)]
         [System.Nullable`1[System.Boolean]] $SecurityEnabled,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "A unique mail alias for the group (max 64 characters). It must use ASCII characters (0–127).")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'A unique mail alias for the group (max 64 characters). It must use ASCII characters (0-127).')]
         [System.String] $MailNickname,
 
-        [Alias('Id')]            
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Unique ID of the group. Should be a valid GUID value.")]
+        [Alias('Id')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = 'Unique ID of the group. Should be a valid GUID value.')]
         [ValidateNotNullOrEmpty()]
         [Guid] $GroupId,
-                
-        [Parameter(ParameterSetName = "UpdateGroupByGroupId", HelpMessage = "Shows if dynamic membership processing is active or paused. Values: On or Paused.")]
+
+        [Parameter(ParameterSetName = 'UpdateGroupByGroupId', HelpMessage = 'Shows if dynamic membership processing is active or paused. Values: On or Paused.')]
         [System.String] $MembershipRuleProcessingState
     )
 
@@ -57,84 +57,84 @@ function Set-EntraBetaGroup {
         }
     }
 
-    PROCESS {    
+    PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
-    
-        if ($null -ne $PSBoundParameters["GroupTypes"]) {
-            $params["GroupTypes"] = $PSBoundParameters["GroupTypes"]
+
+        if ($null -ne $PSBoundParameters['GroupTypes']) {
+            $params['GroupTypes'] = $PSBoundParameters['GroupTypes']
         }
-        if ($null -ne $PSBoundParameters["ProgressAction"]) {
-            $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
+        if ($null -ne $PSBoundParameters['ProgressAction']) {
+            $params['ProgressAction'] = $PSBoundParameters['ProgressAction']
         }
-        if ($null -ne $PSBoundParameters["Visibility"]) {
-            $params["Visibility"] = $PSBoundParameters["Visibility"]
+        if ($null -ne $PSBoundParameters['Visibility']) {
+            $params['Visibility'] = $PSBoundParameters['Visibility']
         }
-        if ($PSBoundParameters.ContainsKey("Debug")) {
-            $params["Debug"] = $PSBoundParameters["Debug"]
+        if ($PSBoundParameters.ContainsKey('Debug')) {
+            $params['Debug'] = $PSBoundParameters['Debug']
         }
-        if ($null -ne $PSBoundParameters["OutBuffer"]) {
-            $params["OutBuffer"] = $PSBoundParameters["OutBuffer"]
+        if ($null -ne $PSBoundParameters['OutBuffer']) {
+            $params['OutBuffer'] = $PSBoundParameters['OutBuffer']
         }
-        if ($null -ne $PSBoundParameters["ErrorAction"]) {
-            $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
+        if ($null -ne $PSBoundParameters['ErrorAction']) {
+            $params['ErrorAction'] = $PSBoundParameters['ErrorAction']
         }
-        if ($null -ne $PSBoundParameters["WarningVariable"]) {
-            $params["WarningVariable"] = $PSBoundParameters["WarningVariable"]
+        if ($null -ne $PSBoundParameters['WarningVariable']) {
+            $params['WarningVariable'] = $PSBoundParameters['WarningVariable']
         }
-        if ($null -ne $PSBoundParameters["WarningAction"]) {
-            $params["WarningAction"] = $PSBoundParameters["WarningAction"]
+        if ($null -ne $PSBoundParameters['WarningAction']) {
+            $params['WarningAction'] = $PSBoundParameters['WarningAction']
         }
-        if ($null -ne $PSBoundParameters["Description"]) {
-            $params["Description"] = $PSBoundParameters["Description"]
+        if ($null -ne $PSBoundParameters['Description']) {
+            $params['Description'] = $PSBoundParameters['Description']
         }
-        if ($null -ne $PSBoundParameters["IsAssignableToRole"]) {
-            $params["IsAssignableToRole"] = $PSBoundParameters["IsAssignableToRole"]
+        if ($null -ne $PSBoundParameters['IsAssignableToRole']) {
+            $params['IsAssignableToRole'] = $PSBoundParameters['IsAssignableToRole']
         }
-        if ($null -ne $PSBoundParameters["DisplayName"]) {
-            $params["DisplayName"] = $PSBoundParameters["DisplayName"]
+        if ($null -ne $PSBoundParameters['DisplayName']) {
+            $params['DisplayName'] = $PSBoundParameters['DisplayName']
         }
-        if ($null -ne $PSBoundParameters["OutVariable"]) {
-            $params["OutVariable"] = $PSBoundParameters["OutVariable"]
+        if ($null -ne $PSBoundParameters['OutVariable']) {
+            $params['OutVariable'] = $PSBoundParameters['OutVariable']
         }
-        if ($null -ne $PSBoundParameters["MembershipRule"]) {
-            $params["MembershipRule"] = $PSBoundParameters["MembershipRule"]
+        if ($null -ne $PSBoundParameters['MembershipRule']) {
+            $params['MembershipRule'] = $PSBoundParameters['MembershipRule']
         }
-        if ($PSBoundParameters.ContainsKey("Verbose")) {
-            $params["Verbose"] = $PSBoundParameters["Verbose"]
+        if ($PSBoundParameters.ContainsKey('Verbose')) {
+            $params['Verbose'] = $PSBoundParameters['Verbose']
         }
-        if ($null -ne $PSBoundParameters["MailEnabled"]) {
-            $params["MailEnabled"] = $PSBoundParameters["MailEnabled"]
+        if ($null -ne $PSBoundParameters['MailEnabled']) {
+            $params['MailEnabled'] = $PSBoundParameters['MailEnabled']
         }
-        if ($null -ne $PSBoundParameters["SecurityEnabled"]) {
-            $params["SecurityEnabled"] = $PSBoundParameters["SecurityEnabled"]
+        if ($null -ne $PSBoundParameters['SecurityEnabled']) {
+            $params['SecurityEnabled'] = $PSBoundParameters['SecurityEnabled']
         }
-        if ($null -ne $PSBoundParameters["MailNickname"]) {
-            $params["MailNickname"] = $PSBoundParameters["MailNickname"]
+        if ($null -ne $PSBoundParameters['MailNickname']) {
+            $params['MailNickname'] = $PSBoundParameters['MailNickname']
         }
-        if ($null -ne $PSBoundParameters["GroupId"]) {
-            $params["GroupId"] = $PSBoundParameters["GroupId"]
+        if ($null -ne $PSBoundParameters['GroupId']) {
+            $params['GroupId'] = $PSBoundParameters['GroupId']
         }
-        if ($null -ne $PSBoundParameters["PipelineVariable"]) {
-            $params["PipelineVariable"] = $PSBoundParameters["PipelineVariable"]
+        if ($null -ne $PSBoundParameters['PipelineVariable']) {
+            $params['PipelineVariable'] = $PSBoundParameters['PipelineVariable']
         }
-        if ($null -ne $PSBoundParameters["InformationVariable"]) {
-            $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
+        if ($null -ne $PSBoundParameters['InformationVariable']) {
+            $params['InformationVariable'] = $PSBoundParameters['InformationVariable']
         }
-        if ($null -ne $PSBoundParameters["InformationAction"]) {
-            $params["InformationAction"] = $PSBoundParameters["InformationAction"]
+        if ($null -ne $PSBoundParameters['InformationAction']) {
+            $params['InformationAction'] = $PSBoundParameters['InformationAction']
         }
-        if ($null -ne $PSBoundParameters["ErrorVariable"]) {
-            $params["ErrorVariable"] = $PSBoundParameters["ErrorVariable"]
+        if ($null -ne $PSBoundParameters['ErrorVariable']) {
+            $params['ErrorVariable'] = $PSBoundParameters['ErrorVariable']
         }
-        if ($null -ne $PSBoundParameters["MembershipRuleProcessingState"]) {
-            $params["MembershipRuleProcessingState"] = $PSBoundParameters["MembershipRuleProcessingState"]
+        if ($null -ne $PSBoundParameters['MembershipRuleProcessingState']) {
+            $params['MembershipRuleProcessingState'] = $PSBoundParameters['MembershipRuleProcessingState']
         }
 
-        Write-Debug("============================ TRANSFORMATIONS ============================")
+        Write-Debug('============================ TRANSFORMATIONS ============================')
         $params.Keys | ForEach-Object { "$_ : $($params[$_])" } | Write-Debug
         Write-Debug("=========================================================================`n")
-    
+
         $response = Update-MgBetaGroup @params -Headers $customHeaders
         $response | ForEach-Object {
             if ($null -ne $_) {
@@ -145,4 +145,3 @@ function Set-EntraBetaGroup {
         $response
     }
 }
-


### PR DESCRIPTION
# Fixed

⚠️ Fixes #1448: Cannot import **Microsoft.Entra.Graph** in Windows PowerShell 5.1 due to en dash being used in parameter HelpMessage text.

This PR replaces the en dashes with a regular hyphen. Successfully tested with a local build in Windows PowerShell 5.1 and PowerShell 7.5.

# Changed

Additional automatic formatting and style updates based on standard conventions. Copilot summary:

- Updated parameter help messages to use single quotes for consistency.
- Changed parameter set names to use single quotes for consistency.
- Improved formatting and alignment of parameter blocks in New-EntraGroup, Set-EntraGroup, New-EntraBetaGroup, and Set-EntraBetaGroup scripts.
- Enhanced readability by standardizing the use of brackets and spacing in conditional statements.
