### PR TITLE
1517 - Updated cmdlet binding for Remove-EntraBetaPrivateAccessApplicationSegment command

### DIFF
--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.ps1
@@ -4,16 +4,14 @@
 # ------------------------------------------------------------------------------ 
 function Remove-EntraBetaPrivateAccessApplicationSegment {
 
-    [CmdletBinding(ParameterSetName = 'Default')]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Alias('ObjectId')]
         [Parameter(Mandatory = $True)]
-        [System.String]
-        $ApplicationId,
+        [System.String] $ApplicationId,
 
         [Parameter(Mandatory = $False)]
-        [System.String]
-        $ApplicationSegmentId
+        [System.String] $ApplicationSegmentId
     )
 
     PROCESS {

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.ps1
@@ -7,10 +7,11 @@ function Remove-EntraBetaPrivateAccessApplicationSegment {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Alias('ObjectId')]
-        [Parameter(Mandatory = $True)]
+        [Parameter(Mandatory = $True, HelpMessage = "The object ID of a Private Access application object.")]
+        [ValidateNotNullOrEmpty()]
         [System.String] $ApplicationId,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $False, HelpMessage = "The application segment ID of the application segment to be deleted.")]
         [System.String] $ApplicationSegmentId
     )
 

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {
+    if((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null){
+        Import-Module Microsoft.Entra.Beta.NetworkAccess    
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All") } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+}
+
+Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
+    It "Should fail when ApplicationId is missing" {
+        $result = Remove-EntraBetaPrivateAccessApplicationSegment 
+        $result | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
+    }
+
+    It "Should fail when ApplicationId is missing" {
+        $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null 
+        $result | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
+    }
+    
+    It "Should fail when ApplicationSegmentId is missing" {
+        $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" 
+        $result | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
+    }   
+
+    It "Should fail when ApplicationSegmentId is missing" {
+        $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId $null 
+        $result | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
+    }
+
+    It "Should execute successfully without throwing an error" {
+        # Disable confirmation prompts       
+        $originalDebugPreference = $DebugPreference
+        $DebugPreference = 'Continue'
+
+        try {
+            # Act & Assert: Ensure the function doesn't throw an exception
+            $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId "TestAppSegmentId"
+            $result | Should -Not -Throw
+        }
+        finally {
+            # Restore original confirmation preference            
+            $DebugPreference = $originalDebugPreference        
+        }
+    }
+}

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -14,19 +14,19 @@ BeforeAll {
 
 Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
     It "Should fail when ApplicationId is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Cannot process argument transformation on parameter '-ApplicationId'*"
+        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: ApplicationId*"
     }
 
     It "Should fail when ApplicationId value is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId } | Should -Throw "Cannot process argument transformation on parameter '-ApplicationId'*"
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId } | Should -Throw "Missing an argument for parameter 'ApplicationId'*"
     }
 
     It "Should fail when ApplicationId is null" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null } | Should -Throw "Cannot process argument transformation on parameter '-ApplicationId'*"
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null } | Should -Throw "Cannot validate argument on parameter 'ApplicationId'*"
     }
     
     It "Should fail when ApplicationSegmentId value is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'*"
     }
 
     It "Should execute successfully without throwing an error" {

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -7,28 +7,26 @@ BeforeAll {
         Import-Module Microsoft.Entra.Beta.NetworkAccess    
     }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.NetworkAccess
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All") } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
     It "Should fail when ApplicationId is missing" {
-        $result = Remove-EntraBetaPrivateAccessApplicationSegment 
-        $result | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
+        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
     }
 
     It "Should fail when ApplicationId is missing" {
-        $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null 
-        $result | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null } | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
     }
     
     It "Should fail when ApplicationSegmentId is missing" {
-        $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" 
-        $result | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
     }   
 
     It "Should fail when ApplicationSegmentId is missing" {
-        $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId $null 
-        $result | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId $null } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
     }
 
     It "Should execute successfully without throwing an error" {
@@ -38,8 +36,7 @@ Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
 
         try {
             # Act & Assert: Ensure the function doesn't throw an exception
-            $result = Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId "TestAppSegmentId"
-            $result | Should -Not -Throw
+            { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId "TestAppSegmentId" } | Should -Not -Throw
         }
         finally {
             # Restore original confirmation preference            

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -14,19 +14,19 @@ BeforeAll {
 
 Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
     It "Should fail when ApplicationId is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
+        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Cannot process argument transformation on parameter '-ApplicationId'*"
     }
 
-    It "Should fail when ApplicationId is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null } | Should -Throw "Missing an argument for parameter 'ApplicationId'. Specify a parameter of type 'System.String' and try again."
+    It "Should fail when ApplicationId value is missing" {
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId } | Should -Throw "Cannot process argument transformation on parameter '-ApplicationId'*"
+    }
+
+    It "Should fail when ApplicationId is null" {
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId $null } | Should -Throw "Cannot process argument transformation on parameter '-ApplicationId'*"
     }
     
-    It "Should fail when ApplicationSegmentId is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
-    }   
-
-    It "Should fail when ApplicationSegmentId is missing" {
-        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId $null } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
+    It "Should fail when ApplicationSegmentId value is missing" {
+        { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId } | Should -Throw "Missing an argument for parameter 'ApplicationSegmentId'. Specify a parameter of type 'System.String' and try again."
     }
 
     It "Should execute successfully without throwing an error" {
@@ -37,6 +37,21 @@ Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
         try {
             # Act & Assert: Ensure the function doesn't throw an exception
             { Remove-EntraBetaPrivateAccessApplicationSegment -ApplicationId "TestApplicationId" -ApplicationSegmentId "TestAppSegmentId" } | Should -Not -Throw
+        }
+        finally {
+            # Restore original confirmation preference            
+            $DebugPreference = $originalDebugPreference        
+        }
+    }
+
+    It "Should execute successfully without throwing an error when using an Alias" {
+        # Disable confirmation prompts       
+        $originalDebugPreference = $DebugPreference
+        $DebugPreference = 'Continue'
+
+        try {
+            # Act & Assert: Ensure the function doesn't throw an exception
+            { Remove-EntraBetaPrivateAccessApplicationSegment -ObjectId "TestApplicationId" -ApplicationSegmentId "TestAppSegmentId" } | Should -Not -Throw
         }
         finally {
             # Restore original confirmation preference            


### PR DESCRIPTION
# Description
- Updated the cmdlet binding for `Remove-EntraBetaPrivateAccessApplicationSegment` command to `DefaultParameterSetName` which resolves an issue where the function was not being found as listed in this issue #1517 
- Added unit test for `Remove-EntraBetaPrivateAccessApplicationSegment`.
- Added validation for `-ApplicationId` parameter.
- Added help messages for both `-ApplicationId` and `-ApplicationSegmentId` parameters.

Issue: #1517 