### PR TITLE
356 - Added authentication checks for Reports cmdlets in Entra and Entra Beta

### DIFF
--- a/module/Entra/Microsoft.Entra/Reports/Get-EntraAuditDirectoryLog.ps1
+++ b/module/Entra/Microsoft.Entra/Reports/Get-EntraAuditDirectoryLog.ps1
@@ -19,6 +19,15 @@ function Get-EntraAuditDirectoryLog {
         [System.String] $Filter
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $params = @{}

--- a/module/Entra/Microsoft.Entra/Reports/Get-EntraAuditSignInLog.ps1
+++ b/module/Entra/Microsoft.Entra/Reports/Get-EntraAuditSignInLog.ps1
@@ -20,6 +20,15 @@ function Get-EntraAuditSignInLog {
         [System.String] $Filter
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaApplicationSignInDetailedSummary.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaApplicationSignInDetailedSummary.ps1
@@ -18,6 +18,15 @@ function Get-EntraBetaApplicationSignInDetailedSummary {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Reports.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaApplicationSignInSummary.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaApplicationSignInSummary.ps1
@@ -17,6 +17,15 @@ function Get-EntraBetaApplicationSignInSummary {
         [System.Nullable`1[System.Int32]] $Top
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Reports.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {  
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaAuditDirectoryLog.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaAuditDirectoryLog.ps1
@@ -21,6 +21,15 @@ function Get-EntraBetaAuditDirectoryLog {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaAuditSignInLog.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaAuditSignInLog.ps1
@@ -21,6 +21,15 @@ function Get-EntraBetaAuditSignInLog {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaCrossTenantAccessActivity.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Reports/Get-EntraBetaCrossTenantAccessActivity.ps1
@@ -20,9 +20,15 @@ function Get-EntraBetaCrossTenantAccessActivity {
     )
 
     begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, CrossTenantInfo.ReadBasic.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
         
-        $currentTenantId = (Get-EntraContext).TenantId        
         #External Tenant ID check
+        $currentTenantId = (Get-EntraContext).TenantId        
         if ($ExternalTenantId) {
             Write-Verbose -Message "$(Get-Date -f T) - Checking supplied external tenant ID - $ExternalTenantId..."
 

--- a/test/Entra/Reports/Get-EntraAuditDirectoryLog.Tests.ps1
+++ b/test/Entra/Reports/Get-EntraAuditDirectoryLog.Tests.ps1
@@ -37,6 +37,15 @@ BeforeAll {
         )
     }
 
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('AuditLog.Read.All', 'Directory.Read.All')
+        }
+    } -ModuleName Microsoft.Entra.Reports
+
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Reports
 }
   

--- a/test/Entra/Reports/Get-EntraAuditDirectoryLog.Tests.ps1
+++ b/test/Entra/Reports/Get-EntraAuditDirectoryLog.Tests.ps1
@@ -51,6 +51,11 @@ BeforeAll {
   
 Describe "Get-EntraAuditDirectoryLog" {
     Context "Test for Get-EntraAuditDirectoryLog" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Reports
+            { Get-EntraAuditDirectoryLog -Id "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Reports -Times 0
+        }
         It "Should return specific Audit Directory Logs" {
             $result = Get-EntraAuditDirectoryLog -Id "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Reports/Get-EntraAuditSignInLog.Tests.ps1
+++ b/test/Entra/Reports/Get-EntraAuditSignInLog.Tests.ps1
@@ -54,6 +54,12 @@ BeforeAll {
   
 Describe "Get-EntraAuditSignInLog" {
     Context "Test for Get-EntraAuditSignInLog" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Reports
+            { Get-EntraAuditSignInLog -SignInId "bbbbbbbb-1111-2222-3333-cccccccccc22" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Reports -Times 0
+        }
+        
         It "Should return specific Audit SignIn Logs" {
             $result = Get-EntraAuditSignInLog -SignInId "bbbbbbbb-1111-2222-3333-cccccccccc22"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Reports/Get-EntraAuditSignInLog.Tests.ps1
+++ b/test/Entra/Reports/Get-EntraAuditSignInLog.Tests.ps1
@@ -36,11 +36,18 @@ BeforeAll {
                 resourceId                  =   'bbbbbbbb-1111-2222-3333-cccccccccc66'
                 riskEventTypes              =   @{}
                 riskState                  =    'none'
-
-
             }
         )
     }
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('AuditLog.Read.All', 'Directory.Read.All')
+        }
+    } -ModuleName Microsoft.Entra.Reports
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Reports
 }

--- a/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInDetailedSummary.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInDetailedSummary.Tests.ps1
@@ -26,7 +26,7 @@ BeforeAll {
             }
         )
     }
-
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Reports.Read.All") } } -ModuleName Microsoft.Entra.Beta.Reports
     Mock -CommandName Get-MgBetaReportApplicationSignInDetailedSummary -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Reports
 }
 

--- a/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInDetailedSummary.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInDetailedSummary.Tests.ps1
@@ -32,6 +32,11 @@ BeforeAll {
 
 Describe "Get-EntraBetaApplicationSignInDetailedSummary" {
     Context "Test for Get-EntraBetaApplicationSignInDetailedSummary" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
+            { Get-EntraBetaApplicationSignInDetailedSummary -Filter "appDisplayName eq 'Mock Portal'" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaReportApplicationSignInDetailedSummary -ModuleName Microsoft.Entra.Beta.Reports -Times 0
+        }
         It "Should return specific application signed in detailed summary by filter" {
             $result = Get-EntraBetaApplicationSignInDetailedSummary -Filter "appDisplayName eq 'Mock Portal'"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInSummary.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInSummary.Tests.ps1
@@ -27,7 +27,7 @@ $scriptblock = {
         }
 
     }
-
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Reports.Read.All") } } -ModuleName Microsoft.Entra.Beta.Reports
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Reports
 }
 

--- a/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInSummary.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaApplicationSignInSummary.Tests.ps1
@@ -33,6 +33,11 @@ $scriptblock = {
 
 Describe "Get-EntraBetaApplicationSignInSummary" {
     Context "Test for Get-EntraBetaApplicationSignInSummary" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
+            { Get-EntraBetaApplicationSignInSummary -Days "30" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Reports -Times 0
+        }
         It "Should return application sign in summary" {
             $result = Get-EntraBetaApplicationSignInSummary -Days "30" 
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Reports/Get-EntraBetaAuditDirectoryLog.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuditDirectoryLog.Tests.ps1
@@ -50,12 +50,18 @@ BeforeAll {
             Scopes      = @('AuditLog.Read.All', 'Directory.Read.All')
         }
     } -ModuleName Microsoft.Entra.Beta.Reports
-    
+
     Mock -CommandName Get-MgBetaAuditLogDirectoryAudit -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Reports
 }
   
 Describe "Get-EntraBetaAuditDirectoryLog" {
     Context "Test for Get-EntraBetaAuditDirectoryLog" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
+            { Get-EntraBetaAuditDirectoryLog -Id "bbbbcccc-1111-dddd-2222-eeee3333ffff" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaAuditLogDirectoryAudit -ModuleName Microsoft.Entra.Beta.Reports -Times 0
+        }
+
         It "Should get all logs" {
             $result = Get-EntraBetaAuditDirectoryLog  -All
             $result | Should -Not -BeNullOrEmpty            

--- a/test/EntraBeta/Reports/Get-EntraBetaAuditDirectoryLog.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuditDirectoryLog.Tests.ps1
@@ -41,6 +41,16 @@ BeforeAll {
             }
         )
     }    
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('AuditLog.Read.All', 'Directory.Read.All')
+        }
+    } -ModuleName Microsoft.Entra.Beta.Reports
+    
     Mock -CommandName Get-MgBetaAuditLogDirectoryAudit -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Reports
 }
   

--- a/test/EntraBeta/Reports/Get-EntraBetaAuditDirectoryLog.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuditDirectoryLog.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Get-EntraBetaAuditDirectoryLog" {
     Context "Test for Get-EntraBetaAuditDirectoryLog" {
         It "Should throw when not connected and not invoke SDK" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
-            { Get-EntraBetaAuditDirectoryLog -Id "bbbbcccc-1111-dddd-2222-eeee3333ffff" } | Should -Throw "Not connected to Microsoft Graph*"
+            { Get-EntraBetaAuditDirectoryLog -Top 1 -Debug } | Should -Throw "Not connected to Microsoft Graph*"
             Should -Invoke -CommandName Get-MgBetaAuditLogDirectoryAudit -ModuleName Microsoft.Entra.Beta.Reports -Times 0
         }
 

--- a/test/EntraBeta/Reports/Get-EntraBetaAuditSignInLog.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuditSignInLog.Tests.ps1
@@ -195,6 +195,12 @@ BeforeAll {
   
 Describe "Get-EntraBetaAuditSignInLog" {
     Context "Test for Get-EntraBetaAuditSignInLog" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
+            { Get-EntraBetaAuditSignInLog -SignInId "bbbbbbbb-1111-2222-3333-cccccccccc22" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaAuditLogSignIn -ModuleName Microsoft.Entra.Beta.Reports -Times 0
+        }
+
         It "Should get all logs" {
             $result = Get-EntraBetaAuditSignInLog -All
             $result | Should -Not -BeNullOrEmpty            

--- a/test/EntraBeta/Reports/Get-EntraBetaAuditSignInLog.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuditSignInLog.Tests.ps1
@@ -197,7 +197,7 @@ Describe "Get-EntraBetaAuditSignInLog" {
     Context "Test for Get-EntraBetaAuditSignInLog" {
         It "Should throw when not connected and not invoke SDK" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
-            { Get-EntraBetaAuditSignInLog -SignInId "bbbbbbbb-1111-2222-3333-cccccccccc22" } | Should -Throw "Not connected to Microsoft Graph*"
+            { Get-EntraBetaAuditSignInLog -Top 1 } | Should -Throw "Not connected to Microsoft Graph*"
             Should -Invoke -CommandName Get-MgBetaAuditLogSignIn -ModuleName Microsoft.Entra.Beta.Reports -Times 0
         }
 

--- a/test/EntraBeta/Reports/Get-EntraBetaAuditSignInLog.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuditSignInLog.Tests.ps1
@@ -179,7 +179,17 @@ BeforeAll {
                 "Parameters"           = $args
             }
         )
-    }    
+    } 
+    
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes      = @('AuditLog.Read.All', 'Directory.Read.All')
+        }
+    } -ModuleName Microsoft.Entra.Beta.Reports
+
     Mock -CommandName Get-MgBetaAuditLogSignIn -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Reports
 }
   

--- a/test/EntraBeta/Reports/Get-EntraBetaAuthenticationMethodUserRegistrationDetailReport.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaAuthenticationMethodUserRegistrationDetailReport.Tests.ps1
@@ -30,6 +30,11 @@ BeforeAll {
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("AuditLog.Read.All") } } -ModuleName Microsoft.Entra.Beta.Reports
 }
 Describe "Tests for Get-EntraBetaAuthenticationMethodUserRegistrationDetailReport" {
+    It "Should throw when not connected and not invoke SDK" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
+        { Get-EntraBetaAuthenticationMethodUserRegistrationDetailReport -UserRegistrationDetailsId "aaaaaaaa-2222-3333-4444-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-MgGraphRequest -ModuleName Microsoft.Entra.Beta.Reports -Times 0
+    }
     It "Result should not be empty" {
         $result = Get-EntraBetaAuthenticationMethodUserRegistrationDetailReport -UserRegistrationDetailsId "aaaaaaaa-2222-3333-4444-bbbbbbbbbbbb"
         $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Reports/Get-EntraBetaCrossTenantAccessActivity.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaCrossTenantAccessActivity.Tests.ps1
@@ -24,7 +24,7 @@ Describe "Get-EntraBetaCrossTenantAccessActivity" {
 
     It "Should throw when not connected and not invoke graph call" {
         Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
-        { Get-EntraBetaCrossTenantAccessActivity { @{} } } | Should -Throw "Not connected to Microsoft Graph*"
+        { Get-EntraBetaCrossTenantAccessActivity } | Should -Throw "Not connected to Microsoft Graph*"
         Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Reports -Times 0
     }
 

--- a/test/EntraBeta/Reports/Get-EntraBetaCrossTenantAccessActivity.Tests.ps1
+++ b/test/EntraBeta/Reports/Get-EntraBetaCrossTenantAccessActivity.Tests.ps1
@@ -22,6 +22,12 @@ Describe "Get-EntraBetaCrossTenantAccessActivity" {
         }
     }
 
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Reports
+        { Get-EntraBetaCrossTenantAccessActivity { @{} } } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Reports -Times 0
+    }
+
     It "Calls Get-EntraBetaCrossTenantAccessActivity with no parameters" {
         Mock Get-EntraBetaCrossTenantAccessActivity {
             @{


### PR DESCRIPTION
# Changes
- Added authentication checks for these Reports sub-module cmdlets in Entra:
   - Get-EntraAuditDirectoryLog
   - Get-EntraAuditSignInLog
- Added authentication checks for these Reports sub-module cmdlets in Entra Beta:
   - Get-EntraBetaAuditSignInLog
   - Get-EntraBetaAuditDirectoryLog
   - Get-EntraBetaApplicationSignInDetailedSummary
   - Get-EntraBetaApplicationSignInSummary

- Updated tests to mock `Get-EntraContext` for all the cmdlets listed above.
- Added scenario tests for all tests to validate a missing auth scenario.

# Issue
Link: #356  