### PR TITLE
356 - Added authentication checks for Network Access sub-module on Entra Beta

### DIFF
--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Enable-EntraBetaGlobalSecureAccessTenant.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Enable-EntraBetaGlobalSecureAccessTenant.ps1
@@ -3,6 +3,15 @@
 #  Licensed under the MIT License.  See License in the project root for license information. 
 # ------------------------------------------------------------------------------ 
 function Enable-EntraBetaGlobalSecureAccessTenant {
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         try {
             # Create custom headers for the request

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Get-EntraBetaGlobalSecureAccessTenantStatus.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Get-EntraBetaGlobalSecureAccessTenantStatus.ps1
@@ -3,6 +3,15 @@
 #  Licensed under the MIT License.  See License in the project root for license information. 
 # ------------------------------------------------------------------------------ 
 function Get-EntraBetaGlobalSecureAccessTenantStatus {
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     PROCESS {
         try {
             # Create custom headers for the request

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.ps1
@@ -16,6 +16,15 @@ function Get-EntraBetaPrivateAccessApplication {
         $ApplicationName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         try {
             # Create custom headers for the request

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Get-EntraBetaPrivateAccessApplicationSegment.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Get-EntraBetaPrivateAccessApplicationSegment.ps1
@@ -16,6 +16,15 @@ function Get-EntraBetaPrivateAccessApplicationSegment {
         $ApplicationSegmentId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         try {
             # Create custom headers for the request

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaPrivateAccessApplication.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaPrivateAccessApplication.ps1
@@ -15,6 +15,15 @@ function New-EntraBetaPrivateAccessApplication {
         $ConnectorGroupId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         try {
             # Create custom headers for the request

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.ps1
@@ -30,6 +30,15 @@ function New-EntraBetaPrivateAccessApplicationSegment {
         $DestinationType
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         try {
             # Create custom headers for the request

--- a/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.ps1
@@ -15,6 +15,15 @@ function Remove-EntraBetaPrivateAccessApplicationSegment {
         [System.String] $ApplicationSegmentId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes NetworkAccessPolicy.ReadWrite.All, Application.ReadWrite.All, NetworkAccess.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         try {
             # Create custom headers for the request

--- a/test/EntraBeta/NetworkAccess/Enable-EntraBetaGlobalSecureAccessTenant.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Enable-EntraBetaGlobalSecureAccessTenant.Tests.ps1
@@ -1,0 +1,38 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {
+    if ((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.NetworkAccess
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith { @{ } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
+}
+
+Describe "Enable-EntraBetaGlobalSecureAccessTenant" {
+    It "Should throw when not connected and not call Graph" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+        { Enable-EntraBetaGlobalSecureAccessTenant } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+    }
+
+    It "Should POST onboard and output success message" {
+        $out = Enable-EntraBetaGlobalSecureAccessTenant
+        $out | Should -Be "Global Secure Access Tenant has been successfully enabled."
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq "/beta/networkAccess/microsoft.graph.networkaccess.onboard" -and $Headers.'User-Agent' -like "PowerShell/* EntraPowershell/* Enable-EntraBetaGlobalSecureAccessTenant"
+        }
+    }
+}

--- a/test/EntraBeta/NetworkAccess/Enable-EntraBetaGlobalSecureAccessTenant.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Enable-EntraBetaGlobalSecureAccessTenant.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "Enable-EntraBetaGlobalSecureAccessTenant" {

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaGlobalSecureAccessTenantStatus.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaGlobalSecureAccessTenantStatus.Tests.ps1
@@ -1,0 +1,38 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {
+    if ((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.NetworkAccess
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith { @{ value = @{ state = 'enabled' } } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
+}
+
+Describe "Get-EntraBetaGlobalSecureAccessTenantStatus" {
+    It "Should throw when not connected and not call Graph" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+        { Get-EntraBetaGlobalSecureAccessTenantStatus } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+    }
+
+    It "Should GET tenant status and return response" {
+        $out = Get-EntraBetaGlobalSecureAccessTenantStatus
+        $out | Should -Not -BeNullOrEmpty
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+            $Method -eq 'GET' -and $Uri -eq "/beta/networkAccess/tenantStatus" -and $Headers.'User-Agent' -like "PowerShell/* EntraPowershell/* Get-EntraBetaGlobalSecureAccessTenantStatus"
+        }
+    }
+}

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaGlobalSecureAccessTenantStatus.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaGlobalSecureAccessTenantStatus.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "Get-EntraBetaGlobalSecureAccessTenantStatus" {

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.Tests.ps1
@@ -1,0 +1,60 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {
+    if ((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.NetworkAccess
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
+}
+
+Describe "Get-EntraBetaPrivateAccessApplication" {
+    Context "Connection checks" {
+        It "Should throw when not connected and not call Graph" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+            { Get-EntraBetaPrivateAccessApplication } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+        }
+    }
+
+    Context "All apps" {
+        It "Should GET all private access applications" {
+            Get-EntraBetaPrivateAccessApplication
+
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like "/beta/applications*" -and $Headers.'User-Agent' -like "PowerShell/* EntraPowershell/* Get-EntraBetaPrivateAccessApplication"
+            }
+        }
+    }
+
+    Context "By id and by name" {
+        It "Should GET app by id" {
+            Get-EntraBetaPrivateAccessApplication -ApplicationId "app-1"
+
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -eq "/beta/applications/app-1/?`$select=displayName,appId,id,tags,createdDateTime,servicePrincipalType,createdDateTime,servicePrincipalNames"
+            }
+        }
+
+        It "Should GET app by name" {
+            Get-EntraBetaPrivateAccessApplication -ApplicationName "MyApp"
+
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like "/beta/applications?*DisplayName eq 'MyApp'*"
+            }
+        }
+    }
+}

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "Get-EntraBetaPrivateAccessApplication" {

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplication.Tests.ps1
@@ -8,7 +8,13 @@ BeforeAll {
     }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
-    Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.NetworkAccess
+    Mock -CommandName Invoke-GraphRequest -MockWith { 
+        @{
+            value = @(
+                [PSCustomObject]@{name = "MyApp"}
+            )
+        }
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 
     Mock -CommandName Get-EntraContext -MockWith {
         @{

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "Get-EntraBetaPrivateAccessApplicationSegment" {

--- a/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Get-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -1,0 +1,45 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {
+    if ((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.NetworkAccess
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith { @{ value = @() } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
+}
+
+Describe "Get-EntraBetaPrivateAccessApplicationSegment" {
+    It "Should throw when not connected and not call Graph" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+        { Get-EntraBetaPrivateAccessApplicationSegment -ApplicationId app1 } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+    }
+
+    It "Should GET all segments by application id" {
+        Get-EntraBetaPrivateAccessApplicationSegment -ApplicationId app1
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+            $Method -eq 'GET' -and $Uri -eq "/beta/applications/app1/onPremisesPublishing/segmentsConfiguration/microsoft.graph.ipSegmentConfiguration/applicationSegments"
+        }
+    }
+
+    It "Should GET a single segment by id" {
+        Get-EntraBetaPrivateAccessApplicationSegment -ApplicationId app1 -ApplicationSegmentId seg1
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+            $Method -eq 'GET' -and $Uri -eq "/beta/applications/app1/onPremisesPublishing/segmentsConfiguration/microsoft.graph.ipSegmentConfiguration/applicationSegments/seg1"
+        }
+    }
+}

--- a/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplication.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplication.Tests.ps1
@@ -1,0 +1,55 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {
+    if ((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.NetworkAccess
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Get-EntraEnvironment -MockWith { @{ GraphEndpoint = 'https://graph.microsoft.com' } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    # default empty response
+    Mock -CommandName Invoke-GraphRequest -MockWith { @{ application = @{ objectId = 'new-app-id' } } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
+}
+
+Describe "New-EntraBetaPrivateAccessApplication" {
+    It "Should throw when not connected and not call Graph" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+        { New-EntraBetaPrivateAccessApplication -ApplicationName 'MyApp' } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+    }
+
+    It "Should create app and patch ZTNA settings" {
+        New-EntraBetaPrivateAccessApplication -ApplicationName 'MyApp'
+
+        # instantiate template
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq '/beta/applicationTemplates/8adf8e6e-67b2-4cf2-a259-e3dc5476c621/instantiate'
+        } -Times 1
+
+        # patch app settings
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -ParameterFilter {
+            $Method -eq 'PATCH' -and $Uri -eq "/beta/applications/new-app-id/"
+        } -Times 1
+    }
+
+    It "Should assign connector group when ConnectorGroupId is provided" {
+        New-EntraBetaPrivateAccessApplication -ApplicationName 'MyApp' -ConnectorGroupId 'cg1'
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -ParameterFilter {
+            $Method -eq 'PUT' -and $Uri -eq "/beta/applications/new-app-id/connectorGroup/`$ref"
+        } -Times 1
+    }
+}

--- a/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplication.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplication.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "New-EntraBetaPrivateAccessApplication" {

--- a/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "New-EntraBetaPrivateAccessApplicationSegment" {

--- a/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/New-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.
+#  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+BeforeAll {
+    if ((Get-Module -Name Microsoft.Entra.Beta.NetworkAccess) -eq $null) {
+        Import-Module Microsoft.Entra.Beta.NetworkAccess
+    }
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Invoke-GraphRequest -MockWith { @{ id = 'seg1' } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
+}
+
+Describe "New-EntraBetaPrivateAccessApplicationSegment" {
+    It "Should throw when not connected and not call Graph" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+        { New-EntraBetaPrivateAccessApplicationSegment -ApplicationId app1 -DestinationHost 'api.contoso.com' -DestinationType 'dnsSuffix' } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+    }
+
+    It "Should POST segment with dnsSuffix" {
+        New-EntraBetaPrivateAccessApplicationSegment -ApplicationId app1 -DestinationHost 'api.contoso.com' -DestinationType 'dnsSuffix'
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq "/beta/applications/app1/onPremisesPublishing/segmentsConfiguration/microsoft.graph.ipSegmentConfiguration/applicationSegments/"
+        }
+    }
+
+    It "Should POST segment with IP details and ports/protocol" {
+        New-EntraBetaPrivateAccessApplicationSegment -ApplicationId app1 -DestinationHost '10.0.0.1' -DestinationType 'ipAddress' -Ports 80,443 -Protocol TCP
+
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 1 -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq "/beta/applications/app1/onPremisesPublishing/segmentsConfiguration/microsoft.graph.ipSegmentConfiguration/applicationSegments/"
+        }
+    }
+}

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
             }
             Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
         }
-    } -ModuleName Microsoft.Entra.NetworkAccess
+    } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 }
 
 Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -9,10 +9,25 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.NetworkAccess
-    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All") } } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+    Mock -CommandName Get-EntraContext -MockWith {
+        @{
+            Environment = @{
+                Name = "Global"
+            }
+            Scopes = @("NetworkAccessPolicy.ReadWrite.All", "Application.ReadWrite.All", "NetworkAccess.ReadWrite.All")
+        }
+    } -ModuleName Microsoft.Entra.NetworkAccess
 }
 
 Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
+    It "Should throw when not connected and not call Graph" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
+
+        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
+    }
+    
     It "Should fail when ApplicationId is missing" {
         { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: ApplicationId*"
     }

--- a/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
+++ b/test/EntraBeta/NetworkAccess/Remove-EntraBetaPrivateAccessApplicationSegment.Tests.ps1
@@ -24,7 +24,7 @@ Describe "Remove-EntraBetaPrivateAccessApplicationSegment" {
     It "Should throw when not connected and not call Graph" {
         Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.NetworkAccess
 
-        { Remove-EntraBetaPrivateAccessApplicationSegment } | Should -Throw "Not connected to Microsoft Graph*"
+        { Remove-EntraBetaPrivateAccessApplicationSegment  -ApplicationId "TestApplicationId" -ApplicationSegmentId "TestAppSegmentId" } | Should -Throw "Not connected to Microsoft Graph*"
         Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.NetworkAccess -Times 0
     }
     


### PR DESCRIPTION
# Changes
- Added authentication checks for these NetworkAccess sub-module cmdlets in Entra Beta:
   - Enable-EntraBetaGlobalSecureAccessTenant
   - Get-EntraBetaGlobalSecureAccessTenantStatus
   - Get-EntraBetaPrivateAccessApplication
   - Get-EntraBetaPrivateAccessApplicationSegment
   - New-EntraBetaPrivateAccessApplication
   - New-EntraBetaPrivateAccessApplicationSegment
   - Remove-EntraBetaPrivateAccessApplicationSegment

- Updated tests to mock `Get-EntraContext` for all the cmdlets listed above.
- Added scenario tests for all tests to validate a missing auth scenario.
- Added missing tests

# Issue
Link: #356  