### PR TITLE
356 - Added Authentication check on Governance sub-module's cmdlets

### DIFF
--- a/module/Entra/Microsoft.Entra/Governance/Get-EntraDirectoryRoleAssignment.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/Get-EntraDirectoryRoleAssignment.ps1
@@ -26,6 +26,15 @@ function Get-EntraDirectoryRoleAssignment {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use ' Connect-Entra -Scopes RoleManagement.Read.Directory, EntitlementManagement.Read.All ' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/Governance/Get-EntraDirectoryRoleDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/Get-EntraDirectoryRoleDefinition.ps1
@@ -21,6 +21,16 @@ function Get-EntraDirectoryRoleDefinition {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory, EntitlementManagement.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/Governance/New-EntraDirectoryRoleAssignment.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/New-EntraDirectoryRoleAssignment.ps1
@@ -16,6 +16,15 @@ function New-EntraDirectoryRoleAssignment {
         [System.String] $RoleDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory, EntitlementManagement.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/Governance/New-EntraDirectoryRoleDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/New-EntraDirectoryRoleDefinition.ps1
@@ -28,6 +28,15 @@ function New-EntraDirectoryRoleDefinition {
         [System.String] $DisplayName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/Governance/Remove-EntraDirectoryRoleAssignment.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/Remove-EntraDirectoryRoleAssignment.ps1
@@ -10,6 +10,15 @@ function Remove-EntraDirectoryRoleAssignment {
         [System.String] $UnifiedRoleAssignmentId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory, EntitlementManagement.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/Governance/Remove-EntraDirectoryRoleDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/Remove-EntraDirectoryRoleDefinition.ps1
@@ -10,6 +10,15 @@ function Remove-EntraDirectoryRoleDefinition {
         [System.String] $UnifiedRoleDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/Governance/Set-EntraDirectoryRoleDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/Governance/Set-EntraDirectoryRoleDefinition.ps1
@@ -31,6 +31,15 @@ function Set-EntraDirectoryRoleDefinition {
         [System.String] $DisplayName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/docs/entra-powershell-v1.0/Governance/Remove-EntraDirectoryRoleAssignment.md
+++ b/module/docs/entra-powershell-v1.0/Governance/Remove-EntraDirectoryRoleAssignment.md
@@ -40,7 +40,7 @@ In delegated scenarios, the signed-in user must have either a supported Microsof
 ### Example 1: Remove a role assignment
 
 ```powershell
-Connect-Entra -Scopes 'RoleManagement.ReadWrite.Directory', 'EntitlementManagement.ReadWrite.All'1
+Connect-Entra -Scopes 'RoleManagement.ReadWrite.Directory', 'EntitlementManagement.ReadWrite.All'
 $user = Get-EntraUser -UserId 'SawyerM@contoso.com'
 $role = Get-EntraDirectoryRoleDefinition -Filter "DisplayName eq 'Helpdesk Administrator'"
 $assignment = Get-EntraDirectoryRoleAssignment -All | Where-Object { $_.principalId -eq $user.Id -AND $_.RoleDefinitionId -eq $role.Id }

--- a/test/Entra/Governance/Get-EntraDirectoryRoleAssignment.Tests.ps1
+++ b/test/Entra/Governance/Get-EntraDirectoryRoleAssignment.Tests.ps1
@@ -27,6 +27,15 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgRoleManagementDirectoryRoleAssignment -MockWith $scriptblock -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.Read.Directory', 'EntitlementManagement.Read.All')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
 
 Describe "Get-EntraDirectoryRoleAssignment" {

--- a/test/Entra/Governance/Get-EntraDirectoryRoleAssignment.Tests.ps1
+++ b/test/Entra/Governance/Get-EntraDirectoryRoleAssignment.Tests.ps1
@@ -35,7 +35,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.Read.Directory', 'EntitlementManagement.Read.All')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
 
 Describe "Get-EntraDirectoryRoleAssignment" {

--- a/test/Entra/Governance/Get-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/Get-EntraDirectoryRoleDefinition.Tests.ps1
@@ -30,6 +30,15 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgRoleManagementDirectoryRoleDefinition -MockWith $scriptblock -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.Read.Directory', 'EntitlementManagement.Read.All')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
 
 Describe "Get-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/Get-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/Get-EntraDirectoryRoleDefinition.Tests.ps1
@@ -38,7 +38,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.Read.Directory', 'EntitlementManagement.Read.All')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
 
 Describe "Get-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/New-EntraDirectoryRoleAssignment.Tests.ps1
+++ b/test/Entra/Governance/New-EntraDirectoryRoleAssignment.Tests.ps1
@@ -27,6 +27,15 @@ BeforeAll {
     }
 
     Mock -CommandName New-MgRoleManagementDirectoryRoleAssignment -MockWith $scriptblock -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.ReadWrite.Directory', 'EntitlementManagement.ReadWrite.All')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
 
 Describe "New-EntraDirectoryRoleAssignment" {

--- a/test/Entra/Governance/New-EntraDirectoryRoleAssignment.Tests.ps1
+++ b/test/Entra/Governance/New-EntraDirectoryRoleAssignment.Tests.ps1
@@ -35,7 +35,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.ReadWrite.Directory', 'EntitlementManagement.ReadWrite.All')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
 
 Describe "New-EntraDirectoryRoleAssignment" {

--- a/test/Entra/Governance/New-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/New-EntraDirectoryRoleDefinition.Tests.ps1
@@ -37,7 +37,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.ReadWrite.Directory')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
 
 Describe "New-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/New-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/New-EntraDirectoryRoleDefinition.Tests.ps1
@@ -29,6 +29,15 @@ BeforeAll {
     }
 
     Mock -CommandName New-MgRoleManagementDirectoryRoleDefinition -MockWith $scriptblock -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.ReadWrite.Directory')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
 
 Describe "New-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/Remove-EntraDirectoryRoleAssignment.Tests.ps1
+++ b/test/Entra/Governance/Remove-EntraDirectoryRoleAssignment.Tests.ps1
@@ -8,6 +8,15 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgRoleManagementDirectoryRoleAssignment -MockWith {} -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.ReadWrite.Directory', 'EntitlementManagement.ReadWrite.All')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
   
 Describe "Remove-EntraDirectoryRoleAssignment" {

--- a/test/Entra/Governance/Remove-EntraDirectoryRoleAssignment.Tests.ps1
+++ b/test/Entra/Governance/Remove-EntraDirectoryRoleAssignment.Tests.ps1
@@ -16,7 +16,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.ReadWrite.Directory', 'EntitlementManagement.ReadWrite.All')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
   
 Describe "Remove-EntraDirectoryRoleAssignment" {

--- a/test/Entra/Governance/Remove-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/Remove-EntraDirectoryRoleDefinition.Tests.ps1
@@ -8,6 +8,15 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgRoleManagementDirectoryRoleDefinition -MockWith {} -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.ReadWrite.Directory')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
 
 Describe "Remove-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/Remove-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/Remove-EntraDirectoryRoleDefinition.Tests.ps1
@@ -16,7 +16,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.ReadWrite.Directory')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
 
 Describe "Remove-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/Set-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/Set-EntraDirectoryRoleDefinition.Tests.ps1
@@ -8,6 +8,15 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Update-MgRoleManagementDirectoryRoleDefinition -MockWith {} -ModuleName Microsoft.Entra.Governance
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('RoleManagement.ReadWrite.Directory')
+        }
+    } -ModuleName Microsoft.Entra.Applications
 }
   
 Describe "Set-EntraDirectoryRoleDefinition" {

--- a/test/Entra/Governance/Set-EntraDirectoryRoleDefinition.Tests.ps1
+++ b/test/Entra/Governance/Set-EntraDirectoryRoleDefinition.Tests.ps1
@@ -16,7 +16,7 @@ BeforeAll {
             }
             Scopes      = @('RoleManagement.ReadWrite.Directory')
         }
-    } -ModuleName Microsoft.Entra.Applications
+    } -ModuleName Microsoft.Entra.Governance
 }
   
 Describe "Set-EntraDirectoryRoleDefinition" {


### PR DESCRIPTION
# Changes
- Added Authentication checks for governance cmdlets namely:
   - Get-EntraDirectoryRoleAssignment
   - Get-EntraDirectoryRoleDefinition
   - Get-EntraUnsupportedCommand
   - New-EntraCustomHeaders
   - New-EntraDirectoryRoleAssignment
   - New-EntraDirectoryRoleDefinition
   - Remove-EntraDirectoryRoleAssignment
   - Remove-EntraDirectoryRoleDefinition
   - Set-EntraDirectoryRoleDefinition
- Updated tests to mock `Get-EntraContext` for all the cmdlets listed above.

# Issue
Link: #356  