### PR TITLE
356-Added authentication checks for Users submodule for Entra and Entra Beta

### DIFF
--- a/module/Entra/Microsoft.Entra/Users/Get-EntraInactiveSignInUser.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Get-EntraInactiveSignInUser.ps1
@@ -17,6 +17,15 @@ function Get-EntraInactiveSignInUser {
         $UserType = "All"
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     process {
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand 
         $queryDate = (Get-Date).AddDays(-$LastSignInBeforeDaysAgo).ToString("yyyy-MM-ddTHH:mm:ssZ")

--- a/module/Entra/Microsoft.Entra/Users/Get-EntraUser.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Get-EntraUser.ps1
@@ -33,6 +33,15 @@ function Get-EntraUser {
         [System.Nullable`1[System.Int32]] $PageSize
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaInactiveSignInUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaInactiveSignInUser.ps1
@@ -17,6 +17,15 @@ function Get-EntraBetaInactiveSignInUser {
         $UserType = "All"
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AuditLog.Read.All, User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     process {
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand 
         $queryDate = (Get-Date).AddDays(-$LastSignInBeforeDaysAgo).ToString("yyyy-MM-ddTHH:mm:ssZ")

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUser.ps1
@@ -33,6 +33,15 @@ function Get-EntraBetaUser {
         [System.Nullable`1[System.Int32]] $PageSize
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserExtension.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Users/Get-EntraBetaUserExtension.ps1
@@ -21,6 +21,16 @@ function Get-EntraBetaUserExtension {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserExtension.md
+++ b/module/docs/entra-powershell-beta/Users/Get-EntraBetaUserExtension.md
@@ -38,7 +38,7 @@ The `Get-EntraBetaUserExtension` cmdlet gets a user extension in Microsoft Entra
 ### Example 1: Retrieve extension attributes for a user
 
 ```powershell
-Connect-Entra -Scopes 'User.Read'
+Connect-Entra -Scopes 'User.Read.All'
 Get-EntraBetaUserExtension -UserId 'SawyerM@contoso.com'
 ```
 

--- a/test/Entra/Users/Get-EntraDeletedUser.Tests.ps1
+++ b/test/Entra/Users/Get-EntraDeletedUser.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
 
 Describe "Get-EntraDeletedUser" {
     Context "Test for Get-EntraDeletedUser" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraDeletedUser -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDirectoryDeletedItemAsUser -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should return specific Deleted User" {
             $result = Get-EntraDeletedUser -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraInactiveSignInUser.Tests.ps1
+++ b/test/Entra/Users/Get-EntraInactiveSignInUser.Tests.ps1
@@ -67,7 +67,12 @@ BeforeAll {
 Describe 'Get-EntraInactiveSignInUser' {
 
     Context "Get-EntraInactiveSignInUser Tests" {
-        
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraInactiveSignInUser -LastSignInBeforeDaysAgo 30 -UserType "All" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return all inactive users" {
             $result = Get-EntraInactiveSignInUser -LastSignInBeforeDaysAgo 30 -UserType "All"
             

--- a/test/Entra/Users/Get-EntraInactiveSignInUser.Tests.ps1
+++ b/test/Entra/Users/Get-EntraInactiveSignInUser.Tests.ps1
@@ -61,6 +61,7 @@ BeforeAll {
             )
         }
     } -ModuleName Microsoft.Entra.Users
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("AuditLog.Read.All", "User.Read.All") } } -ModuleName Microsoft.Entra.Users
 }
 
 Describe 'Get-EntraInactiveSignInUser' {

--- a/test/Entra/Users/Get-EntraUser.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUser.Tests.ps1
@@ -49,6 +49,7 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Users
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("User.Read.All") } } -ModuleName Microsoft.Entra.Users
 }
   
 Describe "Get-EntraUser" {

--- a/test/Entra/Users/Get-EntraUser.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUser.Tests.ps1
@@ -54,6 +54,12 @@ BeforeAll {
   
 Describe "Get-EntraUser" {
     Context "Test for Get-EntraUser" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUser -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific user" {
             $result = Get-EntraUser -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             Write-Verbose "Result : {$result}" -Verbose

--- a/test/Entra/Users/Get-EntraUserAdministrativeUnit.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserAdministrativeUnit.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Get-EntraUserAdministrativeUnit" {
     Context "Test for Get-EntraUserAdministrativeUnit" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserAdministrativeUnit -UserId 'SawyerM@contoso.com' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserMemberOfAsAdministrativeUnit -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return all user roles" {
             $result = Get-EntraUserAdministrativeUnit -UserId 'SawyerM@contoso.com'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserAppRoleAssignment.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserAppRoleAssignment.Tests.ps1
@@ -32,6 +32,12 @@ BeforeAll {
 
 Describe "Get-EntraUserAppRoleAssignment" {
     Context "Test for Get-EntraUserAppRoleAssignment" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserAppRoleAssignment -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserAppRoleAssignment -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific User" {
             $result = Get-EntraUserAppRoleAssignment -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 

--- a/test/Entra/Users/Get-EntraUserCreatedObject.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserCreatedObject.Tests.ps1
@@ -55,6 +55,12 @@ BeforeAll {
 
 Describe "Get-EntraUserCreatedObject" {
     Context "Test for Get-EntraUserCreatedObject" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserCreatedObject -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserCreatedObject -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should return specific User" {
             $result = Get-EntraUserCreatedObject -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 

--- a/test/Entra/Users/Get-EntraUserDirectReport.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserDirectReport.Tests.ps1
@@ -37,10 +37,10 @@ BeforeAll {
 
 Describe "Get-EntraUserDirectReport" {
     Context "Test for Get-EntraUserDirectReport" {
-        It "should throw when not connected and not invoke SDK" {
+        It "should throw when not connected and not invoke graph call" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
             { Get-EntraUserDirectReport -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
-            Should -Invoke -CommandName Get-MgUserDirectReport -ModuleName Microsoft.Entra.Users -Times 0
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
         }
         
         It "Should return specific user direct report" {

--- a/test/Entra/Users/Get-EntraUserDirectReport.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserDirectReport.Tests.ps1
@@ -37,6 +37,12 @@ BeforeAll {
 
 Describe "Get-EntraUserDirectReport" {
     Context "Test for Get-EntraUserDirectReport" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserDirectReport -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserDirectReport -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should return specific user direct report" {
             $result = Get-EntraUserDirectReport -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserExtension.Test.ps1
+++ b/test/Entra/Users/Get-EntraUserExtension.Test.ps1
@@ -21,6 +21,11 @@ BeforeAll {
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("User.Read.All") } } -ModuleName Microsoft.Entra.Users
 }
 Describe "Tests for Get-EntraUserExtension" {
+    It "should throw when not connected and not invoke SDK" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+        { Get-EntraUserExtension -UserId "SawyerM@contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-MgGraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+    }
     It "Result should not be empty" {
         $result = Get-EntraUserExtension -UserId "SawyerM@contoso.com"
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserGroup.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserGroup.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Get-EntraUserGroup" {
     Context "Test for Get-EntraUserGroup" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserGroup -UserId 'SawyerM@contoso.com' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserMemberOfAsGroup -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should return all user roles" {
             $result = Get-EntraUserGroup -UserId 'SawyerM@contoso.com'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserInactiveSignIn.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserInactiveSignIn.Tests.ps1
@@ -46,6 +46,12 @@ BeforeAll {
 
 Describe "Get-EntraUserInactiveSignIn" {
     Context "Test for Get-EntraUserInactiveSignIn" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserInactiveSignIn -Ago 30 -UserType "All" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUser -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Returns all the Inactive users in a tenant in the last N days." {
             $result = Get-EntraUserInactiveSignIn -Ago 30 -UserType "All"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserLicenseDetail.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserLicenseDetail.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Get-EntraUserLicenseDetail" {
     Context "Test for Get-EntraUserLicenseDetail" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserLicenseDetail -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserLicenseDetail -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should return specific User" {
             $result = Get-EntraUserLicenseDetail -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserManager.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserManager.Tests.ps1
@@ -38,6 +38,12 @@ BeforeAll {
 
 Describe "Get-EntraUserManager" {
     Context "Test for Get-EntraUserManager" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserManager -UserId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific User" {
             $result = Get-EntraUserManager -UserId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserMembership.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserMembership.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
   
 Describe "Get-EntraUserMembership" {
     Context "Test for Get-EntraUserMembership" {
+        It "should throw when not connected and not invoke sdk" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserMembership -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserMemberOf -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific user membership" {
             $result = Get-EntraUserMembership -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserOAuth2PermissionGrant.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserOAuth2PermissionGrant.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
   
 Describe "Get-EntraUserOAuth2PermissionGrant" {
     Context "Test for Get-EntraUserOAuth2PermissionGrant" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserOAuth2PermissionGrant -UserId "aaaaaaaa-bbbb-cccc-1111-222222222222" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserOAuth2PermissionGrant -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific UserOAuth2PermissionGrant" {
             $result = Get-EntraUserOAuth2PermissionGrant -UserId "aaaaaaaa-bbbb-cccc-1111-222222222222"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserOwnedDevice.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserOwnedDevice.Tests.ps1
@@ -48,6 +48,12 @@ BeforeAll {
 
 Describe "Get-EntraUserOwnedDevice" {
     Context "Test for Get-EntraUserOwnedDevice" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserOwnedDevice -UserId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserOwnedDevice -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should get devices owned by a user" {
             $result = Get-EntraUserOwnedDevice -UserId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserOwnedObject.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserOwnedObject.Tests.ps1
@@ -31,6 +31,12 @@ BeforeAll {
 
 Describe "Get-EntraUserOwnedObject" {
     Context "Test for Get-EntraUserOwnedObject" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserOwnedObject -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific User" {
             $result = Get-EntraUserOwnedObject -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             

--- a/test/Entra/Users/Get-EntraUserRegisteredDevice.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserRegisteredDevice.Tests.ps1
@@ -35,6 +35,12 @@ BeforeAll {
 
 Describe "Get-EntraUserRegisteredDevice" {
     Context "Test for Get-EntraUserRegisteredDevice" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserRegisteredDevice -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserRegisteredDevice -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific user registered device" {
             $result = Get-EntraUserRegisteredDevice -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserRole.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserRole.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Get-EntraUserRole" {
     Context "Test for Get-EntraUserRole" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserRole -UserId 'SawyerM@contoso.com' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgUserMemberOfAsDirectoryRole -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should return all user roles" {
             $result = Get-EntraUserRole -UserId 'SawyerM@contoso.com'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/Users/Get-EntraUserSponsor.Tests.ps1
+++ b/test/Entra/Users/Get-EntraUserSponsor.Tests.ps1
@@ -31,6 +31,11 @@ BeforeAll {
 
 Describe "Get-EntraUserSponsor" {
     Context "Test for Get-EntraUserSponsor" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Get-EntraUserSponsor -UserId "acc9f0a1-9075-464f-9fe7-049bf1ae6481" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
 
         It "Should fail when UserId is empty" {
             { Get-EntraUserSponsor -UserId } | Should -Throw "Missing an argument for parameter 'UserId'. Specify a parameter of type 'System.String' and try again."

--- a/test/Entra/Users/New-EntraUser.Tests.ps1
+++ b/test/Entra/Users/New-EntraUser.Tests.ps1
@@ -59,6 +59,13 @@ BeforeAll {
   
 Describe "New-EntraUser" {
     Context "Test for New-EntraUser" {
+        It "should throw when not connected and not invoke graph request" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            $PasswordProfile = New-Object -TypeName Microsoft.Open.AzureAD.Model.PasswordProfile
+            $PasswordProfile.Password = "test@1234"
+            { New-EntraUser -DisplayName "demo002" -PasswordProfile $PasswordProfile -UserPrincipalName "demo001@M365x99297270.OnMicrosoft.com" -AccountEnabled $true -MailNickName "demo002NickName" -AgeGroup "adult" -Mobile "1234567890" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
 
         It "Should return created User" {
             # Define Password Profile

--- a/test/Entra/Users/New-EntraUserAppRoleAssignment.Tests.ps1
+++ b/test/Entra/Users/New-EntraUserAppRoleAssignment.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
   
 Describe "New-EntraUserAppRoleAssignment" {
     Context "Test for New-EntraUserAppRoleAssignment" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { New-EntraUserAppRoleAssignment -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -PrincipalId 'aaaaaaaa-bbbb-cccc-1111-222222222222' -ResourceId 'bbbbbbbb-cccc-dddd-2222-333333333333' -AppRoleId '00aa00aa-bb11-cc22-dd33-44ee44ee44ee' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgUserAppRoleAssignment -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return created Group" {
             $expectedResult = @{
                 Id                   = "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"

--- a/test/Entra/Users/Remove-EntraUser.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUser.Tests.ps1
@@ -15,6 +15,12 @@ BeforeAll {
   
 Describe "Remove-EntraUser" {
     Context "Test for Remove-EntraUser" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Remove-EntraUser -UserId "aaaaaaaa-2222-3333-4444-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgUser -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return empty object" {
             $result = Remove-EntraUser -UserId "aaaaaaaa-2222-3333-4444-bbbbbbbbbbbb"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Remove-EntraUserAppRoleAssignment.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUserAppRoleAssignment.Tests.ps1
@@ -13,6 +13,12 @@ BeforeAll {
   
 Describe "Remove-EntraUserAppRoleAssignment" {
     Context "Test for Remove-EntraUserAppRoleAssignment" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Remove-EntraUserAppRoleAssignment -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -AppRoleAssignmentId '33dd33dd-ee44-ff55-aa66-77bb77bb77bb' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgUserAppRoleAssignment -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return empty object" {
             $result = Remove-EntraUserAppRoleAssignment -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -AppRoleAssignmentId "33dd33dd-ee44-ff55-aa66-77bb77bb77bb"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Remove-EntraUserExtension.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUserExtension.Tests.ps1
@@ -14,6 +14,12 @@ BeforeAll {
 
 Describe "Remove-EntraUserExtension" {
     Context "Test for Remove-EntraUserExtension" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Remove-EntraUserExtension -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionName 'extension_bbbbbbbb111122223333cccccccccccc_TestExtension' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return empty object for single extension" {
             $result = Remove-EntraUserExtension -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionName 'extension_bbbbbbbb111122223333cccccccccccc_TestExtension'
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Remove-EntraUserManager.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUserManager.Tests.ps1
@@ -14,6 +14,11 @@ BeforeAll {
 
 Describe "Remove-EntraUserManager" {
     Context "Test for Remove-EntraUserManager" {
+        It "should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Remove-EntraUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgUserManagerByRef -ModuleName Microsoft.Entra.Users -Times 0
+        }
         It "Should return empty object" {
             $result = Remove-EntraUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Remove-EntraUserSponsor.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUserSponsor.Tests.ps1
@@ -14,6 +14,12 @@ BeforeAll {
 
 Describe "Remove-EntraUserSponsor" {
     Context "Test for Remove-EntraUserSponsor" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Remove-EntraUserSponsor -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -SponsorId "sponsor123" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "Should fail when UserId is empty string value" {
             { Remove-EntraUserSponsor -UserId "" -SponsorId "sponsor123" } | 
             Should -Throw "Cannot validate argument on parameter 'UserId'. UserId must be a valid email address or GUID."

--- a/test/Entra/Users/Remove-EntraUserSponsor.Tests.ps1
+++ b/test/Entra/Users/Remove-EntraUserSponsor.Tests.ps1
@@ -16,7 +16,9 @@ Describe "Remove-EntraUserSponsor" {
     Context "Test for Remove-EntraUserSponsor" {
         It "should throw when not connected and not invoke graph call" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
-            { Remove-EntraUserSponsor -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -SponsorId "sponsor123" } | Should -Throw "Not connected to Microsoft Graph*"
+            $userId = "ec5813fb-346e-4a33-a014-b55ffee3662b"
+            $dirObjectId = "ec5b1c17-940b-47c3-9e8e-6c7e71b9c1ca"
+            { Remove-EntraUserSponsor -UserId $userId -DirectoryObjectId $dirObjectId } | Should -Throw "Not connected to Microsoft Graph*"
             Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
         }
         

--- a/test/Entra/Users/Set-EntraSignedInUserPassword.Tests.ps1
+++ b/test/Entra/Users/Set-EntraSignedInUserPassword.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
 }
 Describe "Tests for Set-EntraSignedInUserPassword" {
     Context "Test for Set-EntraSignedInUserPassword" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Set-EntraSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword $NewPassword } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+        
         It "should return empty object" {
             $result = Set-EntraSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword $NewPassword
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Set-EntraUser.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUser.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
 
 }
 Describe "Tests for Set-EntraUser" {
+    It "should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+        { Set-EntraUser -UserId "sawyerM@contoso.com" -DisplayName "Sawyer M" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+    }
 
     It "Should return empty object" {
         $result = Set-EntraUser -UserId "sawyerM@contoso.com" -DisplayName "Sawyer M"

--- a/test/Entra/Users/Set-EntraUserExtension.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserExtension.Tests.ps1
@@ -12,6 +12,11 @@ BeforeAll {
     
 }
 Describe "Tests for Set-EntraUserExtension" {
+    It "should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+        { Set-EntraUserExtension -UserId "sawyerM@contoso.com" -ExtensionName 'extension_e5e29b8a85d941eab8d12162bd004528_JobGroup' -ExtensionValue 'Job Group D' } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+    }
 
     It "Should return empty object" {
         $result = Set-EntraUserExtension -UserId "sawyerM@contoso.com" -ExtensionName 'extension_e5e29b8a85d941eab8d12162bd004528_JobGroup' -ExtensionValue 'Job Group D'

--- a/test/Entra/Users/Set-EntraUserLicense.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserLicense.Tests.ps1
@@ -36,6 +36,17 @@ BeforeAll {
 
 Describe "Set-EntraUserLicense" {
     Context "Test for Set-EntraUserLicense" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            $addLicensesArray = [PSCustomObject]@{
+                skuId = "66aa66aa-bb77-cc88-dd99-00ee00ee00ee"
+            }
+            $Licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
+            $Licenses.AddLicenses = $addLicensesArray
+            { Set-EntraUserLicense -UserId "sawyerM@contoso.com" -AssignedLicenses $Licenses } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific User" {
             $addLicensesArray = [PSCustomObject]@{
                 skuId = "66aa66aa-bb77-cc88-dd99-00ee00ee00ee"

--- a/test/Entra/Users/Set-EntraUserManager.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserManager.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraUserManager" {
     Context "Test for Set-EntraUserManager" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Set-EntraUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ManagerId "00001111-aaaa-2222-bbbb-3333cccc4444" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Set-MgUserManagerByRef -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific User" {
             $result = Set-EntraUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ManagerId "00001111-aaaa-2222-bbbb-3333cccc4444"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Set-EntraUserPasswordProfile.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserPasswordProfile.Tests.ps1
@@ -19,6 +19,8 @@ Describe "Set-EntraUserPasswordProfile" {
     Context "Test for Set-EntraUserPasswordProfile" {
         It "Should throw when not connected and not invoke SDK" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            $newPassword = "New@12345"
+            $secPassword = ConvertTo-SecureString $newPassword -AsPlainText -Force
             { Set-EntraUserPasswordProfile -UserId "sawyerM@contoso.com" -Password $secPassword -ForceChangePasswordNextSignIn -ForceChangePasswordNextSignInWithMfa } | Should -Throw "Not connected to Microsoft Graph*"
             Should -Invoke -CommandName Update-MgUser -ModuleName Microsoft.Entra.Users -Times 0
         }

--- a/test/Entra/Users/Set-EntraUserPasswordProfile.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserPasswordProfile.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
   
 Describe "Set-EntraUserPasswordProfile" {
     Context "Test for Set-EntraUserPasswordProfile" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Set-EntraUserPasswordProfile -UserId "sawyerM@contoso.com" -Password $secPassword -ForceChangePasswordNextSignIn -ForceChangePasswordNextSignInWithMfa } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgUser -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return empty object" {
             $userUPN = "mock106@M365x99297270.OnMicrosoft.com"
             $newPassword = "New@12345"

--- a/test/Entra/Users/Set-EntraUserSponsor.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserSponsor.Tests.ps1
@@ -60,6 +60,11 @@ BeforeAll {
 
 Describe "Set-EntraUserSponsor" {
     Context "Test for Set-EntraUserSponsor" {
+        It "Should throw when not connected and not invoke Graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Set-EntraUserSponsor -UserId "85a57325-fbd3-4649-b636-163573591681" -Type User -SponsorIds "5e8f2da1-2138-4e6b-8d96-f3c5a5bc7f62" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+        }
 
         It "Should fail when UserId is empty" {
             { Set-EntraUserSponsor -UserId } | Should -Throw "Missing an argument for parameter 'UserId'. Specify a parameter of type 'System.String' and try again."

--- a/test/Entra/Users/Set-EntraUserThumbnailPhoto.Tests.ps1
+++ b/test/Entra/Users/Set-EntraUserThumbnailPhoto.Tests.ps1
@@ -13,6 +13,12 @@ BeforeAll {
 
 Describe "Set-EntraUserThumbnailPhoto" {
     Context "Test for Set-EntraUserThumbnailPhoto" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+            { Set-EntraUserThumbnailPhoto -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -FilePath 'D:\UserThumbnailPhoto.jpg' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Set-MgUserPhotoContent -ModuleName Microsoft.Entra.Users -Times 0
+        }
+
         It "Should return specific User" {
             $result = Set-EntraUserThumbnailPhoto -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -FilePath 'D:\UserThumbnailPhoto.jpg'
             $result | Should -BeNullOrEmpty

--- a/test/Entra/Users/Update-EntraUserFromFederated.Tests.ps1
+++ b/test/Entra/Users/Update-EntraUserFromFederated.Tests.ps1
@@ -20,6 +20,11 @@ BeforeAll {
     $global:securePassword = ConvertTo-SecureString $global:newPassword -AsPlainText -Force
 }
 Describe "Tests for Update-EntraUserFromFederated" {
+    It "Should throw when not connected and not invoke Graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Users
+        { Update-EntraUserFromFederated -UserPrincipalName "sawyerM@contoso.com" -NewPassword $global:securePassword } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Users -Times 0
+    }
 
     It "Should return empty object" {
         $result = Update-EntraUserFromFederated -UserPrincipalName "sawyerM@contoso.com" -NewPassword $global:securePassword

--- a/test/EntraBeta/Users/Get-EntraBetaDeletedUser.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaDeletedUser.Tests.ps1
@@ -29,6 +29,11 @@ BeforeAll {
 
 Describe "Get-EntraBetaDeletedUser" {
     Context "Test for Get-EntraBetaDeletedUser" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaDeletedUser -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryDeletedItemAsUser -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return specific Deleted User" {
             $result = Get-EntraBetaDeletedUser -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaInactiveSignInUser.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaInactiveSignInUser.Tests.ps1
@@ -68,7 +68,12 @@ BeforeAll {
 Describe 'Get-EntraBetaInactiveSignInUser' {
 
     Context "Get-EntraBetaInactiveSignInUser Tests" {
-        
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaInactiveSignInUser -LastSignInBeforeDaysAgo 30 -UserType "All" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+
         It "Should return all inactive users" {
             $result = Get-EntraBetaInactiveSignInUser -LastSignInBeforeDaysAgo 30 -UserType "All"
             

--- a/test/EntraBeta/Users/Get-EntraBetaInactiveSignInUser.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaInactiveSignInUser.Tests.ps1
@@ -61,6 +61,8 @@ BeforeAll {
             )
         }
     } -ModuleName Microsoft.Entra.Beta.Users
+
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("AuditLog.Read.All", "User.Read.All") } } -ModuleName Microsoft.Entra.Beta.Users
 }
 
 Describe 'Get-EntraBetaInactiveSignInUser' {

--- a/test/EntraBeta/Users/Get-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUser.Tests.ps1
@@ -50,6 +50,7 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Users
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("User.Read.All") } } -ModuleName Microsoft.Entra.Beta.Users
 }
   
 Describe "Get-EntraBetaUser" {

--- a/test/EntraBeta/Users/Get-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUser.Tests.ps1
@@ -55,6 +55,12 @@ BeforeAll {
   
 Describe "Get-EntraBetaUser" {
     Context "Test for Get-EntraBetaUser" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUser -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+
         It "Should return specific user" {
             $result = Get-EntraBetaUser -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             Write-Verbose "Result : {$result}" -Verbose

--- a/test/EntraBeta/Users/Get-EntraBetaUserAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserAdministrativeUnit.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserAdministrativeUnit" {
     Context "Test for Get-EntraBetaUserAdministrativeUnit" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserAdministrativeUnit -UserId 'SawyerM@contoso.com' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserMemberOfAsAdministrativeUnit -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+
         It "Should return all user roles" {
             $result = Get-EntraBetaUserAdministrativeUnit -UserId 'SawyerM@contoso.com'
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserExtension.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserExtension.Tests.ps1
@@ -15,6 +15,7 @@ BeforeAll {
     }    
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.Users
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("User.Read.All") } } -ModuleName Microsoft.Entra.Beta.Users
 }
 Describe "Get-EntraBetaUserExtension" {
     Context "Test for Get-EntraBetaUserExtension" {

--- a/test/EntraBeta/Users/Get-EntraBetaUserExtension.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserExtension.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
 }
 Describe "Get-EntraBetaUserExtension" {
     Context "Test for Get-EntraBetaUserExtension" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserExtension -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+
         It "Should return user extensions" {
             $result = Get-EntraBetaUserExtension -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"            
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserGroup.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserGroup.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserGroup" {
     Context "Test for Get-EntraBetaUserGroup" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserGroup -UserId 'SawyerM@contoso.com' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserMemberOfAsGroup -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+
         It "Should return all user roles" {
             $result = Get-EntraBetaUserGroup -UserId 'SawyerM@contoso.com'
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserInactiveSignIn.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserInactiveSignIn.Tests.ps1
@@ -47,6 +47,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserInactiveSignIn" {
     Context "Test for Get-EntraBetaUserInactiveSignIn" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserInactiveSignIn -Ago 30 -UserType "All" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUser -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+        
         It "Returns all the Inactive users in a tenant in the last N days." {
             $result = Get-EntraBetaUserInactiveSignIn -Ago 30 -UserType "All"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserLicenseDetail.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserLicenseDetail.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
   
 Describe "Get-EntraBetaUserLicenseDetail" {
     Context "Test for Get-EntraBetaUserLicenseDetail" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserLicenseDetail -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserLicenseDetail -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return specific User License Detail" {
             $result = Get-EntraBetaUserLicenseDetail -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 

--- a/test/EntraBeta/Users/Get-EntraBetaUserManager.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserManager.Tests.ps1
@@ -92,6 +92,12 @@ BeforeAll {
   
 Describe "Get-EntraBetaUserManager" {
     Context "Test for Get-EntraBetaUserManager" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserManager -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+        
         It "Should return specific user manager" {
             $result = Get-EntraBetaUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 

--- a/test/EntraBeta/Users/Get-EntraBetaUserMembership.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserMembership.Tests.ps1
@@ -33,6 +33,11 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserMembership" {
     Context "Test for Get-EntraBetaUserMembership" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserMembership -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserMemberOf -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return specific user membership" {
             $result = Get-EntraBetaUserMembership -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserOwnedDevice.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserOwnedDevice.Tests.ps1
@@ -38,6 +38,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserOwnedDevice" {
     Context "Test for Get-EntraBetaUserOwnedDevice" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserOwnedDevice -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserOwnedDevice -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+        
         It "Should return specific user registered device" {
             $result = Get-EntraBetaUserOwnedDevice -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserRegisteredDevice.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserRegisteredDevice.Tests.ps1
@@ -38,6 +38,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserRegisteredDevice" {
     Context "Test for Get-EntraBetaUserRegisteredDevice" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserRegisteredDevice -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserRegisteredDevice -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+        
         It "Should return specific user registered device" {
             $result = Get-EntraBetaUserRegisteredDevice -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserRole.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserRole.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserRole" {
     Context "Test for Get-EntraBetaUserRole" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserRole -UserId 'SawyerM@contoso.com' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaUserMemberOfAsDirectoryRole -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+        
         It "Should return all user roles" {
             $result = Get-EntraBetaUserRole -UserId 'SawyerM@contoso.com'
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/Users/Get-EntraBetaUserSponsor.Tests.ps1
+++ b/test/EntraBeta/Users/Get-EntraBetaUserSponsor.Tests.ps1
@@ -31,6 +31,11 @@ BeforeAll {
 
 Describe "Get-EntraBetaUserSponsor" {
     Context "Test for Get-EntraBetaUserSponsor" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Get-EntraBetaUserSponsor -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
 
         It "Should fail when UserId is empty" {
             { Get-EntraBetaUserSponsor -UserId } | Should -Throw "Missing an argument for parameter 'UserId'. Specify a parameter of type 'System.String' and try again."

--- a/test/EntraBeta/Users/New-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/New-EntraBetaUser.Tests.ps1
@@ -54,7 +54,9 @@ Describe "New-EntraBetaUser" {
     Context "Test for New-EntraBetaUser" {
         It "Should throw when not connected and not invoke graph call" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
-            { New-EntraBetaUser -DisplayName "demo004" -UserPrincipalName "demo004@contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            $PasswordProfile = New-Object -TypeName Microsoft.Open.AzureAD.Model.PasswordProfile
+            $PasswordProfile.Password = "test@1234"
+            { New-EntraBetaUser -DisplayName "demo002" -PasswordProfile $PasswordProfile -UserPrincipalName "demo001@contoso.com" -AccountEnabled $true -MailNickName "demo002NickName" -AgeGroup "adult" } | Should -Throw "Not connected to Microsoft Graph*"
             Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
         }
 

--- a/test/EntraBeta/Users/New-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/New-EntraBetaUser.Tests.ps1
@@ -52,6 +52,11 @@ BeforeAll {
 
 Describe "New-EntraBetaUser" {
     Context "Test for New-EntraBetaUser" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { New-EntraBetaUser -DisplayName "demo004" -UserPrincipalName "demo004@contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
 
         It "Should return created User" {
             # Define Password Profile

--- a/test/EntraBeta/Users/Remove-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/Remove-EntraBetaUser.Tests.ps1
@@ -13,6 +13,11 @@ BeforeAll {
 
 Describe "Remove-EntraBetaUser" {
     Context "Test for Remove-EntraBetaUser" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Remove-EntraBetaUser -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaUser -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return empty object" {
             $result = Remove-EntraBetaUser -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/Users/Remove-EntraBetaUserExtension.Tests.ps1
+++ b/test/EntraBeta/Users/Remove-EntraBetaUserExtension.Tests.ps1
@@ -14,6 +14,11 @@ BeforeAll {
 
 Describe "Remove-EntraBetaUserExtension" {
     Context "Test for Remove-EntraBetaUserExtension" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Remove-EntraBetaUserExtension -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionName 'extension_bbbbbbbb111122223333cccccccccccc_TestExtension' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return empty object for single extension" {
             $result = Remove-EntraBetaUserExtension -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionName 'extension_bbbbbbbb111122223333cccccccccccc_TestExtension'
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/Users/Remove-EntraBetaUserManager.Tests.ps1
+++ b/test/EntraBeta/Users/Remove-EntraBetaUserManager.Tests.ps1
@@ -13,6 +13,11 @@ BeforeAll {
 
 Describe "Remove-EntraBetaUserManager" {
     Context "Test for Remove-EntraBetaUserManager" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Remove-EntraBetaUserManager -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaUserManagerByRef -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return empty object" {
             $result = Remove-EntraBetaUserManager -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/Users/Remove-EntraBetaUserSponsor.Tests.ps1
+++ b/test/EntraBeta/Users/Remove-EntraBetaUserSponsor.Tests.ps1
@@ -14,6 +14,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaUserSponsor" {
     Context "Test for Remove-EntraBetaUserSponsor" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Remove-EntraBetaUserSponsor -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" -SponsorId "367412e8-7403-454c-b5d9-680fff0afff7" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+        
         It "Should fail when UserId is empty string value" {
             { Remove-EntraBetaUserSponsor -UserId "" -SponsorId "367412e8-7403-454c-b5d9-680fff0afff7" } | 
             Should -Throw "Cannot validate argument on parameter 'UserId'. UserId must be a valid email address or GUID."

--- a/test/EntraBeta/Users/Set-EntraBetaSignedInUserPassword.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaSignedInUserPassword.Tests.ps1
@@ -17,6 +17,14 @@ BeforeAll {
 
 Describe "Tests for Set-EntraBetaSignedInUserPassword" {
     Context "Test for Set-EntraBetaSignedInUserPassword" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
+            $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
+            { Set-EntraBetaSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword $NewPassword } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
+
         It "should updates the password for the signed-in user." {
             $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
             $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
@@ -26,26 +34,22 @@ Describe "Tests for Set-EntraBetaSignedInUserPassword" {
         }
 
         It "Should fail when CurrentPassword is null" {
-            { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
+            { $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Set-EntraBetaSignedInUserPassword -CurrentPassword -NewPassword $NewPassword } | Should -Throw "Missing an argument for parameter 'CurrentPassword'*"
         }  
 
         It "Should fail when CurrentPassword is empty" {
-            { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
+            { $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Set-EntraBetaSignedInUserPassword -CurrentPassword "" -NewPassword $NewPassword } | Should -Throw "Cannot process argument transformation on parameter 'CurrentPassword'*"
         }
 
         It "Should fail when NewPassword is null" {
             { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Set-EntraBetaSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword } | Should -Throw "Missing an argument for parameter 'NewPassword'*"
         }  
 
         It "Should fail when NewPassword is empty" {
             { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Set-EntraBetaSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword "" } | Should -Throw "Cannot process argument transformation on parameter 'NewPassword'*"
         }
 
@@ -92,26 +96,22 @@ Describe "Tests for the Alias Update-EntraBetaSignedInUserPassword" {
         }
 
         It "Should fail when CurrentPassword is null" {
-            { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
+            { $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Update-EntraBetaSignedInUserPassword -CurrentPassword -NewPassword $NewPassword } | Should -Throw "Missing an argument for parameter 'CurrentPassword'*"
         }  
 
         It "Should fail when CurrentPassword is empty" {
-            { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
+            { $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Update-EntraBetaSignedInUserPassword -CurrentPassword "" -NewPassword $NewPassword } | Should -Throw "Cannot process argument transformation on parameter 'CurrentPassword'*"
         }
 
         It "Should fail when NewPassword is null" {
             { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Update-EntraBetaSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword } | Should -Throw "Missing an argument for parameter 'NewPassword'*"
         }  
 
         It "Should fail when NewPassword is empty" {
             { $CurrentPassword = ConvertTo-SecureString 'test@123' -AsPlainText -Force
-                $NewPassword = ConvertTo-SecureString 'test@1234' -AsPlainText -Force
                 Update-EntraBetaSignedInUserPassword -CurrentPassword $CurrentPassword -NewPassword "" } | Should -Throw "Cannot process argument transformation on parameter 'NewPassword'*"
         }
 

--- a/test/EntraBeta/Users/Set-EntraBetaUser.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUser.Tests.ps1
@@ -16,6 +16,11 @@ BeforeAll {
 
 }
 Describe "Tests for Set-EntraBetaUser" {
+    It "should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+        { Set-EntraBetaUser -UserId "sawyerM@contoso.com" -DisplayName "Sawyer M" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+    }
 
     It "Should return empty object" {
         $result = Set-EntraBetaUser -UserId "sawyerM@contoso.com" -DisplayName "Sawyer M"

--- a/test/EntraBeta/Users/Set-EntraBetaUserExtension.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUserExtension.Tests.ps1
@@ -12,6 +12,11 @@ BeforeAll {
 
 }
 Describe "Tests for Set-EntraBetaUserExtension" {
+    It "should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+        { Set-EntraBetaUserExtension -UserId "sawyerM@contoso.com" -ExtensionName 'extension_e5e29b8a85d941eab8d12162bd004528_JobGroup' -ExtensionValue 'Job Group D' } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+    }
 
     It "Should return empty object" {
         $result = Set-EntraBetaUserExtension -UserId "sawyerM@contoso.com" -ExtensionName 'extension_e5e29b8a85d941eab8d12162bd004528_JobGroup' -ExtensionValue 'Job Group D'

--- a/test/EntraBeta/Users/Set-EntraBetaUserManager.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUserManager.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
 
 Describe "Set-EntraBetaUserManager" {
     Context "Test for Set-EntraBetaUserManager" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Set-EntraBetaUserManager -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -ManagerId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return empty object" {
             $result = Set-EntraBetaUserManager -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -ManagerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty 

--- a/test/EntraBeta/Users/Set-EntraBetaUserManager.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUserManager.Tests.ps1
@@ -18,10 +18,10 @@ BeforeAll {
 
 Describe "Set-EntraBetaUserManager" {
     Context "Test for Set-EntraBetaUserManager" {
-        It "Should throw when not connected and not invoke graph call" {
+        It "Should throw when not connected and not invoke SDK" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
             { Set-EntraBetaUserManager -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -ManagerId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
-            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+            Should -Invoke -CommandName Set-MgBetaUserManagerByRef -ModuleName Microsoft.Entra.Beta.Users -Times 0
         }
         It "Should return empty object" {
             $result = Set-EntraBetaUserManager -UserId 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' -ManagerId "bbbbbbbb-1111-2222-3333-cccccccccccc"

--- a/test/EntraBeta/Users/Set-EntraBetaUserPasswordProfile.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUserPasswordProfile.Tests.ps1
@@ -17,6 +17,14 @@ BeforeAll {
   
 Describe "Set-EntraBetaUserPasswordProfile" {
     Context "Test for Set-EntraBetaUserPasswordProfile" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            $userUPN = "mock106@M365x99297270.OnMicrosoft.com"
+            $newPassword = "New@12345"
+            $secPassword = ConvertTo-SecureString $newPassword -AsPlainText -Force
+            { Set-EntraBetaUserPasswordProfile -UserId $userUPN -Password $secPassword -ForceChangePasswordNextSignIn -ForceChangePasswordNextSignInWithMfa } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
         It "Should return empty object" {
             $userUPN = "mock106@M365x99297270.OnMicrosoft.com"
             $newPassword = "New@12345"

--- a/test/EntraBeta/Users/Set-EntraBetaUserPasswordProfile.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUserPasswordProfile.Tests.ps1
@@ -17,13 +17,13 @@ BeforeAll {
   
 Describe "Set-EntraBetaUserPasswordProfile" {
     Context "Test for Set-EntraBetaUserPasswordProfile" {
-        It "should throw when not connected and not invoke graph call" {
+        It "should throw when not connected and not invoke SDK" {
             Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
             $userUPN = "mock106@M365x99297270.OnMicrosoft.com"
             $newPassword = "New@12345"
             $secPassword = ConvertTo-SecureString $newPassword -AsPlainText -Force
             { Set-EntraBetaUserPasswordProfile -UserId $userUPN -Password $secPassword -ForceChangePasswordNextSignIn -ForceChangePasswordNextSignInWithMfa } | Should -Throw "Not connected to Microsoft Graph*"
-            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+            Should -Invoke -CommandName Update-MgBetaUser -ModuleName Microsoft.Entra.Beta.Users -Times 0
         }
         It "Should return empty object" {
             $userUPN = "mock106@M365x99297270.OnMicrosoft.com"

--- a/test/EntraBeta/Users/Set-EntraBetaUserSponsor.Tests.ps1
+++ b/test/EntraBeta/Users/Set-EntraBetaUserSponsor.Tests.ps1
@@ -59,6 +59,11 @@ BeforeAll {
 
 Describe "Set-EntraBetaUserSponsor" {
     Context "Test for Set-EntraBetaUserSponsor" {
+        It "should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+            { Set-EntraBetaUserSponsor -UserId "bedf70bd-0158-46ae-99ef-e7b5f5fc996f" -Type User -SponsorIds "5e8f2da1-2138-4e6b-8d96-f3c5a5bc7f62" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+        }
 
         It "Should fail when UserId is empty" {
             { Set-EntraBetaUserSponsor -UserId } | Should -Throw "Missing an argument for parameter 'UserId'. Specify a parameter of type 'System.String' and try again."

--- a/test/EntraBeta/Users/Update-EntraBetaUserFromFederated.Tests.ps1
+++ b/test/EntraBeta/Users/Update-EntraBetaUserFromFederated.Tests.ps1
@@ -20,6 +20,11 @@ BeforeAll {
     $global:securePassword = ConvertTo-SecureString $global:newPassword -AsPlainText -Force
 }
 Describe "Tests for Update-EntraBetaUserFromFederated" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.Users
+        { Update-EntraBetaUserFromFederated -UserPrincipalName "sawyerM@contoso.com" -NewPassword $global:securePassword } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.Users -Times 0
+    }
 
     It "Should return empty object" {
         $result = Update-EntraBetaUserFromFederated -UserPrincipalName "sawyerM@contoso.com" -NewPassword $global:securePassword


### PR DESCRIPTION
# Changes
- Added Authentication checks for these cmdlets under Users submodule for Entra:
   - Get-EntraInactiveSignInUser.ps1
   - Get-EntraUser.ps1
- Added Authentication checks for these cmdlets under Users submodule for Entra Beta:
   - Get-EntraBetaInactiveSignInUser.ps1
   - Get-EntraBetaUser.ps1
   - Get-EntraBetaUserExtension.ps1
- Updated tests to mock `Get-EntraContext` for all the cmdlets listed above.
- Updated ALL tests for Entra and Entra Beta to include authentication checks to validate the scenario.
- Minor permissions typo fix in documentation.

# Issue
Link: #356  