### PR TITLE
Corrected the Related links heading to sentence case

### DIFF
--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaAdministrativeUnitMember.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaAdministrativeUnitMember](Get-EntraBetaAdministrativeUnitMember.md)
 [Remove-EntraBetaAdministrativeUnitMember](Remove-EntraBetaAdministrativeUnitMember.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaApplicationOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaApplicationOwner.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationOwner](Get-EntraBetaApplicationOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaApplicationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaApplicationPolicy.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationPolicy](Get-EntraBetaApplicationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md
@@ -128,7 +128,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValues` is an alias for `Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue](Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaDeviceRegisteredOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaDeviceRegisteredOwner.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDeviceRegisteredOwner](Get-EntraBetaDeviceRegisteredOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaDeviceRegisteredUser.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaDeviceRegisteredUser.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDeviceRegisteredUser](Get-EntraBetaDeviceRegisteredUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaDirectoryRoleMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaDirectoryRoleMember.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectoryRoleMember](Get-EntraBetaDirectoryRoleMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaFeatureRolloutPolicyDirectoryObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaFeatureRolloutPolicyDirectoryObject.md
@@ -101,6 +101,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaFeatureRolloutPolicyDirectoryObject](Remove-EntraBetaFeatureRolloutPolicyDirectoryObject.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaGroupMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaGroupMember.md
@@ -101,7 +101,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroupMember](Get-EntraBetaGroupMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaGroupOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaGroupOwner.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroupOwner](Get-EntraBetaGroupOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaLifecyclePolicyGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaLifecyclePolicyGroup.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaLifecyclePolicyGroup](Get-EntraBetaLifecyclePolicyGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaScopedRoleMembership.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaScopedRoleMembership.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaScopedRoleMembership](Get-EntraBetaScopedRoleMembership.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaServicePrincipalDelegatedPermissionClassification.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaServicePrincipalDelegatedPermissionClassification.md
@@ -156,7 +156,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaServicePrincipalDelegatedPermissionClassification](Remove-EntraBetaServicePrincipalDelegatedPermissionClassification.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaServicePrincipalOwner.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaServicePrincipalPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Add-EntraBetaServicePrincipalPolicy.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipalPolicy](Get-EntraBetaServicePrincipalPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Confirm-EntraBetaDomain.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Confirm-EntraBetaDomain.md
@@ -106,4 +106,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Connect-Entra.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Connect-Entra.md
@@ -578,6 +578,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Disconnect-Entra](Disconnect-Entra.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Disconnect-Entra.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Disconnect-Entra.md
@@ -73,6 +73,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Connect-Entra](Connect-Entra.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Enable-EntraAzureADAlias.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Enable-EntraAzureADAlias.md
@@ -54,4 +54,4 @@ Enables all Azure AD prefixes for the current PowerShell session.
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Enable-EntraBetaDirectoryRole.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Enable-EntraBetaDirectoryRole.md
@@ -87,7 +87,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectoryRole](Get-EntraBetaDirectoryRole.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAccountSku.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAccountSku.md
@@ -121,4 +121,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAdministrativeUnit.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAdministrativeUnit.md
@@ -234,7 +234,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaAdministrativeUnit](New-EntraBetaAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAdministrativeUnitMember.md
@@ -186,7 +186,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaAdministrativeUnitMember](Add-EntraBetaAdministrativeUnitMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplication.md
@@ -266,7 +266,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplication](New-EntraBetaApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationExtensionProperty.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationExtensionProperty.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationExtensionProperty](New-EntraBetaApplicationExtensionProperty.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationKeyCredential.md
@@ -80,7 +80,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationKeyCredential](New-EntraBetaApplicationKeyCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationLogo.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationLogo.md
@@ -132,6 +132,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaApplicationLogo](Set-EntraBetaApplicationLogo.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationOwner.md
@@ -204,7 +204,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaApplicationOwner](Add-EntraBetaApplicationOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationPasswordCredential.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationPasswordCredential](New-EntraBetaApplicationPasswordCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationPolicy.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaApplicationPolicy](Add-EntraBetaApplicationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyApplication.md
@@ -104,7 +104,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationProxyApplication](New-EntraBetaApplicationProxyApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyApplicationConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyApplicationConnectorGroup.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaApplicationProxyApplicationConnectorGroup](Set-EntraBetaApplicationProxyApplicationConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorGroup.md
@@ -239,7 +239,7 @@ System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutra
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationProxyConnectorGroup](New-EntraBetaApplicationProxyConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorGroupMembers.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorGroupMembers.md
@@ -175,4 +175,4 @@ System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, Pub
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorMemberOf.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationProxyConnectorMemberOf.md
@@ -87,6 +87,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationProxyConnector](Get-EntraBetaApplicationProxyConnector.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationServiceEndpoint.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationServiceEndpoint.md
@@ -160,6 +160,6 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationSignInDetailedSummary.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationSignInDetailedSummary.md
@@ -147,4 +147,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationSignInSummary.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationSignInSummary.md
@@ -163,4 +163,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationTemplate.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaApplicationTemplate.md
@@ -121,4 +121,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAttributeSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAttributeSet.md
@@ -138,7 +138,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaAttributeSet](New-EntraBetaAttributeSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAuditDirectoryLog.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAuditDirectoryLog.md
@@ -186,4 +186,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraBetaAuditDirectoryLogs` is an alias for `Get-EntraBetaAuditDirectoryLog`.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAuditSignInLog.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAuditSignInLog.md
@@ -195,4 +195,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 `Get-EntraBetaAuditSignInLogs` is an alias for `Get-EntraBetaAuditSignInLog`.
 
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAuthorizationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaAuthorizationPolicy.md
@@ -153,6 +153,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaAuthorizationPolicy](Set-EntraBetaAuthorizationPolicy.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaConditionalAccessPolicy.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaConditionalAccessPolicy](New-EntraBetaConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContact.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContact.md
@@ -239,6 +239,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaContact](Remove-EntraBetaContact.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContactDirectReport.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContactDirectReport.md
@@ -160,6 +160,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaContact](Get-EntraBetaContact.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContactManager.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContactManager.md
@@ -100,6 +100,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaContact](Get-EntraBetaContact.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContactMembership.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContactMembership.md
@@ -178,6 +178,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaContact](Get-EntraBetaContact.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContract.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaContract.md
@@ -190,4 +190,4 @@ Corresponds to the ObjectId property of the customer tenant's TenantDetail objec
 
 `ContractId` - the unique identifier for the partnership.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaCustomSecurityAttributeDefinition.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaCustomSecurityAttributeDefinition](New-EntraBetaCustomSecurityAttributeDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md
@@ -190,7 +190,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue](Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeletedApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeletedApplication.md
@@ -252,6 +252,6 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeletedDirectoryObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeletedDirectoryObject.md
@@ -122,4 +122,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeletedGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeletedGroup.md
@@ -280,4 +280,4 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDevice.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDevice.md
@@ -278,7 +278,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaDevice](New-EntraBetaDevice.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeviceRegisteredOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeviceRegisteredOwner.md
@@ -178,7 +178,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaDeviceRegisteredOwner](Add-EntraBetaDeviceRegisteredOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeviceRegisteredUser.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDeviceRegisteredUser.md
@@ -182,7 +182,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaDeviceRegisteredUser](Add-EntraBetaDeviceRegisteredUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirSyncConfiguration.md
@@ -102,6 +102,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaDirSyncConfiguration](Set-EntraBetaDirSyncConfiguration.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirSyncFeature.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirSyncFeature.md
@@ -148,6 +148,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaDirSyncFeature](Set-EntraBetaDirSyncFeature.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.md
@@ -101,4 +101,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRole.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRole.md
@@ -177,6 +177,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Enable-EntraBetaDirectoryRole](Enable-EntraBetaDirectoryRole.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleAssignment.md
@@ -280,7 +280,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraBetaRoleAssignment` is an alias for `Get-EntraBetaDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [New-EntraBetaDirectoryRoleAssignment](New-EntraBetaDirectoryRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleDefinition.md
@@ -270,7 +270,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraBetaRoleDefinition` is an alias for `Get-EntraBetaDirectoryRoleDefinition`.
 
-## Related Links
+## Related links
 
 [New-EntraBetaDirectoryRoleDefinition](New-EntraBetaDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleMember.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaDirectoryRoleMember](Add-EntraBetaDirectoryRoleMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleTemplate.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectoryRoleTemplate.md
@@ -98,4 +98,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectorySetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectorySetting.md
@@ -184,7 +184,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaDirectorySetting](New-EntraBetaDirectorySetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectorySettingTemplate.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDirectorySettingTemplate.md
@@ -124,4 +124,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomain.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomain.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraBetaDomain](Confirm-EntraBetaDomain.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainFederationSettings.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainFederationSettings.md
@@ -126,6 +126,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaDomainFederationSettings](Set-EntraBetaDomainFederationSettings.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainNameReference.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainNameReference.md
@@ -110,4 +110,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainServiceConfigurationRecord.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainServiceConfigurationRecord.md
@@ -115,4 +115,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainVerificationDnsRecord.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaDomainVerificationDnsRecord.md
@@ -113,4 +113,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaFeatureRolloutPolicy.md
@@ -201,7 +201,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaFeatureRolloutPolicy](New-EntraBetaFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaFederationProperty.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaFederationProperty.md
@@ -87,4 +87,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroup.md
@@ -300,7 +300,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaGroup](New-EntraBetaGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupAppRoleAssignment.md
@@ -174,7 +174,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroup](Get-EntraBetaGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupLifecyclePolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupLifecyclePolicy.md
@@ -132,7 +132,7 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaGroupLifecyclePolicy](Set-EntraBetaGroupLifecyclePolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupMember.md
@@ -211,7 +211,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaGroupMember](Add-EntraBetaGroupMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupOwner.md
@@ -179,7 +179,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaGroupOwner](Add-EntraBetaGroupOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupPermissionGrant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGroupPermissionGrant.md
@@ -103,4 +103,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaIdentityProvider.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaIdentityProvider.md
@@ -141,4 +141,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaLifecyclePolicyGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaLifecyclePolicyGroup.md
@@ -104,7 +104,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaLifecyclePolicyGroup](Add-EntraBetaLifecyclePolicyGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaNamedLocationPolicy.md
@@ -138,7 +138,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaNamedLocationPolicy](New-EntraBetaNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaOAuth2PermissionGrant.md
@@ -184,7 +184,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaOAuth2PermissionGrant](Remove-EntraBetaOAuth2PermissionGrant.md)
 [New-EntraBetaOAuth2PermissionGrant](New-EntraBetaOauth2PermissionGrant.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaObjectByObjectId.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaObjectByObjectId.md
@@ -137,4 +137,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaObjectSetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaObjectSetting.md
@@ -241,7 +241,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaObjectSetting](New-EntraBetaObjectSetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPartnerInformation.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPartnerInformation.md
@@ -130,6 +130,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaPartnerInformation](Set-EntraBetaPartnerInformation.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPasswordPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPasswordPolicy.md
@@ -98,4 +98,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPasswordSingleSignOnCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPasswordSingleSignOnCredential.md
@@ -108,7 +108,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPasswordSingleSignOnCredential](New-EntraBetaPasswordSingleSignOnCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPermissionGrantConditionSet.md
@@ -192,7 +192,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPermissionGrantConditionSet](New-EntraBetaPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPermissionGrantPolicy.md
@@ -126,7 +126,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPermissionGrantPolicy](New-EntraBetaPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPolicy.md
@@ -189,7 +189,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPolicy](New-EntraBetaPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPolicyAppliedObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPolicyAppliedObject.md
@@ -83,4 +83,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedResource.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedResource.md
@@ -229,4 +229,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRole.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRole.md
@@ -103,4 +103,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRoleDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRoleDefinition.md
@@ -260,4 +260,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRoleSetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRoleSetting.md
@@ -238,6 +238,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaPrivilegedRoleSetting](Set-EntraBetaPrivilegedRoleSetting.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaScopedRoleMembership.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaScopedRoleMembership.md
@@ -138,7 +138,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaScopedRoleMembership](Add-EntraBetaScopedRoleMembership.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipal.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipal.md
@@ -361,7 +361,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalAppRoleAssignedTo.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalAppRoleAssignedTo.md
@@ -197,7 +197,7 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 `Get-EntraBetaServiceAppRoleAssignedTo` is an alias for `Get-EntraBetaServicePrincipalAppRoleAssignedTo`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalAppRoleAssignment.md
@@ -189,7 +189,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraBetaServiceAppRoleAssignment` is an alias for `Get-EntraBetaServicePrincipalAppRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalCreatedObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalCreatedObject.md
@@ -152,6 +152,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalDelegatedPermissionClassification.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalDelegatedPermissionClassification.md
@@ -188,7 +188,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaServicePrincipalDelegatedPermissionClassification](Add-EntraBetaServicePrincipalDelegatedPermissionClassification.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalKeyCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalKeyCredential.md
@@ -83,6 +83,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalMembership.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalMembership.md
@@ -174,6 +174,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalOAuth2PermissionGrant.md
@@ -173,6 +173,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalOwnedObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalOwnedObject.md
@@ -170,6 +170,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalOwner.md
@@ -171,7 +171,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaServicePrincipalOwner](Add-EntraBetaServicePrincipalOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalPasswordCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalPasswordCredential.md
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaServicePrincipalPasswordCredential](New-EntraBetaServicePrincipalPasswordCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaServicePrincipalPolicy.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaServicePrincipalPolicy](Add-EntraBetaServicePrincipalPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaSubscribedSku.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaSubscribedSku.md
@@ -232,4 +232,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaTenantDetail.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaTenantDetail.md
@@ -164,6 +164,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaTenantDetail](Set-EntraBetaTenantDetail.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaTrustFrameworkPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaTrustFrameworkPolicy.md
@@ -160,7 +160,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaTrustFrameworkPolicy](New-EntraBetaTrustFrameworkPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaTrustedCertificateAuthority.md
@@ -156,7 +156,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaTrustedCertificateAuthority](New-EntraBetaTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUser.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUser.md
@@ -421,7 +421,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaUser](New-EntraBetaUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserAppRoleAssignment.md
@@ -188,7 +188,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserAuthenticationMethod.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserAuthenticationMethod.md
@@ -90,4 +90,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 The authentication administrator only sees masked phone numbers.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserAuthenticationRequirement.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserAuthenticationRequirement.md
@@ -94,4 +94,4 @@ The most effective way to protect users with Microsoft Entra MFA is by creating 
 
 For Microsoft Entra ID Free tenants without Conditional Access, you can [use security defaults](https://learn.microsoft.com/entra/fundamentals/security-defaults) to protect users. MFA prompts are automatic, but you can't customize the rules.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserCreatedObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserCreatedObject.md
@@ -171,4 +171,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserDirectReport.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserDirectReport.md
@@ -175,4 +175,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserExtension.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserExtension.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserLicenseDetail.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserLicenseDetail.md
@@ -110,4 +110,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserManager.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserManager.md
@@ -129,7 +129,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaUserManager](Remove-EntraBetaUserManager.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserMembership.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserMembership.md
@@ -222,4 +222,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserOAuth2PermissionGrant.md
@@ -181,6 +181,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserOwnedDevice.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserOwnedDevice.md
@@ -162,4 +162,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserOwnedObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserOwnedObject.md
@@ -181,4 +181,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserRegisteredDevice.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserRegisteredDevice.md
@@ -163,4 +163,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserThumbnailPhoto.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaUserThumbnailPhoto.md
@@ -104,6 +104,6 @@ System.Boolean
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaUserThumbnailPhoto](Set-EntraBetaUserThumbnailPhoto.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraContext.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraContext.md
@@ -127,4 +127,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 Please note that `Get-EntraCurrentSessionInfo` is now an alias for `Get-EntraContext` and can be used interchangeably.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaAdministrativeUnit.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaAdministrativeUnit.md
@@ -154,7 +154,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaAdministrativeUnit](Get-EntraBetaAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaAdministrativeUnitMember.md
@@ -359,7 +359,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaAdministrativeUnitMember](Add-EntraBetaAdministrativeUnitMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplication.md
@@ -556,7 +556,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationExtensionProperty.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationExtensionProperty.md
@@ -191,7 +191,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationExtensionProperty](Get-EntraBetaApplicationExtensionProperty.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationFromApplicationTemplate.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationFromApplicationTemplate.md
@@ -83,4 +83,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.Online.Administration.ApplicationTemplateCopy
 ## Notes
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationKey.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationKey.md
@@ -148,6 +148,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaApplicationKey](Remove-EntraBetaApplicationKey.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationKeyCredential.md
@@ -245,7 +245,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationPassword.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationPassword.md
@@ -110,6 +110,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaApplicationPassword](Remove-EntraBetaApplicationPassword.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationPasswordCredential.md
@@ -193,6 +193,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaApplicationPasswordCredential](Remove-EntraBetaApplicationPasswordCredential.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationProxyApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationProxyApplication.md
@@ -379,7 +379,7 @@ System.Nullable\`1\[\[Microsoft.Open.MSGraph.Model.ApplicationProxyApplicationOb
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaApplicationProxyApplication](Set-EntraBetaApplicationProxyApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationProxyConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaApplicationProxyConnectorGroup.md
@@ -90,7 +90,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaApplicationProxyConnectorGroup](Set-EntraBetaApplicationProxyConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaAttributeSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaAttributeSet.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaAttributeSet](Set-EntraBetaAttributeSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaConditionalAccessPolicy.md
@@ -293,7 +293,7 @@ Learn more about:
 [Conditions](https://learn.microsoft.com/graph/api/resources/conditionalaccessconditionset)
 [Session controls](https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols)
 
-## Related Links
+## Related links
 
 [Get-EntraBetaConditionalAccessPolicy](Get-EntraBetaConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaCustomSecurityAttributeDefinition.md
@@ -228,7 +228,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaCustomSecurityAttributeDefinition](Set-EntraBetaCustomSecurityAttributeDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDevice.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDevice.md
@@ -335,7 +335,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDevice](Get-EntraBetaDevice.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDirectoryRoleAssignment.md
@@ -129,7 +129,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `New-EntraBetaRoleAssignment` is an alias for `New-EntraBetaDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectoryRoleAssignment](Get-EntraBetaDirectoryRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDirectoryRoleDefinition.md
@@ -307,7 +307,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `New-EntraBetaRoleDefinition` is an alias for `New-EntraBetaDirectoryRoleDefinition`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectoryRoleDefinition](Get-EntraBetaDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDirectorySetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDirectorySetting.md
@@ -87,7 +87,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectorySetting](Get-EntraBetaDirectorySetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDomain.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaDomain.md
@@ -150,7 +150,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraBetaDomain](Confirm-EntraBetaDomain.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaFeatureRolloutPolicy.md
@@ -209,7 +209,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 See more details - <https://learn.microsoft.com/graph/api/resources/featurerolloutpolicy>
 
-## Related Links
+## Related links
 
 [Get-EntraBetaFeatureRolloutPolicy](Get-EntraBetaFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGroup.md
@@ -435,7 +435,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroup](Get-EntraBetaGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGroupAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGroupAppRoleAssignment.md
@@ -140,7 +140,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroupAppRoleAssignment](Get-EntraBetaGroupAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGroupLifecyclePolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGroupLifecyclePolicy.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaGroupLifecyclePolicy](Set-EntraBetaGroupLifecyclePolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaIdentityProvider.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaIdentityProvider.md
@@ -160,7 +160,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaIdentityProvider](Set-EntraBetaIdentityProvider.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaInvitation.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaInvitation.md
@@ -330,4 +330,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - See more information - <https://learn.microsoft.com/graph/api/invitation-post>.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaNamedLocationPolicy.md
@@ -220,7 +220,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For more information, see [Create namedLocation](/graph/api/conditionalaccessroot-post-namedlocations).
 
-## Related Links
+## Related links
 
 [Get-EntraBetaNamedLocationPolicy](Get-EntraBetaNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaObjectSetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaObjectSetting.md
@@ -123,7 +123,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaObjectSetting](Get-EntraBetaObjectSetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPasswordSingleSignOnCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPasswordSingleSignOnCredential.md
@@ -112,7 +112,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaPasswordSingleSignOnCredential](Set-EntraBetaPasswordSingleSignOnCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPermissionGrantConditionSet.md
@@ -361,7 +361,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaPermissionGrantConditionSet](Set-EntraBetaPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPermissionGrantPolicy.md
@@ -118,7 +118,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaPermissionGrantPolicy](Get-EntraBetaPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPolicy.md
@@ -223,7 +223,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaPolicy](Get-EntraBetaPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPrivilegedRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPrivilegedRoleAssignment.md
@@ -133,4 +133,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaServicePrincipal.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaServicePrincipal.md
@@ -389,7 +389,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaServicePrincipalAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaServicePrincipalAppRoleAssignment.md
@@ -220,7 +220,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `New-EntraBetaServiceAppRoleAssignment` is an alias for `New-EntraBetaServicePrincipalAppRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipalAppRoleAssignment](Get-EntraBetaServicePrincipalAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaServicePrincipalPasswordCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaServicePrincipalPasswordCredential.md
@@ -153,7 +153,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipalPasswordCredential](Get-EntraBetaServicePrincipalPasswordCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaTrustFrameworkPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaTrustFrameworkPolicy.md
@@ -182,7 +182,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTrustFrameworkPolicy](Get-EntraBetaTrustFrameworkPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaTrustedCertificateAuthority.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTrustedCertificateAuthority](Get-EntraBetaTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaUser.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaUser.md
@@ -802,7 +802,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaUserAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaUserAppRoleAssignment.md
@@ -198,7 +198,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUserAppRoleAssignment](Get-EntraBetaUserAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaAdministrativeUnit.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaAdministrativeUnit.md
@@ -77,7 +77,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaAdministrativeUnit](New-EntraBetaAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaAdministrativeUnitMember.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaAdministrativeUnitMember](Add-EntraBetaAdministrativeUnitMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplication.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationExtensionProperty.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationExtensionProperty.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationExtensionProperty](Get-EntraBetaApplicationExtensionProperty.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationKey.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationKey.md
@@ -122,6 +122,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationKey](New-EntraBetaApplicationKey.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationKeyCredential.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationKeyCredential](Get-EntraBetaApplicationKeyCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationOwner.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaApplicationOwner](Add-EntraBetaApplicationOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationPassword.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationPassword.md
@@ -96,6 +96,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationPassword](New-EntraBetaApplicationPassword.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationPasswordCredential.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationPolicy.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaApplicationPolicy](Add-EntraBetaApplicationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationProxyApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationProxyApplication.md
@@ -108,7 +108,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationProxyApplication](New-EntraBetaApplicationProxyApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationProxyApplicationConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationProxyApplicationConnectorGroup.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaApplicationProxyApplicationConnectorGroup](Set-EntraBetaApplicationProxyApplicationConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationProxyConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationProxyConnectorGroup.md
@@ -81,7 +81,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationProxyConnectorGroup](New-EntraBetaApplicationProxyConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationVerifiedPublisher.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaApplicationVerifiedPublisher.md
@@ -79,6 +79,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraBetaApplicationVerifiedPublisher](Set-EntraBetaApplicationVerifiedPublisher.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaConditionalAccessPolicy.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaConditionalAccessPolicy](Get-EntraBetaConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaContact.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaContact.md
@@ -75,6 +75,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaContact](Get-EntraBetaContact.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeletedApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeletedApplication.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Restore-EntraBetaDeletedApplication](Restore-EntraBetaDeletedApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeletedDirectoryObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeletedDirectoryObject.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDeletedDirectoryObject](Get-EntraBetaDeletedDirectoryObject.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDevice.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDevice.md
@@ -81,7 +81,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDevice](Get-EntraBetaDevice.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeviceRegisteredOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeviceRegisteredOwner.md
@@ -98,7 +98,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaDeviceRegisteredOwner](Add-EntraBetaDeviceRegisteredOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeviceRegisteredUser.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDeviceRegisteredUser.md
@@ -98,7 +98,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaDeviceRegisteredUser](Add-EntraBetaDeviceRegisteredUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectoryRoleAssignment.md
@@ -88,7 +88,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Remove-EntraBetaRoleAssignment` is an alias for `Remove-EntraBetaDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [New-EntraBetaDirectoryRoleAssignment](New-EntraBetaDirectoryRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectoryRoleDefinition.md
@@ -88,7 +88,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Remove-EntraBetaRoleDefinition` is an alias for `Remove-EntraBetaDirectoryRoleDefinition`.
 
-## Related Links
+## Related links
 
 [New-EntraBetaDirectoryRoleDefinition](New-EntraBetaDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectoryRoleMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectoryRoleMember.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaDirectoryRoleMember](Add-EntraBetaDirectoryRoleMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectorySetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDirectorySetting.md
@@ -86,7 +86,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectorySetting](Get-EntraBetaDirectorySetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDomain.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaDomain.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraBetaDomain](Confirm-EntraBetaDomain.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaFeatureRolloutPolicy.md
@@ -79,7 +79,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaFeatureRolloutPolicy](New-EntraBetaFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaFeatureRolloutPolicyDirectoryObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaFeatureRolloutPolicyDirectoryObject.md
@@ -102,6 +102,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaFeatureRolloutPolicyDirectoryObject](Add-EntraBetaFeatureRolloutPolicyDirectoryObject.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaGroup.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroup](Get-EntraBetaGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaGroupAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaGroupAppRoleAssignment.md
@@ -93,7 +93,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroupAppRoleAssignment](Get-EntraBetaGroupAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaGroupMember.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaGroupMember.md
@@ -92,7 +92,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaGroupMember](Add-EntraBetaGroupMember.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaIdentityProvider.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaIdentityProvider.md
@@ -86,7 +86,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaIdentityProvider](New-EntraBetaIdentityProvider.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaLifecyclePolicyGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaLifecyclePolicyGroup.md
@@ -106,7 +106,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaLifecyclePolicyGroup](Add-EntraBetaLifecyclePolicyGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaNamedLocationPolicy.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaNamedLocationPolicy](New-EntraBetaNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaOAuth2PermissionGrant.md
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaOAuth2PermissionGrant](Get-EntraBetaOAuth2PermissionGrant.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaObjectSetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaObjectSetting.md
@@ -117,7 +117,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaObjectSetting](Get-EntraBetaObjectSetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPasswordSingleSignOnCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPasswordSingleSignOnCredential.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPasswordSingleSignOnCredential](New-EntraBetaPasswordSingleSignOnCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPermissionGrantConditionSet.md
@@ -116,7 +116,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPermissionGrantConditionSet](New-EntraBetaPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPermissionGrantPolicy.md
@@ -76,7 +76,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPermissionGrantPolicy](New-EntraBetaPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPolicy.md
@@ -76,7 +76,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaPolicy](Get-EntraBetaPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaScopedRoleMembership.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaScopedRoleMembership.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaScopedRoleMembership](Add-EntraBetaScopedRoleMembership.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipal.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipal.md
@@ -76,7 +76,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalAppRoleAssignment.md
@@ -112,7 +112,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Remove-EntraBetaServiceAppRoleAssignment` is an alias for `Remove-EntraBetaServicePrincipalAppRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipalAppRoleAssignment](Get-EntraBetaServicePrincipalAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalDelegatedPermissionClassification.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalDelegatedPermissionClassification.md
@@ -96,7 +96,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaServicePrincipalDelegatedPermissionClassification](Add-EntraBetaServicePrincipalDelegatedPermissionClassification.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalOwner.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaServicePrincipalOwner](Add-EntraBetaServicePrincipalOwner.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalPasswordCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalPasswordCredential.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaServicePrincipalPolicy.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaServicePrincipalPolicy](Add-EntraBetaServicePrincipalPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaTrustFrameworkPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaTrustFrameworkPolicy.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTrustFrameworkPolicy](Get-EntraBetaTrustFrameworkPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaTrustedCertificateAuthority.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTrustedCertificateAuthority](Get-EntraBetaTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaUser.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaUser.md
@@ -86,7 +86,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaUserAppRoleAssignment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaUserAppRoleAssignment.md
@@ -107,7 +107,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUserAppRoleAssignment](Get-EntraBetaUserAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaUserExtension.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaUserExtension.md
@@ -119,7 +119,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUserExtension](Get-EntraBetaUserExtension.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Reset-EntraBetaLifeCycleGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Reset-EntraBetaLifeCycleGroup.md
@@ -82,4 +82,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Reset-EntraBetaStrongAuthenticationMethodByUpn.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Reset-EntraBetaStrongAuthenticationMethodByUpn.md
@@ -76,4 +76,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Restore-EntraBetaDeletedApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Restore-EntraBetaDeletedApplication.md
@@ -112,7 +112,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaDeletedApplication](Remove-EntraBetaDeletedApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Restore-EntraBetaDeletedDirectoryObject.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Restore-EntraBetaDeletedDirectoryObject.md
@@ -142,7 +142,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaDeletedApplication](Remove-EntraBetaDeletedApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Revoke-EntraBetaSignedInUserAllRefreshToken.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Revoke-EntraBetaSignedInUserAllRefreshToken.md
@@ -67,6 +67,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Revoke-EntraBetaUserAllRefreshToken](Revoke-EntraBetaUserAllRefreshToken.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Revoke-EntraBetaUserAllRefreshToken.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Revoke-EntraBetaUserAllRefreshToken.md
@@ -85,6 +85,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Revoke-EntraBetaSignedInUserAllRefreshToken](Revoke-EntraBetaSignedInUserAllRefreshToken.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsContactIsMemberOf.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsContactIsMemberOf.md
@@ -96,6 +96,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaContact](Get-EntraBetaContact.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsGroupIsMemberOf.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsGroupIsMemberOf.md
@@ -96,6 +96,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroup](Get-EntraBetaGroup.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsServicePrincipalIsMemberOf.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsServicePrincipalIsMemberOf.md
@@ -101,4 +101,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsUserIsMemberOf.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Select-EntraBetaGroupIdsUserIsMemberOf.md
@@ -100,6 +100,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroup](Get-EntraBetaGroup.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaAdministrativeUnit.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaAdministrativeUnit.md
@@ -145,7 +145,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaAdministrativeUnit](Get-EntraBetaAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplication.md
@@ -539,7 +539,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplication](Get-EntraBetaApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationLogo.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationLogo.md
@@ -117,6 +117,6 @@ System.IO.Stream System.Byte\[\]
 
 File uploads must be smaller than 500KB.
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationLogo](Get-EntraBetaApplicationLogo.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyApplication.md
@@ -378,7 +378,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationProxyApplication](New-EntraBetaApplicationProxyApplication.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyApplicationConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyApplicationConnectorGroup.md
@@ -105,7 +105,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationProxyApplicationConnectorGroup](Get-EntraBetaApplicationProxyApplicationConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyApplicationSingleSignOn.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyApplicationSingleSignOn.md
@@ -165,4 +165,4 @@ System.Nullable\`1\[\[Microsoft.Open.MSGraph.Model.OnPremisesPublishingSingleSig
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyConnector.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyConnector.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaApplicationProxyConnectorGroup](Get-EntraBetaApplicationProxyConnectorGroup.md)
 [Get-EntraBetaApplicationProxyConnector](Get-EntraBetaApplicationProxyConnector.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyConnectorGroup.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationProxyConnectorGroup.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaApplicationProxyConnectorGroup](New-EntraBetaApplicationProxyConnectorGroup.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationVerifiedPublisher.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaApplicationVerifiedPublisher.md
@@ -101,6 +101,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraBetaApplicationVerifiedPublisher](Remove-EntraBetaApplicationVerifiedPublisher.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaAttributeSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaAttributeSet.md
@@ -130,7 +130,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaAttributeSet](New-EntraBetaAttributeSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaAuthorizationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaAuthorizationPolicy.md
@@ -281,6 +281,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaAuthorizationPolicy](Get-EntraBetaAuthorizationPolicy.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaConditionalAccessPolicy.md
@@ -261,7 +261,7 @@ Learn more about:
 [Conditions](https://learn.microsoft.com/graph/api/resources/conditionalaccessconditionset)
 [Session controls](https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols)
 
-## Related Links
+## Related links
 
 [Get-EntraBetaConditionalAccessPolicy](Get-EntraBetaConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaCustomSecurityAttributeDefinition.md
@@ -138,7 +138,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaCustomSecurityAttributeDefinition](New-EntraBetaCustomSecurityAttributeDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md
@@ -120,7 +120,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue](Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDevice.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDevice.md
@@ -386,7 +386,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDevice](Get-EntraBetaDevice.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirSyncConfiguration.md
@@ -149,6 +149,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For additional details see [Update onPremisesDirectorySynchronization](https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update).
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirSyncConfiguration](Get-EntraBetaDirSyncConfiguration.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirSyncEnabled.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirSyncEnabled.md
@@ -141,4 +141,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirSyncFeature.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirSyncFeature.md
@@ -185,6 +185,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 - For additional details see [Update onPremisesDirectorySynchronization](https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update).
 - For the feature list see the [onPremisesDirectorySynchronizationFeature resource type](https://learn.microsoft.com/graph/api/resources/onpremisesdirectorysynchronizationfeature).
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirSyncFeature](Get-EntraBetaDirSyncFeature.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirectoryRoleDefinition.md
@@ -280,7 +280,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Set-EntraBetaRoleAssignment` is an alias for `Set-EntraBetaDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [New-EntraBetaDirectoryRoleDefinition](New-EntraBetaDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirectorySetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDirectorySetting.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDirectorySetting](Get-EntraBetaDirectorySetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDomain.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDomain.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraBetaDomain](Confirm-EntraBetaDomain.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDomainFederationSettings.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaDomainFederationSettings.md
@@ -307,6 +307,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaDomainFederationSettings](Get-EntraBetaDomainFederationSettings.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaFeatureRolloutPolicy.md
@@ -222,7 +222,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 See more details - <https://learn.microsoft.com/graph/api/resources/featurerolloutpolicy>
 
-## Related Links
+## Related links
 
 [New-EntraBetaFeatureRolloutPolicy](New-EntraBetaFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaGroupLifecyclePolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaGroupLifecyclePolicy.md
@@ -145,7 +145,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaGroupLifecyclePolicy](Get-EntraBetaGroupLifecyclePolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaIdentityProvider.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaIdentityProvider.md
@@ -181,7 +181,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaIdentityProvider](New-EntraBetaIdentityProvider.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaNamedLocationPolicy.md
@@ -240,7 +240,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaNamedLocationPolicy](New-EntraBetaNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaObjectSetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaObjectSetting.md
@@ -139,7 +139,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaObjectSetting](Get-EntraBetaObjectSetting.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPartnerInformation.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPartnerInformation.md
@@ -233,6 +233,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaPartnerInformation](Get-EntraBetaPartnerInformation.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPasswordSingleSignOnCredential.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPasswordSingleSignOnCredential.md
@@ -104,7 +104,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPasswordSingleSignOnCredential](New-EntraBetaPasswordSingleSignOnCredential.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPermissionGrantConditionSet.md
@@ -295,7 +295,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPermissionGrantConditionSet](New-EntraBetaPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPermissionGrantPolicy.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraBetaPermissionGrantPolicy](New-EntraBetaPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPolicy.md
@@ -192,7 +192,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaPolicy](Get-EntraBetaPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPrivilegedRoleAssignmentRequest.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPrivilegedRoleAssignmentRequest.md
@@ -136,4 +136,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPrivilegedRoleSetting.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaPrivilegedRoleSetting.md
@@ -309,6 +309,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaPrivilegedRoleSetting](Get-EntraBetaPrivilegedRoleSetting.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaServicePrincipal.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaServicePrincipal.md
@@ -406,7 +406,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaServicePrincipal](Get-EntraBetaServicePrincipal.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaTenantDetail.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaTenantDetail.md
@@ -211,6 +211,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For more details see [Update organization](https://learn.microsoft.com/graph/api/organization-update).
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTenantDetail](Get-EntraBetaTenantDetail.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaTrustFrameworkPolicy.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaTrustFrameworkPolicy.md
@@ -211,7 +211,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTrustFrameworkPolicy](Get-EntraBetaTrustFrameworkPolicy.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaTrustedCertificateAuthority.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaTrustedCertificateAuthority](Get-EntraBetaTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserExtension.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserExtension.md
@@ -140,7 +140,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserLicense.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserLicense.md
@@ -256,6 +256,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUser](Get-EntraBetaUser.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserPassword.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserPassword.md
@@ -161,4 +161,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserThumbnailPhoto.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Set-EntraBetaUserThumbnailPhoto.md
@@ -153,6 +153,6 @@ System.IO.Stream System.Byte\[\]
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaUserThumbnailPhoto](Get-EntraBetaUserThumbnailPhoto.md)

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Test-EntraScript.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Test-EntraScript.md
@@ -113,4 +113,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaOauth2PermissionGrant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaOauth2PermissionGrant.md
@@ -119,7 +119,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraBetaOauth2PermissionGrant](Get-EntraBetaOAuth2PermissionGrant.md)
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaUserAuthenticationRequirement.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaUserAuthenticationRequirement.md
@@ -108,4 +108,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 Enabled users are automatically switched to Enforced when they register for Microsoft Entra multifactor authentication. Don't manually change the user state to Enforced unless the user is already registered or if it's acceptable for the user to experience interruption in connections to legacy authentication protocols.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaUserFromFederated.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Update-EntraBetaUserFromFederated.md
@@ -102,4 +102,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For more information, see [resetPassword](https://learn.microsoft.com/graph/api/authenticationmethod-resetpassword).
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraAdministrativeUnitMember.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraAdministrativeUnitMember](Get-EntraAdministrativeUnitMember.md)
 [Remove-EntraAdministrativeUnitMember](Remove-EntraAdministrativeUnitMember.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraApplicationOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraApplicationOwner.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplicationOwner](Get-EntraApplicationOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.md
@@ -129,7 +129,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Add-EntraCustomSecurityAttributeDefinitionAllowedValues` is an alias for `Add-EntraCustomSecurityAttributeDefinitionAllowedValue`.
 
-## Related Links
+## Related links
 
 [Get-EntraCustomSecurityAttributeDefinitionAllowedValue](Get-EntraCustomSecurityAttributeDefinitionAllowedValue.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraDeviceRegisteredOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraDeviceRegisteredOwner.md
@@ -101,7 +101,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDeviceRegisteredOwner](Get-EntraDeviceRegisteredOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraDeviceRegisteredUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraDeviceRegisteredUser.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDevice](Get-EntraDevice.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraDirectoryRoleMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraDirectoryRoleMember.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRoleMember](Get-EntraDirectoryRoleMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraEnvironment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraEnvironment.md
@@ -111,6 +111,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraEnvironment](Get-EntraEnvironment.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraGroupMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraGroupMember.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroupMember](Get-EntraGroupMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraGroupOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraGroupOwner.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroupOwner](Get-EntraGroupOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraLifecyclePolicyGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraLifecyclePolicyGroup.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraLifecyclePolicyGroup](Get-EntraLifecyclePolicyGroup.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraScopedRoleMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraScopedRoleMembership.md
@@ -123,7 +123,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraScopedRoleMembership](Get-EntraScopedRoleMembership.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraServicePrincipalDelegatedPermissionClassification.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraServicePrincipalDelegatedPermissionClassification.md
@@ -156,7 +156,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalDelegatedPermissionClassification](Get-EntraServicePrincipalDelegatedPermissionClassification.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Add-EntraServicePrincipalOwner.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Confirm-EntraDomain.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Confirm-EntraDomain.md
@@ -101,7 +101,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDomain](Get-EntraDomain.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Connect-Entra.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Connect-Entra.md
@@ -578,6 +578,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Disconnect-Entra](Disconnect-Entra.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Disconnect-Entra.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Disconnect-Entra.md
@@ -73,6 +73,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Connect-Entra](Connect-Entra.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraAzureADAlias.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraAzureADAlias.md
@@ -54,4 +54,4 @@ Enables all Azure AD prefixes for the current PowerShell session.
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraDirectoryRole.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Enable-EntraDirectoryRole.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For additional details see [Activate directoryRole](/graph/api/directoryrole-post-directoryroles).
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRole](Get-EntraDirectoryRole.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Find-EntraPermission.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Find-EntraPermission.md
@@ -236,4 +236,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAccountSku.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAccountSku.md
@@ -121,4 +121,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAdministrativeUnit.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAdministrativeUnit.md
@@ -228,7 +228,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraAdministrativeUnit](New-EntraAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAdministrativeUnitMember.md
@@ -186,7 +186,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraAdministrativeUnitMember](Add-EntraAdministrativeUnitMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplication.md
@@ -267,7 +267,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraApplication](New-EntraApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationExtensionProperty.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationExtensionProperty.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraApplicationExtensionProperty](New-EntraApplicationExtensionProperty.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationKeyCredential.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraApplicationKeyCredential](New-EntraApplicationKeyCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationLogo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationLogo.md
@@ -132,6 +132,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraApplicationLogo](Set-EntraApplicationLogo.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationOwner.md
@@ -205,7 +205,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraApplicationOwner](Add-EntraApplicationOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationPasswordCredential.md
@@ -99,6 +99,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationServiceEndpoint.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationServiceEndpoint.md
@@ -162,6 +162,6 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationTemplate.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraApplicationTemplate.md
@@ -171,4 +171,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAttributeSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAttributeSet.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraAttributeSet](New-EntraAttributeSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAuditDirectoryLog.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAuditDirectoryLog.md
@@ -182,4 +182,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraAuditDirectoryLogs` is an alias for `Get-EntraAuditDirectoryLog`.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAuditSignInLog.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAuditSignInLog.md
@@ -210,4 +210,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraAuditSignInLogs` is an alias for `Get-EntraAuditSignInLog`.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAuthorizationPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraAuthorizationPolicy.md
@@ -161,6 +161,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraAuthorizationPolicy](Set-EntraAuthorizationPolicy.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraConditionalAccessPolicy.md
@@ -135,7 +135,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraConditionalAccessPolicy](New-EntraConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContact.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContact.md
@@ -240,6 +240,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraContact](Remove-EntraContact.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactDirectReport.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactDirectReport.md
@@ -162,6 +162,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraContact](Get-EntraContact.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactManager.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactManager.md
@@ -101,6 +101,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraContact](Get-EntraContact.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContactMembership.md
@@ -178,6 +178,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraContact](Get-EntraContact.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContext.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContext.md
@@ -127,4 +127,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContract.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraContract.md
@@ -189,4 +189,4 @@ Corresponds to the ObjectId property of the customer tenant's TenantDetail objec
 
 `ContractId` - the unique identifier for the partnership.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraCustomSecurityAttributeDefinition.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraCustomSecurityAttributeDefinition](New-EntraCustomSecurityAttributeDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.md
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraCustomSecurityAttributeDefinitionAllowedValue](Add-EntraCustomSecurityAttributeDefinitionAllowedValue.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeletedApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeletedApplication.md
@@ -252,6 +252,6 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeletedDirectoryObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeletedDirectoryObject.md
@@ -119,4 +119,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeletedGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeletedGroup.md
@@ -290,4 +290,4 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDevice.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDevice.md
@@ -271,7 +271,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraDevice](New-EntraDevice.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeviceRegisteredOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeviceRegisteredOwner.md
@@ -178,7 +178,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraDeviceRegisteredOwner](Add-EntraDeviceRegisteredOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeviceRegisteredUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDeviceRegisteredUser.md
@@ -182,7 +182,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraDeviceRegisteredUser](Add-EntraDeviceRegisteredUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncConfiguration.md
@@ -102,6 +102,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraDirSyncConfiguration](Set-EntraDirSyncConfiguration.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncFeature.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirSyncFeature.md
@@ -148,6 +148,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraDirSyncFeature](Set-EntraDirSyncFeature.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryObjectOnPremisesProvisioningError.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryObjectOnPremisesProvisioningError.md
@@ -101,4 +101,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRole.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRole.md
@@ -176,6 +176,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Enable-EntraDirectoryRole](Enable-EntraDirectoryRole.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleAssignment.md
@@ -280,7 +280,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraRoleAssignment` is an alias for `Get-EntraDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [New-EntraDirectoryRoleAssignment](New-EntraDirectoryRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleDefinition.md
@@ -267,7 +267,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraRoleDefinition` is an alias for `Get-EntraDirectoryRoleDefintion`.
 
-## Related Links
+## Related links
 
 [New-EntraDirectoryRoleDefinition](New-EntraDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleMember.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraDirectoryRoleMember](Add-EntraDirectoryRoleMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleTemplate.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDirectoryRoleTemplate.md
@@ -98,4 +98,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomain.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomain.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraDomain](Confirm-EntraDomain.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainFederationSettings.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainFederationSettings.md
@@ -126,4 +126,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainNameReference.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainNameReference.md
@@ -111,4 +111,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainServiceConfigurationRecord.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainServiceConfigurationRecord.md
@@ -114,4 +114,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainVerificationDnsRecord.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraDomainVerificationDnsRecord.md
@@ -112,4 +112,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraEnvironment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraEnvironment.md
@@ -103,6 +103,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraEnvironment](Add-EntraEnvironment.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraExtensionProperty.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraExtensionProperty.md
@@ -94,4 +94,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraFeatureRolloutPolicy.md
@@ -204,7 +204,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraFeatureRolloutPolicy](New-EntraFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraFederationProperty.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraFederationProperty.md
@@ -87,4 +87,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroup.md
@@ -301,7 +301,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraGroup](New-EntraGroup.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupAppRoleAssignment.md
@@ -174,7 +174,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroup](Get-EntraGroup.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupLifecyclePolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupLifecyclePolicy.md
@@ -132,4 +132,4 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupMember.md
@@ -211,7 +211,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraGroupMember](Add-EntraGroupMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupOwner.md
@@ -182,7 +182,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraGroupOwner](Add-EntraGroupOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupPermissionGrant.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraGroupPermissionGrant.md
@@ -103,4 +103,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraIdentityProvider.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraIdentityProvider.md
@@ -141,4 +141,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraLifecyclePolicyGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraLifecyclePolicyGroup.md
@@ -103,4 +103,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraNamedLocationPolicy.md
@@ -138,7 +138,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraNamedLocationPolicy](New-EntraNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraOAuth2PermissionGrant.md
@@ -184,7 +184,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraOAuth2PermissionGrant](Remove-EntraOAuth2PermissionGrant.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraObjectByObjectId.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraObjectByObjectId.md
@@ -139,4 +139,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraObjectSetting.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraObjectSetting.md
@@ -256,4 +256,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPartnerInformation.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPartnerInformation.md
@@ -130,6 +130,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraPartnerInformation](Set-EntraPartnerInformation.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPasswordPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPasswordPolicy.md
@@ -98,4 +98,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPermissionGrantConditionSet.md
@@ -190,7 +190,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPermissionGrantConditionSet](New-EntraPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPermissionGrantPolicy.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPermissionGrantPolicy](New-EntraPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraPolicy.md
@@ -188,7 +188,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPolicy](New-EntraPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraScopedRoleMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraScopedRoleMembership.md
@@ -136,7 +136,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraScopedRoleMembership](Add-EntraScopedRoleMembership.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipal.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipal.md
@@ -361,7 +361,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalAppRoleAssignedTo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalAppRoleAssignedTo.md
@@ -187,7 +187,7 @@ System.Nullable\`1\[\[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral
 
 `Get-EntraServiceAppRoleAssignedTo` is an alias for `Get-EntraServicePrincipalAppRoleAssignedTo`.
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalAppRoleAssignment.md
@@ -186,7 +186,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Get-EntraServiceAppRoleAssignment` is an alias for `Get-EntraServicePrincipalAppRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalCreatedObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalCreatedObject.md
@@ -150,6 +150,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalDelegatedPermissionClassification.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalDelegatedPermissionClassification.md
@@ -187,7 +187,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraServicePrincipalDelegatedPermissionClassification](Remove-EntraServicePrincipalDelegatedPermissionClassification.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalKeyCredential.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalMembership.md
@@ -173,6 +173,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalOAuth2PermissionGrant.md
@@ -166,6 +166,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalOwnedObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalOwnedObject.md
@@ -171,6 +171,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalOwner.md
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraServicePrincipalOwner](Add-EntraServicePrincipalOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraServicePrincipalPasswordCredential.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraSubscribedSku.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraSubscribedSku.md
@@ -230,4 +230,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraTenantDetail.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraTenantDetail.md
@@ -162,6 +162,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraTenantDetail](Set-EntraTenantDetail.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraTrustedCertificateAuthority.md
@@ -177,7 +177,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraTrustedCertificateAuthority](New-EntraTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUser.md
@@ -420,7 +420,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraUser](New-EntraUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserAppRoleAssignment.md
@@ -189,7 +189,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserAuthenticationMethod.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserAuthenticationMethod.md
@@ -90,4 +90,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 The authentication administrator only sees masked phone numbers.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserCreatedObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserCreatedObject.md
@@ -172,4 +172,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserDirectReport.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserDirectReport.md
@@ -176,4 +176,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserExtension.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserExtension.md
@@ -101,7 +101,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserLicenseDetail.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserLicenseDetail.md
@@ -110,4 +110,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserManager.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserManager.md
@@ -129,7 +129,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraUserManager](Remove-EntraUserManager.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserMembership.md
@@ -222,4 +222,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserOAuth2PermissionGrant.md
@@ -180,6 +180,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserOwnedDevice.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserOwnedDevice.md
@@ -163,4 +163,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserOwnedObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserOwnedObject.md
@@ -181,4 +181,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserRegisteredDevice.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserRegisteredDevice.md
@@ -162,4 +162,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserThumbnailPhoto.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Get-EntraUserThumbnailPhoto.md
@@ -104,6 +104,6 @@ System.Boolean
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraUserThumbnailPhoto](Set-EntraUserThumbnailPhoto.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraAdministrativeUnit.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraAdministrativeUnit.md
@@ -119,7 +119,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraAdministrativeUnit](Get-EntraAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplication.md
@@ -481,7 +481,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - See more details - <https://learn.microsoft.com/graph/api/application-post-applications>
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationExtensionProperty.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationExtensionProperty.md
@@ -191,7 +191,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplicationExtensionProperty](Get-EntraApplicationExtensionProperty.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationFromApplicationTemplate.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationFromApplicationTemplate.md
@@ -105,4 +105,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationKey.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationKey.md
@@ -150,6 +150,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraApplicationKey](Remove-EntraApplicationKey.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationKeyCredential.md
@@ -246,7 +246,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationPassword.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationPassword.md
@@ -111,6 +111,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraApplicationPassword](Remove-EntraApplicationPassword.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraApplicationPasswordCredential.md
@@ -193,7 +193,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplicationPasswordCredential](Get-EntraApplicationPasswordCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraAttributeSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraAttributeSet.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraAttributeSet](Get-EntraAttributeSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraConditionalAccessPolicy.md
@@ -259,7 +259,7 @@ Learn more about:
 [Conditions](https://learn.microsoft.com/graph/api/resources/conditionalaccessconditionset)
 [Session controls](https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols)
 
-## Related Links
+## Related links
 
 [Get-EntraConditionalAccessPolicy](Get-EntraConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraCustomSecurityAttributeDefinition.md
@@ -229,7 +229,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraCustomSecurityAttributeDefinition](Set-EntraCustomSecurityAttributeDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDevice.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDevice.md
@@ -335,7 +335,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDevice](Get-EntraDevice.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDirectoryRoleAssignment.md
@@ -129,7 +129,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `New-EntraRoleAssignment` is an alias for `New-EntraDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRoleAssignment](Get-EntraDirectoryRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDirectoryRoleDefinition.md
@@ -290,7 +290,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `New-EntraRoleDefinition` is an alias for `New-EntraDirectoryRoleDefintion`.
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRoleDefinition](Get-EntraDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDomain.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraDomain.md
@@ -149,7 +149,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraDomain](Confirm-EntraDomain.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraFeatureRolloutPolicy.md
@@ -209,7 +209,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 See more details - <https://learn.microsoft.com/graph/api/resources/featurerolloutpolicy>
 
-## Related Links
+## Related links
 
 [Get-EntraFeatureRolloutPolicy](Get-EntraFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraGroup.md
@@ -335,7 +335,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroup](Get-EntraGroup.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraGroupAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraGroupAppRoleAssignment.md
@@ -140,7 +140,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroupAppRoleAssignment](Get-EntraGroupAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraGroupLifecyclePolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraGroupLifecyclePolicy.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroupLifecyclePolicy](Get-EntraGroupLifecyclePolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraIdentityProvider.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraIdentityProvider.md
@@ -160,6 +160,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraIdentityProvider](Remove-EntraIdentityProvider.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraInvitation.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraInvitation.md
@@ -288,4 +288,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - See more information - <https://learn.microsoft.com/graph/api/invitation-post>.
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraNamedLocationPolicy.md
@@ -220,7 +220,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For more information, see [Create namedLocation](/graph/api/conditionalaccessroot-post-namedlocations).
 
-## Related Links
+## Related links
 
 [Get-EntraNamedLocationPolicy](Get-EntraNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraPermissionGrantConditionSet.md
@@ -349,7 +349,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraPermissionGrantConditionSet](Set-EntraPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraPermissionGrantPolicy.md
@@ -118,7 +118,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraPermissionGrantPolicy](Get-EntraPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraPolicy.md
@@ -223,7 +223,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraPolicy](Get-EntraPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipal.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipal.md
@@ -388,7 +388,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipalAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipalAppRoleAssignment.md
@@ -219,7 +219,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `New-EntraServiceAppRoleAssignment` is an alias for `New-EntraServicePrincipalAppRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalAppRoleAssignment](Get-EntraServicePrincipalAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipalKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipalKeyCredential.md
@@ -175,7 +175,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalKeyCredential](Get-EntraServicePrincipalKeyCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipalPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraServicePrincipalPasswordCredential.md
@@ -153,7 +153,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalPasswordCredential](Get-EntraServicePrincipalPasswordCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraTrustedCertificateAuthority.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraTrustedCertificateAuthority](Get-EntraTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraUser.md
@@ -806,7 +806,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraUserAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/New-EntraUserAppRoleAssignment.md
@@ -201,7 +201,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUserAppRoleAssignment](Get-EntraUserAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraAdministrativeUnit.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraAdministrativeUnit.md
@@ -78,7 +78,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraAdministrativeUnit](New-EntraAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraAdministrativeUnitMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraAdministrativeUnitMember.md
@@ -96,7 +96,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraAdministrativeUnitMember](Add-EntraAdministrativeUnitMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplication.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationExtensionProperty.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationExtensionProperty.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplicationExtensionProperty](Get-EntraApplicationExtensionProperty.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationKey.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationKey.md
@@ -122,6 +122,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraApplicationKey](New-EntraApplicationKey.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationKeyCredential.md
@@ -96,7 +96,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplicationKeyCredential](Get-EntraApplicationKeyCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationOwner.md
@@ -96,7 +96,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraApplicationOwner](Add-EntraApplicationOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationPassword.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationPassword.md
@@ -97,6 +97,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraApplicationPassword](New-EntraApplicationPassword.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationPasswordCredential.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationVerifiedPublisher.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraApplicationVerifiedPublisher.md
@@ -78,6 +78,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Set-EntraApplicationVerifiedPublisher](Set-EntraApplicationVerifiedPublisher.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraConditionalAccessPolicy.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraConditionalAccessPolicy](Get-EntraConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraContact.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraContact.md
@@ -74,6 +74,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraContact](Get-EntraContact.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeletedApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeletedApplication.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDeletedApplication](Get-EntraDeletedApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeletedDirectoryObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeletedDirectoryObject.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDeletedDirectoryObject](Get-EntraDeletedDirectoryObject.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDevice.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDevice.md
@@ -80,7 +80,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDevice](Get-EntraDevice.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeviceRegisteredOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeviceRegisteredOwner.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraDeviceRegisteredOwner](Add-EntraDeviceRegisteredOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeviceRegisteredUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDeviceRegisteredUser.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraDeviceRegisteredUser](Add-EntraDeviceRegisteredUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDirectoryRoleAssignment.md
@@ -88,7 +88,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Remove-EntraRoleAssignment` is an alias for `Remove-EntraDirectoryRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRoleAssignment](Get-EntraDirectoryRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDirectoryRoleDefinition.md
@@ -89,7 +89,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Remove-EntraRoleDefinition` is an alias for `Remove-EntraDirectoryRoleDefintion`.
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRoleDefinition](Get-EntraDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDirectoryRoleMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDirectoryRoleMember.md
@@ -99,7 +99,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraDirectoryRoleMember](Add-EntraDirectoryRoleMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDomain.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraDomain.md
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraDomain](Confirm-EntraDomain.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraExternalDomainFederation.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraExternalDomainFederation.md
@@ -76,4 +76,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraFeatureRolloutPolicy.md
@@ -78,7 +78,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraFeatureRolloutPolicy](New-EntraFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraFeatureRolloutPolicyDirectoryObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraFeatureRolloutPolicyDirectoryObject.md
@@ -102,4 +102,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraGroup.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroup](Get-EntraGroup.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraGroupAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraGroupAppRoleAssignment.md
@@ -93,7 +93,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroupAppRoleAssignment](Get-EntraGroupAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraGroupMember.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraGroupMember.md
@@ -96,7 +96,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraGroupMember](Add-EntraGroupMember.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraIdentityProvider.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraIdentityProvider.md
@@ -85,6 +85,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraIdentityProvider](New-EntraIdentityProvider.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraLifecyclePolicyGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraLifecyclePolicyGroup.md
@@ -106,7 +106,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraLifecyclePolicyGroup](Get-EntraLifecyclePolicyGroup.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraNamedLocationPolicy.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraNamedLocationPolicy](New-EntraNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraOAuth2PermissionGrant.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraOAuth2PermissionGrant.md
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraOAuth2PermissionGrant](Get-EntraOAuth2PermissionGrant.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraPermissionGrantConditionSet.md
@@ -115,7 +115,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPermissionGrantConditionSet](New-EntraPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraPermissionGrantPolicy.md
@@ -76,7 +76,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPermissionGrantPolicy](New-EntraPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraPolicy.md
@@ -75,7 +75,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraPolicy](Get-EntraPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraScopedRoleMembership.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraScopedRoleMembership.md
@@ -97,7 +97,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraScopedRoleMembership](Add-EntraScopedRoleMembership.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipal.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipal.md
@@ -76,7 +76,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalAppRoleAssignment.md
@@ -112,7 +112,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Remove-EntraServiceAppRoleAssignment` is an alias for `Remove-EntraServicePrincipalAppRoleAssignment`.
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalAppRoleAssignment](Get-EntraServicePrincipalAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalDelegatedPermissionClassification.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalDelegatedPermissionClassification.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalDelegatedPermissionClassification](Get-EntraServicePrincipalDelegatedPermissionClassification.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalKeyCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalKeyCredential.md
@@ -92,7 +92,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalKeyCredential](Get-EntraServicePrincipalKeyCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalOwner.md
@@ -96,7 +96,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Add-EntraServicePrincipalOwner](Add-EntraServicePrincipalOwner.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalPasswordCredential.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraServicePrincipalPasswordCredential.md
@@ -95,7 +95,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipalPasswordCredential](Get-EntraServicePrincipalPasswordCredential.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraTrustedCertificateAuthority.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraTrustedCertificateAuthority](Get-EntraTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraUser.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraUser.md
@@ -87,7 +87,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraUserAppRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraUserAppRoleAssignment.md
@@ -108,7 +108,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUserAppRoleAssignment](Get-EntraUserAppRoleAssignment.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraUserExtension.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Remove-EntraUserExtension.md
@@ -120,7 +120,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUserExtension](Get-EntraUserExtension.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Reset-EntraLifeCycleGroup.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Reset-EntraLifeCycleGroup.md
@@ -82,4 +82,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Reset-EntraStrongAuthenticationMethodByUpn.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Reset-EntraStrongAuthenticationMethodByUpn.md
@@ -76,4 +76,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Restore-EntraDeletedApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Restore-EntraDeletedApplication.md
@@ -112,7 +112,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraDeletedApplication](Remove-EntraDeletedApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Restore-EntraDeletedDirectoryObject.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Restore-EntraDeletedDirectoryObject.md
@@ -141,7 +141,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraDeletedApplication](Remove-EntraDeletedApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Revoke-EntraSignedInUserAllRefreshToken.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Revoke-EntraSignedInUserAllRefreshToken.md
@@ -68,6 +68,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Revoke-EntraUserAllRefreshToken](Revoke-EntraUserAllRefreshToken.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Revoke-EntraUserAllRefreshToken.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Revoke-EntraUserAllRefreshToken.md
@@ -85,6 +85,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Revoke-EntraSignedInUserAllRefreshToken](Revoke-EntraSignedInUserAllRefreshToken.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsContactIsMemberOf.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsContactIsMemberOf.md
@@ -96,6 +96,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraContact](Get-EntraContact.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsGroupIsMemberOf.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsGroupIsMemberOf.md
@@ -96,6 +96,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroup](Get-EntraGroup.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsServicePrincipalIsMemberOf.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsServicePrincipalIsMemberOf.md
@@ -101,4 +101,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsUserIsMemberOf.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Select-EntraGroupIdsUserIsMemberOf.md
@@ -101,6 +101,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroup](Get-EntraGroup.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraAdministrativeUnit.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraAdministrativeUnit.md
@@ -116,7 +116,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraAdministrativeUnit](Get-EntraAdministrativeUnit.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplication.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplication.md
@@ -475,7 +475,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraApplication](Get-EntraApplication.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplicationLogo.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplicationLogo.md
@@ -117,6 +117,6 @@ System.IO.Stream System.Byte\[\]
 
 File uploads must be smaller than 500KB.
 
-## Related Links
+## Related links
 
 [Get-EntraApplicationLogo](Get-EntraApplicationLogo.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplicationVerifiedPublisher.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraApplicationVerifiedPublisher.md
@@ -101,6 +101,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Remove-EntraApplicationVerifiedPublisher](Remove-EntraApplicationVerifiedPublisher.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraAttributeSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraAttributeSet.md
@@ -130,7 +130,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraAttributeSet](New-EntraAttributeSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraAuthorizationPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraAuthorizationPolicy.md
@@ -238,6 +238,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraAuthorizationPolicy](Get-EntraAuthorizationPolicy.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraConditionalAccessPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraConditionalAccessPolicy.md
@@ -227,7 +227,7 @@ Learn more about:
 [Conditions](https://learn.microsoft.com/graph/api/resources/conditionalaccessconditionset)
 [Session controls](https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols)
 
-## Related Links
+## Related links
 
 [Get-EntraConditionalAccessPolicy](Get-EntraConditionalAccessPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraCustomSecurityAttributeDefinition.md
@@ -139,7 +139,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraCustomSecurityAttributeDefinition](Get-EntraCustomSecurityAttributeDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.md
@@ -119,7 +119,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraCustomSecurityAttributeDefinitionAllowedValue](Get-EntraCustomSecurityAttributeDefinitionAllowedValue.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDevice.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDevice.md
@@ -386,7 +386,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDevice](Get-EntraDevice.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncConfiguration.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncConfiguration.md
@@ -139,6 +139,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For additional details see [Update onPremisesDirectorySynchronization](https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update).
 
-## Related Links
+## Related links
 
 [Get-EntraDirSyncConfiguration](Get-EntraDirSyncConfiguration.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncEnabled.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncEnabled.md
@@ -137,4 +137,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirSyncFeature.md
@@ -182,6 +182,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 - For additional details see [Update onPremisesDirectorySynchronization](https://learn.microsoft.com/graph/api/onpremisesdirectorysynchronization-update).
 - For the feature list see the [onPremisesDirectorySynchronizationFeature resource type](https://learn.microsoft.com/graph/api/resources/onpremisesdirectorysynchronizationfeature).
 
-## Related Links
+## Related links
 
 [Get-EntraDirSyncFeature](Get-EntraDirSyncFeature.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirectoryRoleDefinition.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDirectoryRoleDefinition.md
@@ -263,7 +263,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 `Set-EntraRoleDefinition` is an alias for `Set-EntraDirectoryRoleDefintion`.
 
-## Related Links
+## Related links
 
 [Get-EntraDirectoryRoleDefinition](Get-EntraDirectoryRoleDefinition.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDomain.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDomain.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Confirm-EntraDomain](Confirm-EntraDomain.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDomainFederationSettings.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraDomainFederationSettings.md
@@ -282,6 +282,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraDomainFederationSettings](Get-EntraDomainFederationSettings.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraFeatureRolloutPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraFeatureRolloutPolicy.md
@@ -222,7 +222,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 See more details - <https://learn.microsoft.com/graph/api/resources/featurerolloutpolicy>
 
-## Related Links
+## Related links
 
 [New-EntraFeatureRolloutPolicy](New-EntraFeatureRolloutPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraGroupLifecyclePolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraGroupLifecyclePolicy.md
@@ -145,7 +145,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraGroupLifecyclePolicy](Get-EntraGroupLifecyclePolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraIdentityProvider.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraIdentityProvider.md
@@ -180,7 +180,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraIdentityProvider](New-EntraIdentityProvider.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraNamedLocationPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraNamedLocationPolicy.md
@@ -240,7 +240,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraNamedLocationPolicy](Get-EntraNamedLocationPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPartnerInformation.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPartnerInformation.md
@@ -233,6 +233,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraPartnerInformation](Get-EntraPartnerInformation.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPermissionGrantConditionSet.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPermissionGrantConditionSet.md
@@ -295,7 +295,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPermissionGrantConditionSet](New-EntraPermissionGrantConditionSet.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPermissionGrantPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPermissionGrantPolicy.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [New-EntraPermissionGrantPolicy](New-EntraPermissionGrantPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPolicy.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraPolicy.md
@@ -190,7 +190,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraPolicy](Get-EntraPolicy.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraServicePrincipal.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraServicePrincipal.md
@@ -406,7 +406,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraServicePrincipal](Get-EntraServicePrincipal.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTenantDetail.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTenantDetail.md
@@ -211,6 +211,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For more details see [Update organization](https://learn.microsoft.com/graph/api/organization-update).
 
-## Related Links
+## Related links
 
 [Get-EntraTenantDetail](Get-EntraTenantDetail.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTrustedCertificateAuthority.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraTrustedCertificateAuthority.md
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraTrustedCertificateAuthority](Get-EntraTrustedCertificateAuthority.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserExtension.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserExtension.md
@@ -79,7 +79,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserLicense.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserLicense.md
@@ -238,6 +238,6 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUser](Get-EntraUser.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserPassword.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserPassword.md
@@ -161,4 +161,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserThumbnailPhoto.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Set-EntraUserThumbnailPhoto.md
@@ -121,6 +121,6 @@ System.IO.Stream System.Byte\[\]
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraUserThumbnailPhoto](Get-EntraUserThumbnailPhoto.md)

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Test-EntraScript.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Test-EntraScript.md
@@ -117,4 +117,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraOauth2PermissionGrant.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraOauth2PermissionGrant.md
@@ -119,7 +119,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 ## Notes
 
-## Related Links
+## Related links
 
 [Get-EntraOauth2PermissionGrant](Get-EntraOauth2PermissionGrant.md)
 

--- a/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraUserFromFederated.md
+++ b/module/docs/entra-powershell-v1.0/Microsoft.Graph.Entra/Update-EntraUserFromFederated.md
@@ -102,4 +102,4 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 
 - For more information, see [resetPassword](https://learn.microsoft.com/graph/api/authenticationmethod-resetpassword).
 
-## Related Links
+## Related links

--- a/module/docs/future/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRoleAssignmentRequest.md
+++ b/module/docs/future/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivilegedRoleAssignmentRequest.md
@@ -143,4 +143,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/future/Microsoft.Graph.Entra/Get-EntraApplicationProxyApplicationConnectorGroup.md
+++ b/module/docs/future/Microsoft.Graph.Entra/Get-EntraApplicationProxyApplicationConnectorGroup.md
@@ -74,4 +74,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/future/Microsoft.Graph.Entra/Get-EntraApplicationProxyConnectorMemberOf.md
+++ b/module/docs/future/Microsoft.Graph.Entra/Get-EntraApplicationProxyConnectorMemberOf.md
@@ -77,4 +77,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/future/Microsoft.Graph.Entra/New-EntraApplicationProxyConnectorGroup.md
+++ b/module/docs/future/Microsoft.Graph.Entra/New-EntraApplicationProxyConnectorGroup.md
@@ -74,4 +74,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links

--- a/module/docs/future/Microsoft.Graph.Entra/Remove-EntraApplicationProxyApplicationConnectorGroup.md
+++ b/module/docs/future/Microsoft.Graph.Entra/Remove-EntraApplicationProxyApplicationConnectorGroup.md
@@ -68,6 +68,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## Notes
 
-## Related Links
+## Related links
 
 

--- a/module/docs/future/Microsoft.Graph.Entra/Remove-EntraApplicationProxyConnectorGroup.md
+++ b/module/docs/future/Microsoft.Graph.Entra/Remove-EntraApplicationProxyConnectorGroup.md
@@ -71,4 +71,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Object
 ## Notes
 
-## Related Links
+## Related links


### PR DESCRIPTION
This pull request standardizes the capitalization of the "Related Links" section headers across multiple PowerShell cmdlet documentation files in the `module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta` directory. The change ensures consistency by updating "Related Links" to "Related links" throughout the documentation.

### Documentation Updates:

* Standardized the capitalization of the "Related Links" section header to "Related links" in the following files:
