### PR TITLE
AppendSelected parameter

### DIFF
--- a/module/Entra/Microsoft.Entra/Applications/Get-EntraServicePrincipalOwner.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Get-EntraServicePrincipalOwner.ps1
@@ -5,7 +5,7 @@
 function Get-EntraServicePrincipalOwner {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (
-        [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The number of items to return in the response.")]
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The number of items to return in the response.")]
         [Alias("Limit")]
         [System.Nullable`1[System.Int32]] $Top,
 
@@ -17,9 +17,13 @@ function Get-EntraServicePrincipalOwner {
         [ValidateNotNullOrEmpty()]
         [System.String] $ServicePrincipalId,
 
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery",Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "Append",Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -31,9 +35,10 @@ function Get-EntraServicePrincipalOwner {
         }
     }
 
-    PROCESS {    
+    PROCESS {
         $params = @{}
-        $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand        
+        $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,accountEnabled"
         if ($PSBoundParameters.ContainsKey("Verbose")) {
             $params["Verbose"] = $PSBoundParameters["Verbose"]
         }
@@ -78,8 +83,11 @@ function Get-EntraServicePrincipalOwner {
         if ($null -ne $PSBoundParameters["WarningAction"]) {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/Entra/Microsoft.Entra/Applications/Get-EntraServicePrincipalOwner.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Get-EntraServicePrincipalOwner.ps1
@@ -39,6 +39,7 @@ function Get-EntraServicePrincipalOwner {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,accountEnabled"
+
         if ($PSBoundParameters.ContainsKey("Verbose")) {
             $params["Verbose"] = $PSBoundParameters["Verbose"]
         }

--- a/module/Entra/Microsoft.Entra/Applications/Get-EntraServicePrincipalOwner.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Get-EntraServicePrincipalOwner.ps1
@@ -85,10 +85,10 @@ function Get-EntraServicePrincipalOwner {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
@@ -25,7 +25,9 @@ function Get-EntraGroup {
 
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [switch] $AppendSelected
     )
 
     begin {
@@ -41,6 +43,7 @@ function Get-EntraGroup {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $keysChanged = @{SearchString = "Filter"; ObjectId = "Id" }
+        $defaultProperties = "id,displayName,createdDateTime,createdDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description"
         if ($null -ne $PSBoundParameters["OutVariable"]) {
             $params["OutVariable"] = $PSBoundParameters["OutVariable"]
         }
@@ -101,8 +104,11 @@ function Get-EntraGroup {
         if ($null -ne $PSBoundParameters["ProgressAction"]) {
             $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
 
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------ 
 function Get-EntraGroup {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
-    param (                
+    param (
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
         [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
         [Alias("Limit")]
@@ -21,7 +21,7 @@ function Get-EntraGroup {
         [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Search for a group by its name, email, or mail nickname.")]
         [System.String] $SearchString,
         
-        [Alias('ObjectId')]            
+        [Alias('ObjectId')]
         [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The ID of the group to retrieve. Should be a valid GUID value.")]
         [Parameter(ParameterSetName = "Append", Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The ID of the group to retrieve. Should be a valid GUID value.")]
         [ValidateNotNullOrEmpty()]

--- a/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
@@ -6,27 +6,35 @@ function Get-EntraGroup {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (                
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
         [Alias("Limit")]
         [System.Nullable`1[System.Int32]] $Top,
                 
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter the results based on the specified criteria.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter the results based on the specified criteria.")]
         [System.String] $Filter,
                 
         [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Specifies whether to return all objects.")]
         [switch] $All,
                 
         [Parameter(ParameterSetName = "GetVague", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Search for a group by its name, email, or mail nickname.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Search for a group by its name, email, or mail nickname.")]
         [System.String] $SearchString,
         
         [Alias('ObjectId')]            
         [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The ID of the group to retrieve. Should be a valid GUID value.")]
+        [Parameter(ParameterSetName = "Append", Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The ID of the group to retrieve. Should be a valid GUID value.")]
         [ValidateNotNullOrEmpty()]
         [Guid] $GroupId,
 
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetVague", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetById", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
         [System.String[]] $Property,
 
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
         [switch] $AppendSelected
     )
 
@@ -43,7 +51,7 @@ function Get-EntraGroup {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $keysChanged = @{SearchString = "Filter"; ObjectId = "Id" }
-        $defaultProperties = "id,displayName,createdDateTime,createdDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description"
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description"
         if ($null -ne $PSBoundParameters["OutVariable"]) {
             $params["OutVariable"] = $PSBoundParameters["OutVariable"]
         }

--- a/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Groups/Get-EntraGroup.ps1
@@ -113,10 +113,10 @@ function Get-EntraGroup {
             $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
 
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/Entra/Microsoft.Entra/Users/Get-EntraUserGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Get-EntraUserGroup.ps1
@@ -114,10 +114,10 @@ function Get-EntraUserGroup {
             $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
 
         # Debug logging for transformations

--- a/module/Entra/Microsoft.Entra/Users/Get-EntraUserGroup.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Get-EntraUserGroup.ps1
@@ -6,9 +6,11 @@ function Get-EntraUserGroup {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter to apply to the query.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter to apply to the query.")]
         [System.String] $Filter,
 
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Retrieve all user's group memberships.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Retrieve all user's group memberships.")]
         [switch] $All,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "User object ID or UPN to retrieve.")]
@@ -24,16 +26,21 @@ function Get-EntraUserGroup {
         [System.String] $UserId,
 
         [Alias('DirectoryObjectId')]
-        [Parameter(ParameterSetName = "GetById", Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Group object ID to retrieve.")]
+        [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Group object ID to retrieve.")]
         [System.String] $GroupId,
 
         [Alias('Limit')]
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Maximum number of results to return.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Maximum number of results to return.")]
         [System.Nullable`1[System.Int32]] $Top,
 
         [Alias('Select')]
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
-        [System.String[]] $Property
+        [Parameter(ParameterSetName = "Append",Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery",Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -49,6 +56,7 @@ function Get-EntraUserGroup {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $keysChanged = @{ SearchString = "Filter" }
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description"
 
         if ($null -ne $PSBoundParameters["ErrorAction"]) {
             $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
@@ -105,8 +113,11 @@ function Get-EntraUserGroup {
         if ($null -ne $PSBoundParameters["InformationVariable"]) {
             $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
 
         # Debug logging for transformations

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaApplicationOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaApplicationOwner.ps1
@@ -13,13 +13,17 @@ function Get-EntraBetaApplicationOwner {
         [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Get all owners of the application.")]
         [switch] $All,
 
-        [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The number of items to return.")]
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The number of items to return.")]
         [Alias("Limit")]
         [System.Nullable`1[System.Int32]] $Top,
 
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery",Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "Append",Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -34,6 +38,7 @@ function Get-EntraBetaApplicationOwner {
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,accountEnabled"
         
         if ($PSBoundParameters.ContainsKey("Verbose")) {
             $params["Verbose"] = $PSBoundParameters["Verbose"]
@@ -79,8 +84,11 @@ function Get-EntraBetaApplicationOwner {
         if ($null -ne $PSBoundParameters["WarningAction"]) {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaApplicationOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaApplicationOwner.ps1
@@ -85,10 +85,10 @@ function Get-EntraBetaApplicationOwner {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaServicePrincipalOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaServicePrincipalOwner.ps1
@@ -55,10 +55,10 @@ function Get-EntraBetaServicePrincipalOwner {
             $params["Top"] = $PSBoundParameters["Top"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
 
         # Add common parameters if they exist

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaServicePrincipalOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaServicePrincipalOwner.ps1
@@ -5,7 +5,7 @@
 function Get-EntraBetaServicePrincipalOwner {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (
-        [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The number of items to return in the response.")]
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The number of items to return in the response.")]
         [Alias("Limit")]
         [System.Nullable`1[System.Int32]] $Top,
 
@@ -17,9 +17,13 @@ function Get-EntraBetaServicePrincipalOwner {
         [ValidateNotNullOrEmpty()]
         [System.String] $ServicePrincipalId,
 
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery",Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "Append",Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -34,6 +38,7 @@ function Get-EntraBetaServicePrincipalOwner {
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,accountEnabled"
 
         if ($null -ne $PSBoundParameters["ServicePrincipalId"]) {
             $params["ServicePrincipalId"] = $PSBoundParameters["ServicePrincipalId"]
@@ -49,9 +54,13 @@ function Get-EntraBetaServicePrincipalOwner {
         if ($PSBoundParameters.ContainsKey("Top")) {
             $params["Top"] = $PSBoundParameters["Top"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
         }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
+        }
+
         # Add common parameters if they exist
         $commonParams = @("WarningVariable", "InformationVariable", "InformationAction", "OutVariable", "OutBuffer", "ErrorVariable", "PipelineVariable", "ErrorAction", "WarningAction")
         foreach ($param in $commonParams) {

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroup.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroup.ps1
@@ -113,10 +113,10 @@ function Get-EntraBetaGroup {
             $params["Top"] = $PSBoundParameters["Top"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
 
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroup.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroup.ps1
@@ -5,28 +5,37 @@
 function Get-EntraBetaGroup {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (
-                
-        [Parameter(ParameterSetName = "GetVague", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Search for groups by name, email, or mail nickname.")]
-        [System.String] $SearchString,
-                
-        [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter the results based on the specified criteria.")]
-        [System.String] $Filter,
-
-        [Alias('ObjectId')]            
-        [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Unique ID of the group. Should be a valid GUID value.")]
-        [ValidateNotNullOrEmpty()]
-        [Guid] $GroupId,
-                
-        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Specifies whether to return all object items.")]
-        [switch] $All,
-                
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
         [Alias("Limit")]
         [System.Nullable`1[System.Int32]] $Top,
+                
+        [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter the results based on the specified criteria.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter the results based on the specified criteria.")]
+        [System.String] $Filter,
+                
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Specifies whether to return all objects.")]
+        [switch] $All,
+                
+        [Parameter(ParameterSetName = "GetVague", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Search for a group by its name, email, or mail nickname.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Search for a group by its name, email, or mail nickname.")]
+        [System.String] $SearchString,
         
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Alias('ObjectId')]
+        [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The ID of the group to retrieve. Should be a valid GUID value.")]
+        [Parameter(ParameterSetName = "Append", Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The ID of the group to retrieve. Should be a valid GUID value.")]
+        [ValidateNotNullOrEmpty()]
+        [Guid] $GroupId,
+
+        [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetVague", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetById", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -42,6 +51,7 @@ function Get-EntraBetaGroup {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
         $keysChanged = @{SearchString = "Filter"; ObjectId = "Id" }
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description"
         if ($null -ne $PSBoundParameters["ProgressAction"]) {
             $params["ProgressAction"] = $PSBoundParameters["ProgressAction"]
         }
@@ -102,8 +112,11 @@ function Get-EntraBetaGroup {
         if ($PSBoundParameters.ContainsKey("Top")) {
             $params["Top"] = $PSBoundParameters["Top"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
 
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroupMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroupMember.ps1
@@ -5,7 +5,7 @@
 function Get-EntraBetaGroupMember {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (
-        [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "The maximum number of items to return.")]
         [Alias("Limit")]
         [System.Nullable`1[System.Int32]] $Top,
 
@@ -17,9 +17,13 @@ function Get-EntraBetaGroupMember {
         [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Return all members of the group.")]
         [switch] $All,
 
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "The properties to include in the response.")]
+        [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "The properties to include in the response.")]
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "The properties to include in the response.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -31,9 +35,10 @@ function Get-EntraBetaGroupMember {
         }
     }
     
-    PROCESS {    
+    PROCESS {
         $params = @{}
-        $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand        
+        $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
+        $defaultProperties = "id,displayName,userPrincipalName,mail,mailNickName,createdDateTime,deletedDateTime,givenName,surname,usageLocation,accountEnabled"
 
         if ($null -ne $PSBoundParameters["GroupId"]) {
             $params["GroupId"] = $PSBoundParameters["GroupId"]
@@ -79,8 +84,11 @@ function Get-EntraBetaGroupMember {
         if ($null -ne $PSBoundParameters["WarningAction"]) {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroupMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Groups/Get-EntraBetaGroupMember.ps1
@@ -85,10 +85,10 @@ function Get-EntraBetaGroupMember {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserGroup.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserGroup.ps1
@@ -114,10 +114,10 @@ function Get-EntraBetaUserGroup {
             $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
 
         # Debug logging for transformations

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserGroup.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserGroup.ps1
@@ -6,9 +6,11 @@ function Get-EntraBetaUserGroup {
     [CmdletBinding(DefaultParameterSetName = 'GetQuery')]
     param (
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter to apply to the query.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Filter to apply to the query.")]
         [System.String] $Filter,
 
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Retrieve all user's group memberships.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Retrieve all user's group memberships.")]
         [switch] $All,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "User object ID or UPN to retrieve.")]
@@ -24,16 +26,21 @@ function Get-EntraBetaUserGroup {
         [System.String] $UserId,
 
         [Alias('DirectoryObjectId')]
-        [Parameter(ParameterSetName = "GetById", Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Group object ID to retrieve.")]
+        [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Group object ID to retrieve.")]
         [System.String] $GroupId,
 
         [Alias('Limit')]
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Maximum number of results to return.")]
+        [Parameter(ParameterSetName = "Append", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Maximum number of results to return.")]
         [System.Nullable`1[System.Int32]] $Top,
 
         [Alias('Select')]
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
-        [System.String[]] $Property
+        [Parameter(ParameterSetName = "Append",Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery",Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -49,6 +56,7 @@ function Get-EntraBetaUserGroup {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
         $keysChanged = @{ SearchString = "Filter" }
+        $defaultProperties = "id,displayName,createdDateTime,deletedDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description"
 
         if ($null -ne $PSBoundParameters["ErrorAction"]) {
             $params["ErrorAction"] = $PSBoundParameters["ErrorAction"]
@@ -105,8 +113,11 @@ function Get-EntraBetaUserGroup {
         if ($null -ne $PSBoundParameters["InformationVariable"]) {
             $params["InformationVariable"] = $PSBoundParameters["InformationVariable"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
 
         # Debug logging for transformations

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
@@ -77,10 +77,10 @@ function Get-EntraBetaUserManager {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
         if ($null -ne $Property -and $Property.Count -gt 0) {
-            $params["Property"] = $Property
+            $params["Property"] = $Property -join ','
         }
         if ($PSBoundParameters.ContainsKey("AppendSelected")) {
-            $params["Property"] = $defaultProperties + "," + $params["Property"]
+            $params["Property"] = $defaultProperties + "," + ($Property -join ',')
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
@@ -92,12 +92,15 @@ function Get-EntraBetaUserManager {
             
             $targetList = @()
             foreach ($res in $data) {
+                $orderedDictionary = $res.AdditionalProperties | ConvertTo-Json | ConvertFrom-Json -AsHashtable
+                Add-Member -InputObject $res -NotePropertyMembers $orderedDictionary
                 $targetType = New-Object Microsoft.Graph.Beta.PowerShell.Models.MicrosoftGraphDirectoryObject
                 $res.PSObject.Properties | ForEach-Object {
                     $propertyName = $_.Name.Substring(0, 1).ToUpper() + $_.Name.Substring(1)
                     $propertyValue = $_.Value
                     $targetType | Add-Member -MemberType NoteProperty -Name $propertyName -Value $propertyValue -Force
                 }
+                #$targetType | Add-Member -InputObject $_ -NotePropertyMembers $res.AdditionalProperties
                 $targetList += $targetType
             }
             $targetList   

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
@@ -17,9 +17,13 @@ function Get-EntraBetaUserManager {
             })]
         [System.String] $UserId,
         
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Properties to include in the results.")]
         [Alias("Select")]
-        [System.String[]] $Property
+        [System.String[]] $Property,
+
+        [Parameter(ParameterSetName = "Append", Mandatory = $true, HelpMessage = "Specifies whether to append the selected properties.")]
+        [switch] $AppendSelected
     )
 
     begin {
@@ -34,6 +38,7 @@ function Get-EntraBetaUserManager {
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
+        $defaultProperties = "id,displayName,userPrincipalName,mail,mailNickName,createdDateTime,deletedDateTime,givenName,surname,usageLocation,accountEnabled"
         
         if ($PSBoundParameters.ContainsKey("Verbose")) {
             $params["Verbose"] = $PSBoundParameters["Verbose"]
@@ -71,8 +76,11 @@ function Get-EntraBetaUserManager {
         if ($null -ne $PSBoundParameters["WarningAction"]) {
             $params["WarningAction"] = $PSBoundParameters["WarningAction"]
         }
-        if ($null -ne $PSBoundParameters["Property"]) {
-            $params["Property"] = $PSBoundParameters["Property"]
+        if ($null -ne $Property -and $Property.Count -gt 0) {
+            $params["Property"] = $Property
+        }
+        if ($PSBoundParameters.ContainsKey("AppendSelected")) {
+            $params["Property"] = $defaultProperties + "," + $params["Property"]
         }
     
         Write-Debug("============================ TRANSFORMATIONS ============================")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserManager.ps1
@@ -100,7 +100,6 @@ function Get-EntraBetaUserManager {
                     $propertyValue = $_.Value
                     $targetType | Add-Member -MemberType NoteProperty -Name $propertyName -Value $propertyValue -Force
                 }
-                #$targetType | Add-Member -InputObject $_ -NotePropertyMembers $res.AdditionalProperties
                 $targetList += $targetType
             }
             $targetList   

--- a/module/docs/entra-powershell-beta/Applications/Get-EntraBetaApplicationOwner.md
+++ b/module/docs/entra-powershell-beta/Applications/Get-EntraBetaApplicationOwner.md
@@ -35,7 +35,7 @@ Get-EntraBetaApplicationOwner
 ### Append
 
 ```powershell
-Get-EntraGroup
+Get-EntraBetaApplicationOwner
  -ApplicationId <String>
  -Property <String[]>
  -AppendSelected

--- a/module/docs/entra-powershell-beta/Applications/Get-EntraBetaApplicationOwner.md
+++ b/module/docs/entra-powershell-beta/Applications/Get-EntraBetaApplicationOwner.md
@@ -118,7 +118,7 @@ This example demonstrates how to get the two owners of a specified application i
 ```powershell
 Connect-Entra -Scopes 'Application.Read.All'
 $application = Get-EntraBetaApplication -Filter "DisplayName eq 'Helpdesk Application'"
-Get-EntraBetaApplicationOwner -ApplicationId $application.Id -Property OnPremisesImmutableId -AppendSelected -Top 2 | Select-Object Id, userPrincipalName, DisplayName, '@odata.type', OnPremisesImmutableId
+Get-EntraBetaApplicationOwner -ApplicationId $application.Id -Property onPremisesImmutableId -AppendSelected -Top 2 | Select-Object Id, userPrincipalName, DisplayName, '@odata.type', OnPremisesImmutableId
 ```
 
 ```Output

--- a/module/docs/entra-powershell-beta/Applications/Get-EntraBetaApplicationOwner.md
+++ b/module/docs/entra-powershell-beta/Applications/Get-EntraBetaApplicationOwner.md
@@ -21,12 +21,26 @@ Gets the owner of an application.
 
 ## SYNTAX
 
+### GetQuery (Default)
+
 ```powershell
 Get-EntraBetaApplicationOwner
  -ApplicationId <String>
  [-Top <Int32>]
  [-All]
  [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraGroup
+ -ApplicationId <String>
+ -Property <String[]>
+ -AppendSelected
+ [-Top <Int32>]
+ [-All]
  [<CommonParameters>]
 ```
 
@@ -99,6 +113,27 @@ This example demonstrates how to get the two owners of a specified application i
 
 - `-ApplicationId` parameter specifies the unique identifier of an application.
 
+### Example 4: Retrieve top two owners of a service principal and select and append a property not returned by default.
+
+```powershell
+Connect-Entra -Scopes 'Application.Read.All'
+$application = Get-EntraBetaApplication -Filter "DisplayName eq 'Helpdesk Application'"
+Get-EntraBetaApplicationOwner -ApplicationId $application.Id -Property OnPremisesImmutableId -AppendSelected -Top 2 | Select-Object Id, userPrincipalName, DisplayName, '@odata.type', OnPremisesImmutableId
+```
+
+```Output
+Id                                   userPrincipalName          @odata.type              OnPremisesImmutableId
+--                                   -----------                -----------              ---------
+aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb AdeleV@contoso.com         #microsoft.graph.user    hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq
+bbbbbbbb-1111-2222-3333-cccccccccccc CameronW@contoso.com       #microsoft.graph.user    eeeeeeee-4444-5555-6666-ffffffffffff
+```
+
+This command gets top two owners of an application. You can use the command `Get-EntraBetaApplication` to get application ID. You can use `-Limit` as an alias for `-Top`.
+
+- `-ApplicationId` parameter specifies the unique identifier of an application.
+- `-Property` parameter selects a property `userType` that is not returned by default.
+- `-AppendSelected` parameter ensures the selected property is returned together with default properties.
+
 ## PARAMETERS
 
 ### -All
@@ -161,6 +196,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-beta/Applications/Get-EntraBetaServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-beta/Applications/Get-EntraBetaServicePrincipalOwner.md
@@ -21,12 +21,26 @@ Get the owner of a service principal.
 
 ## SYNTAX
 
+### GetQuery (Default)
+
 ```powershell
-Get-EntraBetaServicePrincipalOwner
+Get-EntraServicePrincipalOwner
  -ServicePrincipalId <String>
  [-All]
  [-Top <Int32>]
  [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraGroup
+ -ServicePrincipalId <String>
+ -Property <String[]
+ -AppendSelected
+ [-Top <Int32>]
+ [-All]
  [<CommonParameters>]
 ```
 
@@ -93,6 +107,27 @@ This command gets top two owners of a service principal. You can use the command
 
 - `-ServicePrincipalId` parameter specifies the unique identifier of a service principal.
 
+### Example 4: Retrieve top two owners of a service principal and select and append a property not returned by default.
+
+```powershell
+Connect-Entra -Scopes 'Application.Read.All'
+$servicePrincipal = Get-EntraBetaServicePrincipal -Filter "displayName eq 'Helpdesk Application'"
+Get-EntraBetaServicePrincipalOwner -ServicePrincipalId 0a40f8f8-4e30-4f58-bf26-772ad69f41f6 -Property userType -AppendSelected -Top 2 | Select-Object Id, userPrincipalName, DisplayName, '@odata.type', userType
+```
+
+```Output
+Id                                   displayName          @odata.type              userType
+--                                   -----------          -----------              ---------
+aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb Alex Wilber          #microsoft.graph.user    Member
+bbbbbbbb-1111-2222-3333-cccccccccccc Christie Cline       #microsoft.graph.user    Member
+```
+
+This command gets top two owners of a service principal. You can use the command `Get-EntraServicePrincipal` to get service principal object ID. You can use `-Limit` as an alias for `-Top`.
+
+- `-ServicePrincipalId` parameter specifies the unique identifier of a service principal.
+- `-Property` parameter selects a property `userType` that is not returned by default.
+- `-AppendSelected` parameter ensures the selected property is returned together with default properties.
+
 ## PARAMETERS
 
 ### -All
@@ -155,6 +190,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-beta/Applications/Get-EntraBetaServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-beta/Applications/Get-EntraBetaServicePrincipalOwner.md
@@ -24,7 +24,7 @@ Get the owner of a service principal.
 ### GetQuery (Default)
 
 ```powershell
-Get-EntraServicePrincipalOwner
+Get-EntraBetaServicePrincipalOwner
  -ServicePrincipalId <String>
  [-All]
  [-Top <Int32>]
@@ -35,7 +35,7 @@ Get-EntraServicePrincipalOwner
 ### Append
 
 ```powershell
-Get-EntraGroup
+Get-EntraBetaServicePrincipalOwner
  -ServicePrincipalId <String>
  -Property <String[]>
  -AppendSelected

--- a/module/docs/entra-powershell-beta/Applications/Get-EntraBetaServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-beta/Applications/Get-EntraBetaServicePrincipalOwner.md
@@ -37,7 +37,7 @@ Get-EntraServicePrincipalOwner
 ```powershell
 Get-EntraGroup
  -ServicePrincipalId <String>
- -Property <String[]
+ -Property <String[]>
  -AppendSelected
  [-Top <Int32>]
  [-All]

--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
@@ -56,8 +56,8 @@ Get-EntraBetaGroup
 ### Append
 
 ```powershell
-Get-EntraGroup
- -Property <String[]
+Get-EntraBetaGroup
+ -Property <String[]>
  -AppendSelected
  [-GroupId <String>]
  [-Top <Int32>]

--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
@@ -336,7 +336,7 @@ Accept wildcard characters: False
 
 ### -AppendSelected
 
-List all pages.
+Specifies whether to append the selected properties.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
@@ -53,6 +53,20 @@ Get-EntraBetaGroup
  [<CommonParameters>]
 ```
 
+### Append
+
+```powershell
+Get-EntraGroup
+ -Property <String[]
+ -AppendSelected
+ [-GroupId <String>]
+ [-Top <Int32>]
+ [-All]
+ [-Filter <String>]
+ [-SearchString <String>]
+ [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 The `Get-EntraBetaGroup` cmdlet gets a group in Microsoft Entra ID. Specify the `GroupId` parameter to get a specific group.
@@ -205,6 +219,22 @@ bbbbbbbb-5555-5555-0000-qqqqqqqqqqqq HelpDesk admin group      True            {
 
 This example demonstrates how to return only a specific property of a group. You can use `-Select` alias or `-Property`.
 
+### Example 9: Get groups with specific properties and append the selected properties
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All'
+Get-EntraBetaGroup -GroupId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -Property IsSubscribedByMail -AppendSelected | Select-Object Id, DisplayName, MailEnabled, Visibility, IsSubscribedByMail | Format-Table -AutoSize
+```
+
+```Output
+Id                                   DisplayName                MailEnabled Visibility IsSubscribedByMail
+--                                   -----------                --------------- ---------- ----------
+aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb SimpleGroup               False           Public     False
+```
+
+This example demonstrates how to append a selected property to the default properties.
+
+
 ## PARAMETERS
 
 ### -All
@@ -300,6 +330,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+List all pages.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroupMember.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroupMember.md
@@ -38,7 +38,7 @@ Get-EntraBetaGroupMember
 ```powershell
 Get-EntraBetaGroupMember
  -GroupId <String>
- -Property <String[]
+ -Property <String[]>
  -AppendSelected
  [-Top <Int32>]
  [-All]
@@ -155,7 +155,7 @@ This example demonstrates how to retrieve group member by ID.
 ```powershell
 Connect-Entra -Scopes 'GroupMember.Read.All'
 $group = Get-EntraBetaGroup -Filter "DisplayName eq 'Sales and Marketing'"
-Get-EntraBetaGroupMember -GroupId $group.Id -Top 2  -Property OnPremisesImmutableId -AppendSelected | Select-Object Id, DisplayName, '@odata.type', OnPremisesImmutableId
+Get-EntraBetaGroupMember -GroupId $group.Id -Top 2  -Property onPremisesImmutableId -AppendSelected | Select-Object Id, DisplayName, '@odata.type', OnPremisesImmutableId
 ```
 
 ```Output
@@ -233,6 +233,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroupMember.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroupMember.md
@@ -22,12 +22,26 @@ Gets a member of a group.
 
 ## SYNTAX
 
+### GetQuery (Default)
+
 ```powershell
 Get-EntraBetaGroupMember
  -GroupId <String>
  [-Top <Int32>]
  [-All]
  [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraBetaGroupMember
+ -GroupId <String>
+ -Property <String[]
+ -AppendSelected
+ [-Top <Int32>]
+ [-All]
  [<CommonParameters>]
 ```
 
@@ -135,6 +149,27 @@ cccccccc-8888-9999-0000-dddddddddddd Contoso Group     #microsoft.graph.group
 This example demonstrates how to retrieve group member by ID.
 
 - `-GroupId` Specifies the ID of a group.
+
+### Example 5: Retrieve top two members of a group and select and append a property not returned by default.
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All'
+$group = Get-EntraBetaGroup -Filter "DisplayName eq 'Sales and Marketing'"
+Get-EntraBetaGroupMember -GroupId $group.Id -Top 2  -Property onPremImmutableId -AppendSelected | Select-Object Id, DisplayName, '@odata.type', OnPremImmutableId
+```
+
+```Output
+Id                                   DisplayName       @odata.type                 OnPremImmutableId
+------------------------------------ ----------------- ------------------------    ----------------------------
+dddddddd-3333-4444-5555-eeeeeeeeeeee Sawyer Miller     #microsoft.graph.user       eeeeeeee-4444-5555-6666-ffffffffffff
+eeeeeeee-4444-5555-6666-ffffffffffff Alex Wilber       #microsoft.graph.user       aaaaaaaa-6666-7777-8888-bbbbbbbbbbbb
+```
+
+This example demonstrates how to retrieve group member by ID.
+
+- `-GroupId` Specifies the ID of a group.
+- `-Property` parameter selects a property `onPremImmutableId` that is not returned by default.
+- `-AppendSelected` parameter ensures the selected property is returned together with default properties.
 
 ## PARAMETERS
 

--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroupMember.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroupMember.md
@@ -155,11 +155,11 @@ This example demonstrates how to retrieve group member by ID.
 ```powershell
 Connect-Entra -Scopes 'GroupMember.Read.All'
 $group = Get-EntraBetaGroup -Filter "DisplayName eq 'Sales and Marketing'"
-Get-EntraBetaGroupMember -GroupId $group.Id -Top 2  -Property onPremImmutableId -AppendSelected | Select-Object Id, DisplayName, '@odata.type', OnPremImmutableId
+Get-EntraBetaGroupMember -GroupId $group.Id -Top 2  -Property OnPremisesImmutableId -AppendSelected | Select-Object Id, DisplayName, '@odata.type', OnPremisesImmutableId
 ```
 
 ```Output
-Id                                   DisplayName       @odata.type                 OnPremImmutableId
+Id                                   DisplayName       @odata.type                 OnPremisesImmutableId
 ------------------------------------ ----------------- ------------------------    ----------------------------
 dddddddd-3333-4444-5555-eeeeeeeeeeee Sawyer Miller     #microsoft.graph.user       eeeeeeee-4444-5555-6666-ffffffffffff
 eeeeeeee-4444-5555-6666-ffffffffffff Alex Wilber       #microsoft.graph.user       aaaaaaaa-6666-7777-8888-bbbbbbbbbbbb
@@ -168,7 +168,7 @@ eeeeeeee-4444-5555-6666-ffffffffffff Alex Wilber       #microsoft.graph.user    
 This example demonstrates how to retrieve group member by ID.
 
 - `-GroupId` Specifies the ID of a group.
-- `-Property` parameter selects a property `onPremImmutableId` that is not returned by default.
+- `-Property` parameter selects a property `OnPremisesImmutableId` that is not returned by default.
 - `-AppendSelected` parameter ensures the selected property is returned together with default properties.
 
 ## PARAMETERS

--- a/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserGroup.md
+++ b/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserGroup.md
@@ -45,7 +45,7 @@ Get-EntraBetaUserGroup
 ### Append
 
 ```powershell
-Get-EntraUserGroup
+Get-EntraBetaUserGroup
  -UserId <String>
  -Property <String[]>
  -AppendSelected

--- a/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserGroup.md
+++ b/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserGroup.md
@@ -39,7 +39,19 @@ Get-EntraBetaUserGroup
 Get-EntraBetaUserGroup
  -UserId <String>
  -GroupId <String>
- [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraUserGroup
+ -UserId <String>
+ -Property <String[]>
+ -AppendSelected
+ [-All]
+ [-Filter <String>]
+ [-Top <Int32>]
  [<CommonParameters>]
 ```
 
@@ -120,6 +132,70 @@ This cmdlet retrieves a list of groups to which a specific user belongs using th
 
 - `-GroupId` parameter specifies the group ID.
 
+### Example 5: Get a list of groups to which a specific user belongs and select specific properties.
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All', 'Group.Read.All', 'Directory.Read.All'
+Get-EntraBetaUserGroup -UserId 'SawyerM@contoso.com' -Property id,displayName,mailNickName -Debug | Select-Object displayName,id,mailNickName
+```
+
+```Output
+DisplayName                Id                                   MailNickname
+-----------                --                                   ------------
+Contoso Marketing          hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq ContosoMarketing
+Contoso Sales              qqqqqqqq-5555-0000-1111-hhhhhhhhhhhh ContosoSales
+Contoso Digital            aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb ContosoDigital
+```
+
+This cmdlet returns specific properties in the list of groups to which a specific user belongs to.
+
+### Example 6: Get a list of groups to which a specific user belongs and append the selected properties
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All', 'Group.Read.All', 'Directory.Read.All'
+Get-EntraBetaUserGroup -UserId 'SawyerM@contoso.com' -Property AssignedLabels -AppendSelected | Select-Object id,displayName,createdDateTime,deletedDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description,AssignedLabels
+```
+
+```Output
+Id              : hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq
+DisplayName     : Contoso Marketing
+CreatedDateTime : 22/08/2024 03:02:41
+DeletedDateTime :
+GroupTypes      : {Unified}
+MailEnabled     : True
+MailNickname    : ContosoMarketing
+SecurityEnabled : False
+Visibility      : Public
+Description     :
+AssignedLabels  : {TagA,TagB}
+
+Id              : qqqqqqqq-5555-0000-1111-hhhhhhhhhhhh
+DisplayName     : Contoso Sales
+CreatedDateTime : 22/08/2024 06:18:23
+DeletedDateTime :
+GroupTypes      : {Unified}
+MailEnabled     : True
+MailNickname    : ContosoSales
+SecurityEnabled : False
+Visibility      : Public
+Description     : Description of Contoso Sales
+AssignedLabels  : {TagA,TagB}
+
+Id              : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
+DisplayName     : Contoso Digital
+CreatedDateTime : 22/08/2024 06:20:00
+DeletedDateTime :
+GroupTypes      : {Unified}
+MailEnabled     : True
+MailNickname    : ContosoDigital
+SecurityEnabled : False
+Visibility      : Public
+Description     : Description of Contoso Digital
+AssignedLabels  : {TagA,TagB}
+```
+
+We only selected one property using the `Property` parameter, but the response has more properties since `AppendSelected` parameter appended default properties to the selected properties.
+
 ## PARAMETERS
 
 ### -UserId
@@ -176,7 +252,7 @@ Specifies properties to be returned
 
 ```yaml
 Type: System.String[]
-Parameter Sets: (All)
+Parameter Sets: GetQuery,Append
 Aliases: Select
 
 Required: False
@@ -192,7 +268,7 @@ The unique ID of the group.
 
 ```yaml
 Type: System.String
-Parameter Sets: GetQuery
+Parameter Sets: GetById
 Aliases: DirectoryObjectId
 
 Required: True
@@ -216,6 +292,22 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserManager.md
+++ b/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserManager.md
@@ -22,10 +22,22 @@ Gets the manager of a user.
 
 ## SYNTAX
 
+### GetQuery (Default)
+
 ```powershell
 Get-EntraBetaUserManager
  -UserId <String>
  [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraBetaUserManager
+ -UserId <String>
+ -Property <String[]>
+ -AppendSelected
  [<CommonParameters>]
 ```
 
@@ -85,6 +97,27 @@ bbbbbbbb-1111-2222-3333-cccccccccccc Sawyer Miller     SawyerM@contoso.com      
 
 This example demonstrates how to retrieve users without managers.
 
+### Example 3: Get the manager of a user and select and append a property not returned by default.
+
+```powershell
+Connect-Entra -Scopes 'User.Read.All'
+Get-EntraBetaUserManager -UserId 'SawyerM@contoso.com' -Property onPremisesImmutableId -AppendSelected |
+Select-Object Id, displayName, userPrincipalName, createdDateTime, accountEnabled, onPremisesImmutableId |
+Format-Table -AutoSize
+```
+
+```Output
+id                                    displayName     userPrincipalName      createdDateTime           accountEnabled  onPremisesImmutableId
+--                                    -----------     -----------------      ---------------           --------------  --------
+00aa00aa-bb11-cc22-dd33-44ee44ee44ee  Patti Fernandez PattiF@Contoso.com     10/7/2024 12:32:01 AM     True            hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq
+```
+
+This example demonstrates how to retrieve the manager of a specific user.
+
+- `-UserId` Parameter specifies UserId or User Principal Name of User.
+- `-Property` parameter selects a property `OnPremisesImmutableId` that is not returned by default.
+- `-AppendSelected` parameter ensures the selected property is returned together with default properties.
+
 ## PARAMETERS
 
 ### -UserId
@@ -115,6 +148,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-v1.0/Applications/Get-EntraServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-v1.0/Applications/Get-EntraServicePrincipalOwner.md
@@ -35,9 +35,9 @@ Get-EntraServicePrincipalOwner
 ### Append
 
 ```powershell
-Get-EntraGroup
+Get-EntraServicePrincipalOwner
  -ServicePrincipalId <String>
- -Property <String[]
+ -Property <String[]>
  -AppendSelected
  [-Top <Int32>]
  [-All]

--- a/module/docs/entra-powershell-v1.0/Applications/Get-EntraServicePrincipalOwner.md
+++ b/module/docs/entra-powershell-v1.0/Applications/Get-EntraServicePrincipalOwner.md
@@ -21,12 +21,26 @@ Get the owner of a service principal.
 
 ## SYNTAX
 
+### GetQuery (Default)
+
 ```powershell
 Get-EntraServicePrincipalOwner
  -ServicePrincipalId <String>
  [-All]
  [-Top <Int32>]
  [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraGroup
+ -ServicePrincipalId <String>
+ -Property <String[]
+ -AppendSelected
+ [-Top <Int32>]
+ [-All]
  [<CommonParameters>]
 ```
 
@@ -93,6 +107,27 @@ This command gets top two owners of a service principal. You can use the command
 
 - `-ServicePrincipalId` parameter specifies the unique identifier of a service principal.
 
+### Example 4: Retrieve top two owners of a service principal and select and append a property not returned by default.
+
+```powershell
+Connect-Entra -Scopes 'Application.Read.All'
+$servicePrincipal = Get-EntraServicePrincipal -Filter "displayName eq 'Helpdesk Application'"
+Get-EntraServicePrincipalOwner -ServicePrincipalId 0a40f8f8-4e30-4f58-bf26-772ad69f41f6 -Property userType -AppendSelected -Top 2 | Select-Object Id, userPrincipalName, DisplayName, '@odata.type', userType
+```
+
+```Output
+Id                                   displayName          @odata.type              userType
+--                                   -----------          -----------              ---------
+aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb Alex Wilber          #microsoft.graph.user    Member
+bbbbbbbb-1111-2222-3333-cccccccccccc Christie Cline       #microsoft.graph.user    Member
+```
+
+This command gets top two owners of a service principal. You can use the command `Get-EntraServicePrincipal` to get service principal object ID. You can use `-Limit` as an alias for `-Top`.
+
+- `-ServicePrincipalId` parameter specifies the unique identifier of a service principal.
+- `-Property` parameter selects a property `userType` that is not returned by default.
+- `-AppendSelected` parameter ensures the selected property is returned together with default properties.
+
 ## PARAMETERS
 
 ### -All
@@ -155,6 +190,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
@@ -57,7 +57,7 @@ Get-EntraGroup
 
 ```powershell
 Get-EntraGroup
- -Property <String[]
+ -Property <String[]>
  -AppendSelected
  [-GroupId <String>]
  [-Top <Int32>]

--- a/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
@@ -33,7 +33,7 @@ Get-EntraGroup
  [<CommonParameters>]
 ```
 
-### GetByValue
+### GetVague
 
 ```powershell
 Get-EntraGroup
@@ -50,6 +50,20 @@ Get-EntraGroup
  -GroupId <String>
  [-All]
  [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraGroup
+ -Property <String[]
+ -AppendSelected
+ [-GroupId <String>]
+ [-Top <Int32>]
+ [-All]
+ [-Filter <String>]
+ [-SearchString <String>]
  [<CommonParameters>]
 ```
 
@@ -206,6 +220,21 @@ bbbbbbbb-5555-5555-0000-qqqqqqqqqqqq HelpDesk admin group      True            {
 
 This example demonstrates how to return only a specific property of a group. You can use `-Select` alias or `-Property`.
 
+### Example 9: Get groups with specific properties and append the selected properties
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All'
+Get-EntraGroup -GroupId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -Property IsSubscribedByMail -AppendSelected | Select-Object Id, DisplayName, MailEnabled, Visibility, IsSubscribedByMail | Format-Table -AutoSize
+```
+
+```Output
+Id                                   DisplayName                MailEnabled Visibility IsSubscribedByMail
+--                                   -----------                --------------- ---------- ----------
+aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb SimpleGroup               False           Public     False
+```
+
+This example demonstrates how to append a selected property to the default properties.
+
 ## PARAMETERS
 
 ### -All
@@ -231,7 +260,7 @@ This parameter controls which objects are returned.
 
 ```yaml
 Type: System.String
-Parameter Sets: GetQuery
+Parameter Sets: GetQuery, Append
 Aliases:
 
 Required: False
@@ -247,7 +276,7 @@ The unique identifier of a group in Microsoft Entra ID (GroupId)
 
 ```yaml
 Type: System.String
-Parameter Sets: GetById
+Parameter Sets: GetById, Append
 Aliases: ObjectId
 
 Required: True
@@ -263,7 +292,7 @@ Specifies a search string.
 
 ```yaml
 Type: System.String
-Parameter Sets: GetValue
+Parameter Sets: GetValue, Append
 Aliases:
 
 Required: False
@@ -279,7 +308,7 @@ Specifies the maximum number of records to return.
 
 ```yaml
 Type: System.Int32
-Parameter Sets: GetQuery
+Parameter Sets: GetQuery, Append
 Aliases: Limit
 
 Required: False
@@ -301,6 +330,22 @@ Aliases: Select
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+List all pages.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
@@ -336,7 +336,7 @@ Accept wildcard characters: False
 
 ### -AppendSelected
 
-List all pages.
+Specifies whether to append the selected properties.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/module/docs/entra-powershell-v1.0/Users/Get-EntraUserGroup.md
+++ b/module/docs/entra-powershell-v1.0/Users/Get-EntraUserGroup.md
@@ -39,7 +39,19 @@ Get-EntraUserGroup
 Get-EntraUserGroup
  -UserId <String>
  -GroupId <String>
- [-Property <String[]>]
+ [<CommonParameters>]
+```
+
+### Append
+
+```powershell
+Get-EntraUserGroup
+ -UserId <String>
+ -Property <String[]>
+ -AppendSelected
+ [-All]
+ [-Filter <String>]
+ [-Top <Int32>]
  [<CommonParameters>]
 ```
 
@@ -120,6 +132,70 @@ This cmdlet retrieves a list of groups to which a specific user belongs using th
 
 - `-GroupId` parameter specifies the group ID.
 
+### Example 5: Get a list of groups to which a specific user belongs and select specific properties.
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All', 'Group.Read.All', 'Directory.Read.All'
+Get-EntraUserGroup -UserId 'SawyerM@contoso.com' -Property id,displayName,mailNickName -Debug | Select-Object displayName,id,mailNickName
+```
+
+```Output
+DisplayName                Id                                   MailNickname
+-----------                --                                   ------------
+Contoso Marketing          hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq ContosoMarketing
+Contoso Sales              qqqqqqqq-5555-0000-1111-hhhhhhhhhhhh ContosoSales
+Contoso Digital            aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb ContosoDigital
+```
+
+This cmdlet returns specific properties in the list of groups to which a specific user belongs to.
+
+### Example 6: Get a list of groups to which a specific user belongs and append the selected properties
+
+```powershell
+Connect-Entra -Scopes 'GroupMember.Read.All', 'Group.Read.All', 'Directory.Read.All'
+Get-EntraUserGroup -UserId 'SawyerM@contoso.com' -Property AssignedLabels -AppendSelected | Select-Object id,displayName,createdDateTime,deletedDateTime,groupTypes,mailEnabled,mailNickname,securityEnabled,visibility,description,AssignedLabels
+```
+
+```Output
+Id              : hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq
+DisplayName     : Contoso Marketing
+CreatedDateTime : 22/08/2024 03:02:41
+DeletedDateTime :
+GroupTypes      : {Unified}
+MailEnabled     : True
+MailNickname    : ContosoMarketing
+SecurityEnabled : False
+Visibility      : Public
+Description     :
+AssignedLabels  : {TagA,TagB}
+
+Id              : qqqqqqqq-5555-0000-1111-hhhhhhhhhhhh
+DisplayName     : Contoso Sales
+CreatedDateTime : 22/08/2024 06:18:23
+DeletedDateTime :
+GroupTypes      : {Unified}
+MailEnabled     : True
+MailNickname    : ContosoSales
+SecurityEnabled : False
+Visibility      : Public
+Description     : Description of Contoso Sales
+AssignedLabels  : {TagA,TagB}
+
+Id              : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
+DisplayName     : Contoso Digital
+CreatedDateTime : 22/08/2024 06:20:00
+DeletedDateTime :
+GroupTypes      : {Unified}
+MailEnabled     : True
+MailNickname    : ContosoDigital
+SecurityEnabled : False
+Visibility      : Public
+Description     : Description of Contoso Digital
+AssignedLabels  : {TagA,TagB}
+```
+
+We only selected one property using the `Property` parameter, but the response has more properties since `AppendSelected` parameter appended default properties to the selected properties.
+
 ## PARAMETERS
 
 ### -UserId
@@ -176,7 +252,7 @@ Specifies properties to be returned
 
 ```yaml
 Type: System.String[]
-Parameter Sets: (All)
+Parameter Sets: GetQuery,Append
 Aliases: Select
 
 Required: False
@@ -192,7 +268,7 @@ The unique ID of the group.
 
 ```yaml
 Type: System.String
-Parameter Sets: GetQuery
+Parameter Sets: GetById
 Aliases: DirectoryObjectId
 
 Required: True
@@ -216,6 +292,22 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -AppendSelected
+
+Specifies whether to append the selected properties.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: Append
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/test/Entra/Applications/Get-EntraServicePrincipalOwner.Tests.ps1
+++ b/test/Entra/Applications/Get-EntraServicePrincipalOwner.Tests.ps1
@@ -108,7 +108,7 @@ Describe "Get-EntraServicePrincipalOwner" {
             }
 
             Mock -CommandName Get-MgServicePrincipalOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Applications
-            $result = Get-EntraServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType -AppendSelected | Select-Object id,displayName,'@odata.type',userType
+            $result = Get-EntraServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType,Id -AppendSelected | Select-Object id,displayName,'@odata.type',userType
             $result.Id | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
             $result.UserType | should -Be "Member"
 

--- a/test/Entra/Applications/Get-EntraServicePrincipalOwner.Tests.ps1
+++ b/test/Entra/Applications/Get-EntraServicePrincipalOwner.Tests.ps1
@@ -100,7 +100,7 @@ Describe "Get-EntraServicePrincipalOwner" {
                         "DeletedDateTime"    = $null
                         "UserType"           = "Member"
                         "AdditionalProperties"   = @{
-                            "@odata.type"  = "#microsoft.graph.user";
+                            "@odata.type"  = "#microsoft.graph.user"
                             accountEnabled = $true
                         }
                     }

--- a/test/Entra/Groups/Get-EntraGroup.Tests.ps1
+++ b/test/Entra/Groups/Get-EntraGroup.Tests.ps1
@@ -128,7 +128,7 @@ Describe "Get-EntraGroup" {
             }
 
             Mock -CommandName Get-MgGroup -MockWith $scriptblock -ModuleName Microsoft.Entra.Groups
-            $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property IsSubscribedByMail
+            $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property IsSubscribedByMail -AppendSelected
             $result.ObjectId | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
             $result.IsSubscribedByMail | should -Be $false
         }

--- a/test/Entra/Groups/Get-EntraGroup.Tests.ps1
+++ b/test/Entra/Groups/Get-EntraGroup.Tests.ps1
@@ -93,6 +93,45 @@ Describe "Get-EntraGroup" {
             $params = Get-Parameters -data $result.Parameters
             $params.Filter | Should -Match "demo"
         }
+        It "Should return specified properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"     = "demo"
+                        "Id"              = "aaaaaaaa-1111-2222-3333-cccccccccccc"
+                        "MailEnabled"     = $false
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgGroup -MockWith $scriptblock -ModuleName Microsoft.Entra.Groups
+            $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property Id,DisplayName,MailEnabled
+            $result.ObjectId | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
+        }
+        It "Should return append specified properties to the default properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"        = "demo"
+                        "Id"                 = "aaaaaaaa-1111-2222-3333-cccccccccccc"
+                        "MailEnabled"        = $false
+                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                        "IsSubscribedByMail" = $false
+                        "DeletedDateTime"    = $null
+                        "GroupTypes"         = @("Unified")
+                        "MailNickname"       = "demoNickname"
+                        "SecurityEnabled"    = $true
+                        "Visibility"         = "Public"
+                        "Description"        = "test"
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgGroup -MockWith $scriptblock -ModuleName Microsoft.Entra.Groups
+            $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property IsSubscribedByMail
+            $result.ObjectId | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
+            $result.IsSubscribedByMail | should -Be $false
+        }
         It "Should contain 'User-Agent' header" {
             $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraGroup"
             $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc"

--- a/test/Entra/Groups/Get-EntraGroup.Tests.ps1
+++ b/test/Entra/Groups/Get-EntraGroup.Tests.ps1
@@ -128,7 +128,7 @@ Describe "Get-EntraGroup" {
             }
 
             Mock -CommandName Get-MgGroup -MockWith $scriptblock -ModuleName Microsoft.Entra.Groups
-            $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property IsSubscribedByMail -AppendSelected
+            $result = Get-EntraGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property IsSubscribedByMail,Id -AppendSelected
             $result.ObjectId | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
             $result.IsSubscribedByMail | should -Be $false
         }

--- a/test/Entra/Users/Get-EntraUserGroup.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserGroup.Tests.ps1
@@ -56,6 +56,31 @@ Describe "Get-EntraUserGroup" {
             { Get-EntraUserGroup -UserId 'SawyerM@contoso.com' -Property } | Should -Throw "Missing an argument for parameter 'Property'*"
         }
 
+        It "Should return append specified properties to the default properties" {
+            $sblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"        = "Contoso Sales"
+                        "Id"                 = "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
+                        "MailEnabled"        = $false
+                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                        "DeletedDateTime"    = $null
+                        "GroupTypes"         = @("Unified")
+                        "MailNickname"       = "contosoSales"
+                        "SecurityEnabled"    = $true
+                        "Visibility"         = "Public"
+                        "Description"        = "test"
+                        "AssignedLabels"         = @("TagA", "TagB")
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgUserMemberOfAsGroup -MockWith $sblock -ModuleName Microsoft.Entra.Users
+            $result = Get-EntraUserGroup -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property AssignedLabels -AppendSelected -Top 1
+            $result.Id | should -Be "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
+            $result.AssignedLabels | should -Be @("TagA", "TagB")
+        }
+
         It "Should contain 'User-Agent' header" {
             $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraUserGroup"
             $result = Get-EntraUserGroup -UserId 'SawyerM@contoso.com'

--- a/test/Entra/Users/Get-EntraUserGroup.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserGroup.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Get-EntraUserGroup" {
             }
 
             Mock -CommandName Get-MgUserMemberOfAsGroup -MockWith $sblock -ModuleName Microsoft.Entra.Users
-            $result = Get-EntraUserGroup -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property AssignedLabels -AppendSelected -Top 1
+            $result = Get-EntraUserGroup -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property AssignedLabels,Id -AppendSelected -Top 1
             $result.Id | should -Be "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
             $result.AssignedLabels | should -Be @("TagA", "TagB")
         }

--- a/test/EntraBeta/Applications/Get-EntraBetaApplicationOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaApplicationOwner.Tests.ps1
@@ -1,0 +1,115 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {  
+    if ((Get-Module -Name Microsoft.Entra.Beta.Applications) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.Applications      
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    $mockResponse = {
+        return @(
+            [PSCustomObject]@{
+                Id                          = "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"          
+                ageGroup                    = $null
+                onPremisesLastSyncDateTime  = $null
+                creationType                = $null
+                preferredLanguage           = $null
+                mail                        = "admin@contonso.com"
+                securityIdentifier          = "S-1-12-1-1093396945-1080104032-2731339150-364051459"
+                consentProvidedForMinor     = $null
+                onPremisesUserPrincipalName = $null
+                Parameters                  = $args
+                AdditionalProperties        = @{
+                        "@odata.type"  = "#microsoft.graph.user"
+                        accountEnabled = $true
+                    }
+            }
+        )
+    }
+
+    Mock -CommandName Get-MgBetaApplicationOwner -MockWith $mockResponse -ModuleName Microsoft.Entra.Beta.Applications
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Application.Read.All") } } -ModuleName Microsoft.Entra.Beta.Applications
+}
+
+Describe "Get-EntraBetaApplicationOwner" {
+    Context "Test for Get-EntraBetaApplicationOwner" {
+        It "Should return application owner" {
+            $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+            Write-Host $result
+            $result | Should -Not -BeNullOrEmpty
+            $result.Id | should -Be @('aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb')
+
+            Should -Invoke -CommandName Get-MgBetaApplicationOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+        }
+        It "Should fail when ApplicationId is empty" {
+            { Get-EntraBetaApplicationOwner -ApplicationId "" } | Should -Throw "Cannot validate argument on parameter 'ApplicationId'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It "Should fail when ApplicationId is null" {
+            { Get-EntraBetaApplicationOwner -ApplicationId } | Should -Throw "Missing an argument for parameter 'ApplicationId'*"
+        }
+        It "Should fail when All has an argument" {
+            { Get-EntraBetaApplicationOwner -All $true } | Should -Throw "A positional parameter cannot be found that accepts argument 'True'.*"
+        }
+        It "Should fail when Top is empty" {
+            { Get-EntraBetaApplicationOwner -Top } | Should -Throw "Missing an argument for parameter 'Top'*"
+        }
+        It "Should fail when Top is invalid" {
+            { Get-EntraBetaApplicationOwner -Top XY } | Should -Throw "Cannot process argument transformation on parameter 'Top'*"
+        } 
+        It "Property parameter should work" {
+            $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Property Id 
+            $result | Should -Not -BeNullOrEmpty
+            $result.Id | Should -Be "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        }
+        It "Should return append specified properties to the default properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"           = "Sawyer M"
+                        "Id"                    = "bbbbbbbb-1111-2222-3333-cccccccccccc"
+                        "CreatedDateTime"       = "2023-01-01T00:00:00Z"
+                        "DeletedDateTime"       = $null
+                        "OnPremisesImmutableId" = "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
+                        "AdditionalProperties"  = @{
+                            "@odata.type"  = "#microsoft.graph.user"
+                            accountEnabled = $true
+                        }
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgBetaApplicationOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
+            $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId -AppendSelected | Select-Object id,displayName,'@odata.type',onPremisesImmutableId
+            $result.Id | should -Be "bbbbbbbb-1111-2222-3333-cccccccccccc"
+            $result.OnPremisesImmutableId | should -Be "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
+
+            Should -Invoke -CommandName Get-MgBetaApplicationOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+        }
+        It "Should contain 'User-Agent' header" {
+            $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaApplicationOwner"
+            $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+            $result | Should -Not -BeNullOrEmpty
+            $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaApplicationOwner"    
+            Should -Invoke -CommandName Get-MgBetaApplicationOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1 -ParameterFilter {
+                $Headers.'User-Agent' | Should -Be $userAgentHeaderValue
+                $true
+            }
+        }
+        It "Should execute successfully without throwing an error " {
+            # Disable confirmation prompts       
+            $originalDebugPreference = $DebugPreference
+            $DebugPreference = 'Continue'
+    
+            try {
+                # Act & Assert: Ensure the function doesn't throw an exception
+                { Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Debug } | Should -Not -Throw
+            }
+            finally {
+                # Restore original confirmation preference            
+                $DebugPreference = $originalDebugPreference        
+            }
+        } 
+    }
+}
+

--- a/test/EntraBeta/Applications/Get-EntraBetaApplicationOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaApplicationOwner.Tests.ps1
@@ -34,6 +34,11 @@ BeforeAll {
 
 Describe "Get-EntraBetaApplicationOwner" {
     Context "Test for Get-EntraBetaApplicationOwner" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Applications 
+            { Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaApplicationOwner  -ModuleName Microsoft.Entra.Beta.Applications  -Times 0
+        }
         It "Should return application owner" {
             $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             Write-Host $result

--- a/test/EntraBeta/Applications/Get-EntraBetaApplicationOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaApplicationOwner.Tests.ps1
@@ -80,7 +80,7 @@ Describe "Get-EntraBetaApplicationOwner" {
             }
 
             Mock -CommandName Get-MgBetaApplicationOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
-            $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId -AppendSelected | Select-Object id,displayName,'@odata.type',onPremisesImmutableId
+            $result = Get-EntraBetaApplicationOwner -ApplicationId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId,Id -AppendSelected | Select-Object id,displayName,'@odata.type',onPremisesImmutableId
             $result.Id | should -Be "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result.OnPremisesImmutableId | should -Be "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
 

--- a/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
@@ -45,6 +45,11 @@ BeforeAll {
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Application.Read.All") } } -ModuleName Microsoft.Entra.Beta.Applications
 }
 Describe "Get-EntraBetaServicePrincipalOwner" {
+    It "Should throw when not connected and not invoke SDK" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Applications 
+        { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner  -ModuleName Microsoft.Entra.Beta.Applications  -Times 0
+    }
     It "Result should not be empty" {
         $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
         $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
@@ -108,7 +108,7 @@ Describe "Get-EntraBetaServicePrincipalOwner" {
         }
 
         Mock -CommandName Get-MgBetaServicePrincipalOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
-        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType -AppendSelected | Select-Object id,displayName,'@odata.type',userType
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType,Id -AppendSelected | Select-Object id,displayName,'@odata.type',userType
         $result.Id | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
         $result.UserType | should -Be "Member"
 

--- a/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
@@ -100,7 +100,7 @@ Describe "Get-EntraBetaServicePrincipalOwner" {
                         "DeletedDateTime"    = $null
                         "UserType"           = "Member"
                         "AdditionalProperties"   = @{
-                            "@odata.type"  = "#microsoft.graph.user";
+                            "@odata.type"  = "#microsoft.graph.user"
                             accountEnabled = $true
                         }
                     }

--- a/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
@@ -91,29 +91,29 @@ Describe "Get-EntraBetaServicePrincipalOwner" {
         { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Property } | Should -Throw "Missing an argument for parameter 'Property'*"
     }
     It "Should return append specified properties to the default properties" {
-            $scriptblock = {
-                return @(
-                    [PSCustomObject]@{
-                        "DisplayName"        = "Sawyer M"
-                        "Id"                 = "aaaaaaaa-1111-2222-3333-cccccccccccc"
-                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
-                        "DeletedDateTime"    = $null
-                        "UserType"           = "Member"
-                        "AdditionalProperties"   = @{
-                            "@odata.type"  = "#microsoft.graph.user"
-                            accountEnabled = $true
-                        }
+        $scriptblock = {
+            return @(
+                [PSCustomObject]@{
+                    "DisplayName"        = "Sawyer M"
+                    "Id"                 = "eeeeeeee-4444-5555-6666-ffffffffffff"
+                    "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                    "DeletedDateTime"    = $null
+                    "UserType"           = "Member"
+                    "AdditionalProperties"   = @{
+                        "@odata.type"  = "#microsoft.graph.user"
+                        accountEnabled = $true
                     }
-                )
-            }
-
-            Mock -CommandName Get-MgBetaServicePrincipalOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
-            $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType -AppendSelected | Select-Object id,displayName,'@odata.type',userType
-            $result.Id | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
-            $result.UserType | should -Be "Member"
-
-            Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+                }
+            )
         }
+
+        Mock -CommandName Get-MgBetaServicePrincipalOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType -AppendSelected | Select-Object id,displayName,'@odata.type',userType
+        $result.Id | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
+        $result.UserType | should -Be "Member"
+
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+    }
     It "Should contain 'User-Agent' header" {
         $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaServicePrincipalOwner"
         $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"

--- a/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
@@ -1,0 +1,142 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {  
+    if ((Get-Module -Name Microsoft.Entra.Beta.Applications) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.Applications      
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    $scriptblock = {
+        return @(
+            [PSCustomObject]@{
+                "Id"                     = "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
+                "DisplayName"            = "Adams Smith"
+                "UserPrincipalName"      = "Adams@contoso.com"
+                "UserType"               = "Member"
+                "appRoles"               = @{
+                    allowedMemberTypes = $null; 
+                    description        = "msiam_access";
+                    displayName        = "msiam_access"; 
+                    id                 = "d0d7e4e4-96be-41c9-805a-08e0526868ad";
+                    isEnabled          = $True; 
+                    origin             = "Application"
+                }
+                "oauth2PermissionScopes" = @{
+                    adminConsentDescription = "Allow the application to access from tmplate test 3 on behalf of the signed-in user."; 
+                    adminConsentDisplayName = "Access from tmplate test 3"; 
+                    id                      = "64c2cef3-e118-4795-a580-a32bdbd7ba88"; 
+                    isEnabled               = $True; 
+                    type                    = "User";
+                    userConsentDescription  = "Allow the application to access from tmplate test 3 on your behalf."; 
+                    userConsentDisplayName  = "Access from tmplate test 3";
+                    value                   = "user_impersonation"
+                }
+                "AdditionalProperties"   = @{
+                    "@odata.type"  = "#microsoft.graph.servicePrincipal";
+                    accountEnabled = $true
+                }
+                "Parameters"             = $args
+            }
+        )
+    }
+
+    Mock -CommandName Get-MgBetaServicePrincipalOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Application.Read.All") } } -ModuleName Microsoft.Entra.Beta.Applications
+}
+Describe "Get-EntraBetaServicePrincipalOwner" {
+    It "Result should not be empty" {
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        $result | Should -Not -BeNullOrEmpty
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+    }
+    It "Should update the parameter with Alias" {
+        $result = Get-EntraBetaServicePrincipalOwner -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        $result | Should -Not -BeNullOrEmpty
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+    }
+    It "Should fail when ServicePrincipalId is empty" {
+        { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "" } | Should -Throw "Cannot validate argument on parameter 'ServicePrincipalId'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+    }
+    It "Should return all applications" {
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -All
+        $result | Should -Not -BeNullOrEmpty
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+    }
+    It "Should fail when All has an argument" {
+        { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -All $true } | Should -Throw "A positional parameter cannot be found that accepts argument 'True'."
+    }
+    It "Should return top application" {
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Top 1
+        $result | Should -Not -BeNullOrEmpty
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+    }
+    It "Result should Contain ServicePrincipalId" {            
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        $result.ObjectId | should -Be "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
+    }
+    It "Should contain ServicePrincipalId in parameters when passed ServicePrincipalId to it" {    
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        $params = Get-Parameters -data $result.Parameters
+        $params.ServicePrincipalId | Should -Be "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+    }
+    It "Property parameter should work" {
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Property DisplayName
+        $result | Should -Not -BeNullOrEmpty
+        $result.DisplayName | Should -Be 'Adams Smith'
+
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+    }
+    It "Should fail when Property is empty" {
+        { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Property } | Should -Throw "Missing an argument for parameter 'Property'*"
+    }
+    It "Should return append specified properties to the default properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"        = "Sawyer M"
+                        "Id"                 = "aaaaaaaa-1111-2222-3333-cccccccccccc"
+                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                        "DeletedDateTime"    = $null
+                        "UserType"           = "Member"
+                        "AdditionalProperties"   = @{
+                            "@odata.type"  = "#microsoft.graph.user";
+                            accountEnabled = $true
+                        }
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgBetaServicePrincipalOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Applications
+            $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property userType -AppendSelected | Select-Object id,displayName,'@odata.type',userType
+            $result.Id | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
+            $result.UserType | should -Be "Member"
+
+            Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1
+        }
+    It "Should contain 'User-Agent' header" {
+        $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaServicePrincipalOwner"
+        $result = Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        $result | Should -Not -BeNullOrEmpty
+        $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaServicePrincipalOwner"    
+        Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner -ModuleName Microsoft.Entra.Beta.Applications -Times 1 -ParameterFilter {
+            $Headers.'User-Agent' | Should -Be $userAgentHeaderValue
+            $true
+        }
+    }
+    It "Should execute successfully without throwing an error " {
+        # Disable confirmation prompts       
+        $originalDebugPreference = $DebugPreference
+        $DebugPreference = 'Continue'
+
+        try {
+            # Act & Assert: Ensure the function doesn't throw an exception
+            { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Debug } | Should -Not -Throw
+        }
+        finally {
+            # Restore original confirmation preference            
+            $DebugPreference = $originalDebugPreference        
+        }
+    } 
+}
+

--- a/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
+++ b/test/EntraBeta/Applications/Get-EntraBetaServicePrincipalOwner.Tests.ps1
@@ -46,7 +46,7 @@ BeforeAll {
 }
 Describe "Get-EntraBetaServicePrincipalOwner" {
     It "Should throw when not connected and not invoke SDK" {
-        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Applications 
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Applications
         { Get-EntraBetaServicePrincipalOwner -ServicePrincipalId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
         Should -Invoke -CommandName Get-MgBetaServicePrincipalOwner  -ModuleName Microsoft.Entra.Beta.Applications  -Times 0
     }

--- a/test/EntraBeta/Groups/Get-EntraBetaGroup.Tests.ps1
+++ b/test/EntraBeta/Groups/Get-EntraBetaGroup.Tests.ps1
@@ -125,6 +125,46 @@ Describe "Get-EntraBetaGroup" {
             { Get-EntraBetaGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property } | Should -Throw "Missing an argument for parameter 'Property'*"
         }
 
+        It "Should return specified properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"     = "demo"
+                        "Id"              = "aaaaaaaa-1111-2222-3333-cccccccccccc"
+                        "MailEnabled"     = $false
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgBetaGroup -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Groups
+            $result = Get-EntraBetaGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property Id,DisplayName,MailEnabled
+            $result.ObjectId | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
+        }
+        It "Should return append specified properties to the default properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"        = "demo"
+                        "Id"                 = "aaaaaaaa-1111-2222-3333-cccccccccccc"
+                        "MailEnabled"        = $false
+                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                        "IsSubscribedByMail" = $false
+                        "DeletedDateTime"    = $null
+                        "GroupTypes"         = @("Unified")
+                        "MailNickname"       = "demoNickname"
+                        "SecurityEnabled"    = $true
+                        "Visibility"         = "Public"
+                        "Description"        = "test"
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgBetaGroup -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Groups
+            $result = Get-EntraBetaGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property IsSubscribedByMail
+            $result.ObjectId | should -Be "aaaaaaaa-1111-2222-3333-cccccccccccc"
+            $result.IsSubscribedByMail | should -Be $false
+        }
+
         It "Should contain 'User-Agent' header" {
             $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaGroup"
             $result = Get-EntraBetaGroup -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc"

--- a/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
+++ b/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
@@ -96,7 +96,7 @@ Describe "Get-EntraBetaGroupMember" {
             }
 
             Mock -CommandName Get-MgBetaGroupMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Groups
-            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property OnPremisesImmutableId -AppendSelected -Top 1
+            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId -AppendSelected -Top 1
             $result.Id | should -Be "dddddddd-3333-4444-5555-eeeeeeeeeeee"
             $result.OnPremisesImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
         }

--- a/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
+++ b/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
@@ -84,7 +84,7 @@ Describe "Get-EntraBetaGroupMember" {
                         "DisplayName"        = "Sawyer Miller"
                         "Id"                 = "dddddddd-3333-4444-5555-eeeeeeeeeeee"
                         "UserPrincipalName"  = "SawyerM@contoso.com"
-                        "OnPremImmutableId"  = "eeeeeeee-4444-5555-6666-ffffffffffff"
+                        "OnPremisesImmutableId"  = "eeeeeeee-4444-5555-6666-ffffffffffff"
                         "CreatedDateTime"    = "2023-01-01T00:00:00Z"
                         "DeletedDateTime"    = $null
                         "AdditionalProperties"   = @{
@@ -96,9 +96,9 @@ Describe "Get-EntraBetaGroupMember" {
             }
 
             Mock -CommandName Get-MgBetaGroupMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Groups
-            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremImmutableId -AppendSelected -Top 1
+            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property OnPremisesImmutableId -AppendSelected -Top 1
             $result.Id | should -Be "dddddddd-3333-4444-5555-eeeeeeeeeeee"
-            $result.OnPremImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
+            $result.OnPremisesImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
         }
         
         It "Should contain 'User-Agent' header" {

--- a/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
+++ b/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
@@ -96,7 +96,7 @@ Describe "Get-EntraBetaGroupMember" {
             }
 
             Mock -CommandName Get-MgBetaGroupMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Groups
-            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId -AppendSelected -Top 1
+            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId,Id -AppendSelected -Top 1
             $result.Id | should -Be "dddddddd-3333-4444-5555-eeeeeeeeeeee"
             $result.OnPremisesImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
         }

--- a/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
+++ b/test/EntraBeta/Groups/Get-EntraBetaGroupMember.Tests.ps1
@@ -76,6 +76,30 @@ Describe "Get-EntraBetaGroupMember" {
         It "Should fail when Property is empty" {
             { Get-EntraBetaGroupMember -ObjectId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property } | Should -Throw "Missing an argument for parameter 'Property'*"
         }
+
+        It "Should return append specified properties to the default properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"        = "Sawyer Miller"
+                        "Id"                 = "dddddddd-3333-4444-5555-eeeeeeeeeeee"
+                        "UserPrincipalName"  = "SawyerM@contoso.com"
+                        "OnPremImmutableId"  = "eeeeeeee-4444-5555-6666-ffffffffffff"
+                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                        "DeletedDateTime"    = $null
+                        "AdditionalProperties"   = @{
+                            "@odata.type"  = "#microsoft.graph.user"
+                            accountEnabled = $true
+                        }
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgBetaGroupMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Groups
+            $result = Get-EntraBetaGroupMember -GroupId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremImmutableId -AppendSelected -Top 1
+            $result.Id | should -Be "dddddddd-3333-4444-5555-eeeeeeeeeeee"
+            $result.OnPremImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
+        }
         
         It "Should contain 'User-Agent' header" {
             $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaGroupMember"

--- a/test/EntraBeta/Users/Get-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUser.Tests.ps1
@@ -115,7 +115,7 @@ Describe "Get-EntraBetaUser" {
         }
 
         It "Should fail when Top is less than 1" {
-            { Get-EntraUser -Top 0 } | Should -Throw "Cannot validate argument on parameter 'Top'*"
+            { Get-EntraBetaUser -Top 0 } | Should -Throw "Cannot validate argument on parameter 'Top'*"
         }
         
         It "Should fail when pagesize is empty" {
@@ -127,11 +127,11 @@ Describe "Get-EntraBetaUser" {
         }
 
         It "Should fail when pagesize is less than 1" {
-            { Get-EntraUser -PageSize 0 } | Should -Throw "Cannot validate argument on parameter 'PageSize'*"
+            { Get-EntraBetaUser -PageSize 0 } | Should -Throw "Cannot validate argument on parameter 'PageSize'*"
         }
 
         It "Should fail when pagesize is greater than 999" {
-            { Get-EntraUser -PageSize 1000 } | Should -Throw "Cannot validate argument on parameter 'PageSize'*"
+            { Get-EntraBetaUser -PageSize 1000 } | Should -Throw "Cannot validate argument on parameter 'PageSize'*"
         }
 
         It "Should return user when pageSize is applied with all" {

--- a/test/EntraBeta/Users/Get-EntraBetaUserGroup.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserGroup.Tests.ps1
@@ -56,6 +56,31 @@ Describe "Get-EntraBetaUserGroup" {
             { Get-EntraBetaUserGroup -UserId 'SawyerM@contoso.com' -Property } | Should -Throw "Missing an argument for parameter 'Property'*"
         }
 
+        It "Should return append specified properties to the default properties" {
+            $sblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"        = "Contoso Sales"
+                        "Id"                 = "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
+                        "MailEnabled"        = $false
+                        "CreatedDateTime"    = "2023-01-01T00:00:00Z"
+                        "DeletedDateTime"    = $null
+                        "GroupTypes"         = @("Unified")
+                        "MailNickname"       = "contosoSales"
+                        "SecurityEnabled"    = $true
+                        "Visibility"         = "Public"
+                        "Description"        = "test"
+                        "AssignedLabels"         = @("TagA", "TagB")
+                    }
+                )
+            }
+
+            Mock -CommandName Get-MgBetaUserMemberOfAsGroup -MockWith $sblock -ModuleName Microsoft.Entra.Beta.Users
+            $result = Get-EntraBetaUserGroup -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property AssignedLabels -AppendSelected -Top 1
+            $result.Id | should -Be "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
+            $result.AssignedLabels | should -Be @("TagA", "TagB")
+        }
+
         It "Should contain 'User-Agent' header" {
             $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaUserGroup"
             $result = Get-EntraBetaUserGroup -UserId 'SawyerM@contoso.com'

--- a/test/EntraBeta/Users/Get-EntraBetaUserGroup.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserGroup.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Get-EntraBetaUserGroup" {
             }
 
             Mock -CommandName Get-MgBetaUserMemberOfAsGroup -MockWith $sblock -ModuleName Microsoft.Entra.Beta.Users
-            $result = Get-EntraBetaUserGroup -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property AssignedLabels -AppendSelected -Top 1
+            $result = Get-EntraBetaUserGroup -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property AssignedLabels,Id -AppendSelected -Top 1
             $result.Id | should -Be "hhhhhhhh-3333-5555-3333-qqqqqqqqqqqq"
             $result.AssignedLabels | should -Be @("TagA", "TagB")
         }

--- a/test/EntraBeta/Users/Get-EntraBetaUserManager.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserManager.Tests.ps1
@@ -131,14 +131,28 @@ Describe "Get-EntraBetaUserManager" {
             $params = Get-Parameters -data $result.Parameters
             $params.UserId | Should -Be "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
         }
+        It "Should return append specified properties to the default properties" {
+            $scriptblock = {
+                return @(
+                    [PSCustomObject]@{
+                        "DisplayName"            = "Sawyer Miller"
+                        "Id"                     = "dddddddd-3333-4444-5555-eeeeeeeeeeee"
+                        "UserPrincipalName"      = "SawyerM@contoso.com"
+                        "OnPremisesImmutableId"  = "eeeeeeee-4444-5555-6666-ffffffffffff"
+                        "CreatedDateTime"        = "2023-01-01T00:00:00Z"
+                        "DeletedDateTime"        = $null
+                        "AdditionalProperties"   = @{
+                            "@odata.type"  = "#microsoft.graph.user"
+                            accountEnabled = $true
+                        }
+                    }
+                )
+            }
 
-        It "Should contain 'User-Agent' header" {
-            $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaUserManager"
-
-            $result = Get-EntraBetaUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
-            $params = Get-Parameters -data $result.Parameters
-
-            $params.Headers."User-Agent" | Should -Be $userAgentHeaderValue
+            Mock -CommandName Get-MgBetaUserManager -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Users
+            $result = Get-EntraBetaUserManager -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId -AppendSelected
+            $result.Id | should -Be "dddddddd-3333-4444-5555-eeeeeeeeeeee"
+            $result.OnPremisesImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
         }
         It "Should contain 'User-Agent' header" {
             $userAgentHeaderValue = "PowerShell/$psVersion EntraPowershell/$entraVersion Get-EntraBetaUserManager"

--- a/test/EntraBeta/Users/Get-EntraBetaUserManager.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserManager.Tests.ps1
@@ -150,7 +150,7 @@ Describe "Get-EntraBetaUserManager" {
             }
 
             Mock -CommandName Get-MgBetaUserManager -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Users
-            $result = Get-EntraBetaUserManager -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId -AppendSelected
+            $result = Get-EntraBetaUserManager -UserId "aaaaaaaa-1111-2222-3333-cccccccccccc" -Property onPremisesImmutableId,Id -AppendSelected
             $result.Id | should -Be "dddddddd-3333-4444-5555-eeeeeeeeeeee"
             $result.OnPremisesImmutableId | should -Be "eeeeeeee-4444-5555-6666-ffffffffffff"
         }


### PR DESCRIPTION
**Background**

We shipped the Property param feature in Version [0.10.0-preview](https://github.com/microsoftgraph/entra-powershell/releases/tag/0.10.0-preview). This feature allowed customers to select the properties they would want returned with the response. 

Property param is used in 2 main scenarios: 

To request extra properties that are not returned by default.  

To return a subset of the properties when the response returns alot of properties by default (for performance reasons). 

In scenario 1 above, there exists one major problem. When you specify the properties, only the specified properties are returned and default ones are ignored. 

AppendSelected switch param is aimed at ensuring the default properties are returned together with the specified properties. 

AppendSelected param will not be used in the second scenario since the property or properties are in the default response, we will only select the subset that we need.

_We have added the `AppendSelected` parameter to high usage cmdlets in `Applications`, `Users` and `Groups` sub-modules._

**Example 1**
```powershell
Connect-Entra -Scopes 'Application.Read.All'
$servicePrincipal = Get-EntraServicePrincipal -Filter "displayName eq 'Helpdesk Application'"
Get-EntraServicePrincipalOwner -ServicePrincipalId 0a40f8f8-4e30-4f58-bf26-772ad69f41f6 -Property userType -AppendSelected -Top 2 | Select-Object Id, userPrincipalName, DisplayName, '@odata.type', userType
```

```Output
Id                                   displayName          @odata.type              userType
--                                   -----------          -----------              ---------
aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb Alex Wilber          #microsoft.graph.user    Member
bbbbbbbb-1111-2222-3333-cccccccccccc Christie Cline       #microsoft.graph.user    Member
```

- `-Property` parameter selects a property `userType` that is not returned by default.
- `-AppendSelected` parameter ensures the selected property is returned together with default properties.

**Example 2**
```powershell
Connect-Entra -Scopes 'GroupMember.Read.All'
Get-EntraGroup -GroupId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -Property IsSubscribedByMail -AppendSelected | Select-Object Id, DisplayName, MailEnabled, Visibility, IsSubscribedByMail | Format-Table -AutoSize
```

```Output
Id                                   DisplayName                MailEnabled Visibility IsSubscribedByMail
--                                   -----------                --------------- ---------- ----------
aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb SimpleGroup               False           Public     False
```