### PR TITLE
Remove Microsoft.Graph.Users.Functions dependency

### DIFF
--- a/module/Entra/config/ModuleMetadata.json
+++ b/module/Entra/config/ModuleMetadata.json
@@ -8,7 +8,6 @@
   "requiredModules": [
     "Microsoft.Graph.Users",
     "Microsoft.Graph.Users.Actions",
-    "Microsoft.Graph.Users.Functions",
     "Microsoft.Graph.Groups",
     "Microsoft.Graph.Identity.DirectoryManagement",
     "Microsoft.Graph.Identity.Governance",

--- a/module/Entra/config/ModuleSettings.json
+++ b/module/Entra/config/ModuleSettings.json
@@ -7,7 +7,6 @@
       "Microsoft.Graph.DirectoryObjects",
       "Microsoft.Graph.Users",
       "Microsoft.Graph.Users.Actions", 
-      "Microsoft.Graph.Users.Functions", 
       "Microsoft.Graph.Groups", 
       "Microsoft.Graph.Identity.DirectoryManagement", 
       "Microsoft.Graph.Identity.Governance", 

--- a/module/Entra/config/dependencyMapping.json
+++ b/module/Entra/config/dependencyMapping.json
@@ -1,5 +1,5 @@
 {
-    "Microsoft.Entra.Users":["Microsoft.Graph.Users","Microsoft.Graph.Users.Actions","Microsoft.Graph.Users.Functions"],
+    "Microsoft.Entra.Users":["Microsoft.Graph.Users","Microsoft.Graph.Users.Actions"],
     "Microsoft.Entra.Authentication":["Microsoft.Graph.Authentication"],
     "Microsoft.Entra.Groups":["Microsoft.Graph.Groups"],
     "Microsoft.Entra.DirectoryManagement":["Microsoft.Graph.Identity.DirectoryManagement"],

--- a/module/EntraBeta/config/ModuleMetadata.json
+++ b/module/EntraBeta/config/ModuleMetadata.json
@@ -8,7 +8,6 @@
   "requiredModules": [
     "Microsoft.Graph.Beta.Users",
     "Microsoft.Graph.Beta.Users.Actions",
-    "Microsoft.Graph.Beta.Users.Functions",
     "Microsoft.Graph.Beta.Groups",
     "Microsoft.Graph.Beta.Identity.DirectoryManagement",
     "Microsoft.Graph.Beta.Identity.Governance",

--- a/module/EntraBeta/config/ModuleSettings.json
+++ b/module/EntraBeta/config/ModuleSettings.json
@@ -6,8 +6,7 @@
     "destinationModuleName" : [
       "Microsoft.Graph.Beta.DirectoryObjects",
       "Microsoft.Graph.Beta.Users",
-      "Microsoft.Graph.Beta.Users.Actions", 
-      "Microsoft.Graph.Beta.Users.Functions", 
+      "Microsoft.Graph.Beta.Users.Actions",
       "Microsoft.Graph.Beta.Groups", 
       "Microsoft.Graph.Beta.Identity.DirectoryManagement", 
       "Microsoft.Graph.Beta.Identity.Governance", 

--- a/module/EntraBeta/config/dependencyMapping.json
+++ b/module/EntraBeta/config/dependencyMapping.json
@@ -1,5 +1,5 @@
 {
-    "Microsoft.Entra.Beta.Users":["Microsoft.Graph.Beta.Users","Microsoft.Graph.Beta.Users.Actions","Microsoft.Graph.Beta.Users.Functions"],
+    "Microsoft.Entra.Beta.Users":["Microsoft.Graph.Beta.Users","Microsoft.Graph.Beta.Users.Actions"],
     "Microsoft.Entra.Beta.Authentication":["Microsoft.Graph.Authentication"],
     "Microsoft.Entra.Beta.Groups":["Microsoft.Graph.Beta.Groups"],
     "Microsoft.Entra.Beta.DirectoryManagement":["Microsoft.Graph.Beta.Identity.DirectoryManagement"],


### PR DESCRIPTION
Fixes #1307

`Microsoft.Graph.Users.Functions` is not used by any cmdlet so we remove it from `Microsoft.Entra.Users` and `Microsoft.Entra.Beta.Users` sub-modules. The reason is when you execute a cmdlet in the Users submodule for the first time, the `Microsoft.Graph.Users.Functions` will be loaded which degrades the first time execution experience.

Before
<img width="176" height="37" alt="image" src="https://github.com/user-attachments/assets/8ec547f2-7633-47dc-857a-9ba78d7ba01f" />
After
<img width="187" height="34" alt="image" src="https://github.com/user-attachments/assets/9cf91a0f-43de-4287-b247-08f744ec747c" />

We have a slight improvement in the first time execution of `Get-EntraUser`.
