### PR TITLE
Fix New-EntraBetaPrivateAccessApplication cmdletbinding

### DIFF
--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.ps1
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------ 
 function New-EntraBetaPrivateAccessApplicationSegment {
 
-    [CmdletBinding(ParameterSetName = 'Default')]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Alias('ObjectId')]
         [Parameter(Mandatory = $True, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]


### PR DESCRIPTION
The CmdletBinding line for New-EntraBetaPrivateAccessApplicationSegment appears to be misconfigured, resulting in an error upon running the cmdlet.

Fixes #1494 