### PR TITLE
356 - Added Authentication checks for cmdlets under DirectoryManagement submodule for Entra

### DIFF
--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraAdministrativeUnitMember.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraAdministrativeUnitMember.ps1
@@ -14,6 +14,15 @@ function Add-EntraAdministrativeUnitMember {
         [System.String] $AdministrativeUnitId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.ps1
@@ -13,6 +13,15 @@ function Add-EntraCustomSecurityAttributeDefinitionAllowedValue {
         [System.String] $CustomSecurityAttributeDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraDeviceRegisteredOwner.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraDeviceRegisteredOwner.ps1
@@ -14,6 +14,15 @@ function Add-EntraDeviceRegisteredOwner {
         [System.String] $OwnerId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraDeviceRegisteredUser.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraDeviceRegisteredUser.ps1
@@ -14,6 +14,15 @@ function Add-EntraDeviceRegisteredUser {
         [System.String] $UserId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraScopedRoleMembership.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Add-EntraScopedRoleMembership.ps1
@@ -14,6 +14,15 @@ function Add-EntraScopedRoleMembership {
     [Microsoft.Open.MSGraph.Model.MsRoleMemberInfo] $RoleMemberInfo
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Confirm-EntraDomain.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Confirm-EntraDomain.ps1
@@ -13,6 +13,15 @@ function Confirm-EntraDomain {
     [Microsoft.Open.AzureAD.Model.CrossCloudVerificationCodeBody] $CrossCloudVerificationCode
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Enable-EntraDirectoryRole.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Enable-EntraDirectoryRole.ps1
@@ -11,6 +11,15 @@ function Enable-EntraDirectoryRole {
     [System.String] $RoleTemplateId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAccountSku.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAccountSku.ps1
@@ -10,6 +10,15 @@ function Get-EntraAccountSku {
         [System.Guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All, LicenseAssignment.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand        

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAdministrativeUnit.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAdministrativeUnit.ps1
@@ -17,6 +17,15 @@ function Get-EntraAdministrativeUnit {
         [System.String] $Filter
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAdministrativeUnitMember.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAdministrativeUnitMember.ps1
@@ -15,6 +15,15 @@ function Get-EntraAdministrativeUnitMember {
         [switch] $All
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $topCount = $null

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAttributeSet.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraAttributeSet.ps1
@@ -10,6 +10,15 @@ function Get-EntraAttributeSet {
         [System.String] $AttributeSetId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContact.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContact.ps1
@@ -19,6 +19,16 @@ function Get-EntraContact {
         [Alias("Select")]
         [System.String[]] $Property
     )  
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContactDirectReport.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContactDirectReport.ps1
@@ -20,6 +20,15 @@ function Get-EntraContactDirectReport {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContactManager.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContactManager.ps1
@@ -13,6 +13,15 @@ function Get-EntraContactManager {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContactMembership.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContactMembership.ps1
@@ -20,6 +20,15 @@ function Get-EntraContactMembership {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContract.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraContract.ps1
@@ -23,6 +23,15 @@ function Get-EntraContract {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinition.ps1
@@ -9,6 +9,15 @@ function Get-EntraCustomSecurityAttributeDefinition {
         [System.String] $Id
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $Method = "GET"

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.ps1
@@ -13,6 +13,15 @@ function Get-EntraCustomSecurityAttributeDefinitionAllowedValue {
         [System.String] $CustomSecurityAttributeDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $params["Uri"] = "/v1.0/directory/customSecurityAttributeDefinitions/$CustomSecurityAttributeDefinitionId/allowedValues/"

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeletedAdministrativeUnit.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeletedAdministrativeUnit.ps1
@@ -28,6 +28,15 @@ function Get-EntraDeletedAdministrativeUnit {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeletedDevice.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeletedDevice.ps1
@@ -28,6 +28,15 @@ function Get-EntraDeletedDevice {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeletedDirectoryObject.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeletedDirectoryObject.ps1
@@ -14,6 +14,15 @@ function Get-EntraDeletedDirectoryObject {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.Read.All, Application.Read.All, Group.Read.All, User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDevice.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDevice.ps1
@@ -26,6 +26,15 @@ function Get-EntraDevice {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeviceRegisteredOwner.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeviceRegisteredOwner.ps1
@@ -20,6 +20,16 @@ function Get-EntraDeviceRegisteredOwner {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeviceRegisteredUser.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDeviceRegisteredUser.ps1
@@ -20,6 +20,16 @@ function Get-EntraDeviceRegisteredUser {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirSyncConfiguration.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirSyncConfiguration.ps1
@@ -10,6 +10,15 @@ function Get-EntraDirSyncConfiguration {
         [System.Guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand       

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirSyncFeature.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirSyncFeature.ps1
@@ -12,6 +12,16 @@ function Get-EntraDirSyncFeature {
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [System.String]$Feature
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryObject.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryObject.ps1
@@ -19,6 +19,15 @@ function Get-EntraDirectoryObject {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.ps1
@@ -11,7 +11,15 @@ function Get-EntraDirectoryObjectOnPremisesProvisioningError {
         [Obsolete("This parameter provides compatibility with Azure AD and MSOnline for partner scenarios. TenantID is the signed-in user's tenant ID. It should not be used for any other purpose.")]
         [System.Guid] $TenantId
     )
-    begin { }
+    
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.Read.All, Directory.Read.All, Group.Read.All, Contacts.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
 
     process {
         $params = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryRole.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryRole.ps1
@@ -17,6 +17,15 @@ function Get-EntraDirectoryRole {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryRoleMember.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryRoleMember.ps1
@@ -12,6 +12,16 @@ function Get-EntraDirectoryRoleMember {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand       

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryRoleTemplate.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirectoryRoleTemplate.ps1
@@ -10,6 +10,15 @@ function Get-EntraDirectoryRoleTemplate {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomain.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomain.ps1
@@ -13,6 +13,15 @@ function Get-EntraDomain {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainFederationSettings.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainFederationSettings.ps1
@@ -14,6 +14,16 @@ function Get-EntraDomainFederationSettings {
         [Obsolete("This parameter provides compatibility with Azure AD and MSOnline for partner scenarios. TenantID is the signed-in user's tenant ID. It should not be used for any other purpose.")]
         [System.guid] $TenantId
     ) 
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     process { 
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainNameReference.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainNameReference.ps1
@@ -13,6 +13,15 @@ function Get-EntraDomainNameReference {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand       

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainServiceConfigurationRecord.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainServiceConfigurationRecord.ps1
@@ -13,6 +13,15 @@ function Get-EntraDomainServiceConfigurationRecord {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainVerificationDnsRecord.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDomainVerificationDnsRecord.ps1
@@ -13,6 +13,15 @@ function Get-EntraDomainVerificationDnsRecord {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraFederationProperty.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraFederationProperty.ps1
@@ -7,7 +7,16 @@ function Get-EntraFederationProperty {
     param (
         [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)][System.String] $DomainName,
         [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)][Switch] $SupportMultipleDomain
-        )
+    )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
 
     PROCESS {    
         $params = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraPartnerInformation.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraPartnerInformation.ps1
@@ -9,6 +9,15 @@ function Get-EntraPartnerInformation {
         [Obsolete("This parameter provides compatibility with Azure AD and MSOnline for partner scenarios. TenantID is the signed-in user's tenant ID. It should not be used for any other purpose.")]
         [System.Guid] $TenantId
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
     
     PROCESS {    
         $params = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraPasswordPolicy.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraPasswordPolicy.ps1
@@ -8,6 +8,15 @@ function Get-EntraPasswordPolicy {
         [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)][System.String] $DomainName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand        

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraScopedRoleMembership.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraScopedRoleMembership.ps1
@@ -12,6 +12,15 @@ function Get-EntraScopedRoleMembership {
     [System.String] $ScopedRoleMembershipId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraSubscribedSku.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraSubscribedSku.ps1
@@ -12,6 +12,16 @@ function Get-EntraSubscribedSku {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All, LicenseAssignment.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand        

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraSubscription.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraSubscription.ps1
@@ -24,6 +24,15 @@ function Get-EntraSubscription {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $topCount = 0

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraTenantDetail.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraTenantDetail.ps1
@@ -17,6 +17,15 @@ function Get-EntraTenantDetail {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand        

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraAdministrativeUnit.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraAdministrativeUnit.ps1
@@ -23,6 +23,15 @@ function New-EntraAdministrativeUnit {
         [System.String] $Visibility
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraAttributeSet.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraAttributeSet.ps1
@@ -16,6 +16,15 @@ function New-EntraAttributeSet {
         [System.Nullable`1[System.Int32]] $MaxAttributesPerSet
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraCustomSecurityAttributeDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraCustomSecurityAttributeDefinition.ps1
@@ -23,6 +23,15 @@ function New-EntraCustomSecurityAttributeDefinition {
     [System.String] $Status
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraDevice.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraDevice.ps1
@@ -52,6 +52,15 @@ function New-EntraDevice {
     [System.Nullable`1[System.Int32]] $DeviceObjectVersion
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All, Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraDomain.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/New-EntraDomain.ps1
@@ -19,6 +19,15 @@ function New-EntraDomain {
     [System.Nullable`1[System.Boolean]] $IsDefaultForCloudRedirections
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraAdministrativeUnit.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraAdministrativeUnit.ps1
@@ -10,6 +10,15 @@ function Remove-EntraAdministrativeUnit {
     [System.String] $AdministrativeUnitId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand    

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraAdministrativeUnitMember.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraAdministrativeUnitMember.ps1
@@ -12,6 +12,15 @@ function Remove-EntraAdministrativeUnitMember {
     [System.String] $MemberId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand    

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraContact.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraContact.ps1
@@ -10,6 +10,15 @@ function Remove-EntraContact {
     [System.String] $OrgContactId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDevice.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDevice.ps1
@@ -10,6 +10,15 @@ function Remove-EntraDevice {
         [System.String] $DeviceId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All, Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDeviceRegisteredOwner.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDeviceRegisteredOwner.ps1
@@ -13,6 +13,15 @@ function Remove-EntraDeviceRegisteredOwner {
         [System.String] $OwnerId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDeviceRegisteredUser.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDeviceRegisteredUser.ps1
@@ -14,6 +14,15 @@ function Remove-EntraDeviceRegisteredUser {
         [System.String] $DeviceId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDirectoryRoleMember.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDirectoryRoleMember.ps1
@@ -13,6 +13,15 @@ function Remove-EntraDirectoryRoleMember {
     [System.String] $MemberId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDomain.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraDomain.ps1
@@ -10,6 +10,15 @@ function Remove-EntraDomain {
     [System.String] $Name
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraScopedRoleMembership.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Remove-EntraScopedRoleMembership.ps1
@@ -12,6 +12,15 @@ function Remove-EntraScopedRoleMembership {
     [System.String] $ScopedRoleMembershipId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand    

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Resolve-EntraTenant.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Resolve-EntraTenant.ps1
@@ -58,6 +58,13 @@ function Resolve-EntraTenant {
     )
 
     begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CrossTenantInformation.ReadBasic.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+
         # Retrieve endpoint information based on the environment
         $graphEndpoint = (Get-EntraEnvironment -Name $Environment).GraphEndpoint
         $azureAdEndpoint = (Get-EntraEnvironment -Name $Environment).AzureAdEndpoint

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Restore-EntraDeletedDirectoryObject.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Restore-EntraDeletedDirectoryObject.ps1
@@ -25,6 +25,15 @@ function Restore-EntraDeletedDirectoryObject {
         [System.String] $NewUserPrincipalName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.ReadWrite.All, AdministrativeUnit.ReadWrite.All, Application.ReadWrite.All, Group.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraAdministrativeUnit.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraAdministrativeUnit.ps1
@@ -28,6 +28,15 @@ function Set-EntraAdministrativeUnit {
         [System.String] $Visibility
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraAttributeSet.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraAttributeSet.ps1
@@ -16,6 +16,15 @@ function Set-EntraAttributeSet {
     [System.Nullable`1[System.Int32]] $MaxAttributesPerSet
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinition.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinition.ps1
@@ -18,6 +18,15 @@ function Set-EntraCustomSecurityAttributeDefinition {
     [System.String] $Status
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.ps1
@@ -13,6 +13,15 @@ function Set-EntraCustomSecurityAttributeDefinitionAllowedValue {
     [System.String] $CustomSecurityAttributeDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
 
     $params = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDevice.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDevice.ps1
@@ -40,6 +40,15 @@ function Set-EntraDevice {
     [System.Collections.Generic.List`1[System.String]] $SystemLabels
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All, Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncConfiguration.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncConfiguration.ps1
@@ -15,6 +15,15 @@ function Set-EntraDirSyncConfiguration {
         [switch] $Force
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncEnabled.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncEnabled.ps1
@@ -15,6 +15,15 @@ function Set-EntraDirSyncEnabled {
         [switch] $Force
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All, Organization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncFeature.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncFeature.ps1
@@ -33,6 +33,15 @@ function Set-EntraDirSyncFeature {
         [switch] $Force
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
     
         $params = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDomain.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDomain.ps1
@@ -19,6 +19,15 @@ function Set-EntraDomain {
     [System.Nullable`1[System.Boolean]] $IsDefaultForCloudRedirections
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDomainFederationSettings.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDomainFederationSettings.ps1
@@ -17,7 +17,17 @@ function Set-EntraDomainFederationSettings {
             [Parameter(Mandatory = $false,ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)][string]$PreferredAuthenticationProtocol,
             [Parameter(Mandatory = $false,ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]$SigningCertificateUpdateStatus,
             [Parameter(Mandatory = $false,ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)][string]$PromptLoginBehavior
-            ) 
+        )
+        
+        begin {
+            # Ensure connection to Microsoft Entra
+            if (-not (Get-EntraContext)) {
+                $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+                Write-Error -Message $errorMessage -ErrorAction Stop
+                return
+            }
+        }
+
         process { 
             $params = @{}
             $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraPartnerInformation.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraPartnerInformation.ps1
@@ -31,6 +31,15 @@ function Set-EntraPartnerInformation {
         [System.Guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
 
     PROCESS {    
         $params = @{}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraTenantDetail.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraTenantDetail.ps1
@@ -22,6 +22,15 @@ function Set-EntraTenantDetail {
     [Microsoft.Open.AzureAD.Model.PrivacyProfile] $PrivacyProfile
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/docs/entra-powershell-v1.0/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.md
+++ b/module/docs/entra-powershell-v1.0/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.md
@@ -37,7 +37,7 @@ The `Get-EntraDirectoryObjectOnPremisesProvisioningError` returns directory sync
 ### Example 1: Get directory synchronization errors
 
 ```powershell
-Connect-Entra -Scopes 'User.Read.All', 'Directory.Read.All', 'Group.Read.All', 'Contacts.Read'
+Connect-Entra -Scopes 'User.Read.All', 'Directory.Read.All', 'Group.Read.All', 'Contacts.Read.All'
 Get-EntraDirectoryObjectOnPremisesProvisioningError | Format-Table -AutoSize
 ```
 

--- a/test/Entra/DirectoryManagement/Add-EntraAdministrativeUnitMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraAdministrativeUnitMember.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Add-EntraAdministrativeUnitMember tests" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Add-EntraAdministrativeUnitMember -AdministrativeUnitId "f306a126-cf2e-439d-b20f-95ce4bcb7ffa" -MemberId "d6873b36-81d6-4c5e-bec0-9e3ca2c86846" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+    
     It "Should return empty object" {
         $result = Add-EntraAdministrativeUnitMember -AdministrativeUnitId "f306a126-cf2e-439d-b20f-95ce4bcb7ffa" -MemberId "d6873b36-81d6-4c5e-bec0-9e3ca2c86846"
         $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Add-EntraAdministrativeUnitMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraAdministrativeUnitMember.Tests.ps1
@@ -9,7 +9,8 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @("AdministrativeUnit.ReadWrite.All")
     }} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/Entra/DirectoryManagement/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -25,6 +25,12 @@ BeforeAll {
   
 Describe "Add-EntraCustomSecurityAttributeDefinitionAllowedValue" {
     Context "Test for Add-EntraCustomSecurityAttributeDefinitionAllowedValue" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Add-EntraCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId 'Engineering_Project' -Id 'Apline' -IsActive $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should add specific Allowed Values" {
             $result = Add-EntraCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId 'Engineering_Project' -Id 'Apline' -IsActive $true
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -16,6 +16,11 @@ BeforeAll {
     }
     
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Add-EntraCustomSecurityAttributeDefinitionAllowedValue" {

--- a/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredOwner.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredOwner.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
 
 Describe "Add-EntraDeviceRegisteredOwner" {
     Context "Test for Add-EntraDeviceRegisteredOwner" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Add-EntraDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgDeviceRegisteredOwnerByRef -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Add-EntraDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredOwner.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredOwner.Tests.ps1
@@ -9,7 +9,8 @@ BeforeAll {
 
     Mock -CommandName New-MgDeviceRegisteredOwnerByRef -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @("Directory.AccessAsUser.All")
     }} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredUser.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredUser.Tests.ps1
@@ -9,7 +9,8 @@ BeforeAll {
 
     Mock -CommandName New-MgDeviceRegisteredUserByRef -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @("Device.ReadWrite.All")
     }} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredUser.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraDeviceRegisteredUser.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
 
 Describe "Add-EntraDeviceRegisteredUser" {
     Context "Test for Add-EntraDeviceRegisteredUser" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Add-EntraDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgDeviceRegisteredUserByRef -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Add-EntraDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Add-EntraDirectoryRoleMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraDirectoryRoleMember.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Add-EntraDirectoryRoleMember" {
     Context "Test for Add-EntraDirectoryRoleMember" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Add-EntraDirectoryRoleMember -DirectoryRoleId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgDirectoryRoleMemberByRef -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Add-EntraDirectoryRoleMember -DirectoryRoleId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Add-EntraScopedRoleMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraScopedRoleMembership.Tests.ps1
@@ -37,6 +37,11 @@ BeforeAll{
     }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Add-EntraScopedRoleMembership"{
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Add-EntraScopedRoleMembership -AdministrativeUnitId $unitObjId -RoleObjectId $roleObjId -RoleMemberInfo $RoleMember } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
     It "Result should not be empty"{
         $result = Add-EntraScopedRoleMembership -AdministrativeUnitId $unitObjId -RoleObjectId $roleObjId -RoleMemberInfo $RoleMember
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Add-EntraScopedRoleMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Add-EntraScopedRoleMembership.Tests.ps1
@@ -30,6 +30,11 @@ BeforeAll{
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("RoleManagement.ReadWrite.Directory")
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Add-EntraScopedRoleMembership"{
     It "Result should not be empty"{

--- a/test/Entra/DirectoryManagement/Enable-EntraDirectoryRole.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Enable-EntraDirectoryRole.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Enable-EntraDirectoryRole" {
     Context "Test for Enable-EntraDirectoryRole" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Enable-EntraDirectoryRole -RoleTemplateId 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgDirectoryRole -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Enable-EntraDirectoryRole -RoleTemplateId 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb'
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Enable-EntraDirectoryRole.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Enable-EntraDirectoryRole.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName New-MgDirectoryRole -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("RoleManagement.ReadWrite.Directory")
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Enable-EntraDirectoryRole" {

--- a/test/Entra/DirectoryManagement/Get-EntraAccountSku.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAccountSku.Tests.ps1
@@ -31,6 +31,12 @@ BeforeAll {
 
 Describe "Get-EntraAccountSku" {
     Context "Test for Get-EntraAccountSku" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraAccountSku -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgSubscribedSku -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Returns all the SKUs for a company." {
             $result = Get-EntraAccountSku -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraAccountSku.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAccountSku.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgSubscribedSku -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.Read.All', 'LicenseAssignment.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraAccountSku" {

--- a/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnit.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll{
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraAdministrativeUnit"{
     It "Result should not be empty"{

--- a/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnit.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll{
     }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraAdministrativeUnit"{
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Get-EntraAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty"{
         $result = Get-EntraAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnitMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnitMember.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll{
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraAdministrativeUnitMember"{
     It "Result should not be empty"{

--- a/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnitMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAdministrativeUnitMember.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll{
     }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraAdministrativeUnitMember"{
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Get-EntraAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty"{
         $result = Get-EntraAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraAttributeSet.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAttributeSet.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
   
 Describe "Get-EntraAttributeSet" {
     Context "Test for Get-EntraAttributeSet" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraAttributeSet -AttributeSetId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return AttributeSets with any parameter" {
             $result = Get-EntraAttributeSet -AttributeSetId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraAttributeSet.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraAttributeSet.Tests.ps1
@@ -19,6 +19,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Get-EntraAttributeSet" {

--- a/test/Entra/DirectoryManagement/Get-EntraContact.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraContact.Tests.ps1
@@ -43,6 +43,11 @@ BeforeAll {
     }  
 
     Mock -CommandName Get-MgContact -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OrgContact.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Get-EntraContact" {

--- a/test/Entra/DirectoryManagement/Get-EntraContact.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraContact.Tests.ps1
@@ -52,6 +52,12 @@ BeforeAll {
   
 Describe "Get-EntraContact" {
     Context "Test for Get-EntraContact" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraContact -OrgContactId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgContact -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific Contact" {
             $result = Get-EntraContact -OrgContactId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraContactMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraContactMembership.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
   
 Describe "Get-EntraContactMembership" {
     Context "Test for Get-EntraContactMembership" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraContactMembership -OrgContactId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgContactMemberOf -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific Contact Membership" {
             $result = Get-EntraContactMembership -OrgContactId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraContactMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraContactMembership.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
     }  
 
     Mock -CommandName Get-MgContactMemberOf -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OrgContact.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Get-EntraContactMembership" {

--- a/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinition.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.Read.All', 'CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Get-EntraCustomSecurityAttributeDefinition" {

--- a/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinition.Tests.ps1
@@ -35,6 +35,12 @@ BeforeAll {
   
 Describe "Get-EntraCustomSecurityAttributeDefinition" {
     Context "Test for Get-EntraCustomSecurityAttributeDefinition" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraCustomSecurityAttributeDefinition -Id 'Engineering_Project' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific group" {
             $result = Get-EntraCustomSecurityAttributeDefinition -Id 'Engineering_Project'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Get-EntraCustomSecurityAttributeDefinitionAllowedValue" {

--- a/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -26,6 +26,12 @@ BeforeAll {
   
 Describe "Get-EntraCustomSecurityAttributeDefinitionAllowedValue" {
     Context "Test for Get-EntraCustomSecurityAttributeDefinitionAllowedValue" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId 'Engineering_Project' -Id 'Apline' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific Allowed Value" {
             $result = Get-EntraCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId 'Engineering_Project' -Id 'Apline'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDeletedAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeletedAdministrativeUnit.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgDirectoryDeletedItemAsAdministrativeUnit -MockWith $mockDeletedAdministrativeUnit -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraDeletedAdministrativeUnit" {

--- a/test/Entra/DirectoryManagement/Get-EntraDeletedAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeletedAdministrativeUnit.Tests.ps1
@@ -35,6 +35,12 @@ BeforeAll {
 
 Describe "Get-EntraDeletedAdministrativeUnit" {
     Context "Test for Get-EntraDeletedAdministrativeUnit" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDeletedAdministrativeUnit } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDirectoryDeletedItemAsAdministrativeUnit -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return all administrative units" {
             $result = Get-EntraDeletedAdministrativeUnit
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDeletedDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeletedDevice.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
 
 Describe "Get-EntraDeletedDevice" {
     Context "Test for Get-EntraDeletedDevice" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDeletedDevice } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDirectoryDeletedItemAsDevice -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return all devices" {
             $result = Get-EntraDeletedDevice
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDeletedDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeletedDevice.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgDirectoryDeletedItemAsDevice -MockWith $mockDeletedDevice -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraDeletedDevice" {

--- a/test/Entra/DirectoryManagement/Get-EntraDeletedDirectoryObject.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeletedDirectoryObject.Tests.ps1
@@ -32,6 +32,12 @@ BeforeAll {
 }
 
 Describe "Get-EntraDeletedDirectoryObject" {
+    It "Should throw when not connected and not invoke SDK call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Get-EntraDeletedDirectoryObject -DirectoryObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Get-MgDirectoryDeletedItem -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+    
     It "Result should return DeletedDirectoryObject using alias" {
         $result = Get-EntraDeletedDirectoryObject -Id "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
         $result.Id | should -Be "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"

--- a/test/Entra/DirectoryManagement/Get-EntraDeletedDirectoryObject.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeletedDirectoryObject.Tests.ps1
@@ -24,6 +24,11 @@ BeforeAll {
     }
     
     Mock -CommandName Get-MgDirectoryDeletedItem -MockWith $mockDeletedDirectoryObject -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.Read.All', 'Application.Read.All','Group.Read.All','User.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraDeletedDirectoryObject" {

--- a/test/Entra/DirectoryManagement/Get-EntraDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDevice.Tests.ps1
@@ -46,6 +46,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgDevice -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Get-EntraDevice" {

--- a/test/Entra/DirectoryManagement/Get-EntraDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDevice.Tests.ps1
@@ -55,6 +55,12 @@ BeforeAll {
   
 Describe "Get-EntraDevice" {
     Context "Test for Get-EntraDevice" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDevice -DeviceId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDevice -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific device" {
             $result = Get-EntraDevice -DeviceId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredOwner.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredOwner.Tests.ps1
@@ -29,6 +29,11 @@ BeforeAll {
     
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 

--- a/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredOwner.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredOwner.Tests.ps1
@@ -40,6 +40,12 @@ BeforeAll {
 
 Describe "Get-EntraDeviceRegisteredOwner" {
     Context "Test for Get-EntraDeviceRegisteredOwner" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific device registered owner" {
             $result = Get-EntraDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredUser.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredUser.Tests.ps1
@@ -29,6 +29,11 @@ BeforeAll {
     
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 

--- a/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredUser.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDeviceRegisteredUser.Tests.ps1
@@ -40,6 +40,12 @@ BeforeAll {
 
 Describe "Get-EntraDeviceRegisteredUser" {
     Context "Test for Get-EntraDeviceRegisteredUser" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDeviceRegisteredUser -DeviceId "8542ebd1-3d49-4073-9dce-30f197c67755" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific device registered User" {
             $result = Get-EntraDeviceRegisteredUser -DeviceId "8542ebd1-3d49-4073-9dce-30f197c67755"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDirSyncConfiguration.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirSyncConfiguration.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
         }
     }
     Mock -CommandName Get-MgDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Get-EntraDirSyncConfiguration" {
     Context "Test for Get-EntraDirSyncConfiguration" {

--- a/test/Entra/DirectoryManagement/Get-EntraDirSyncConfiguration.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirSyncConfiguration.Tests.ps1
@@ -26,7 +26,13 @@ BeforeAll {
 }
 Describe "Get-EntraDirSyncConfiguration" {
     Context "Test for Get-EntraDirSyncConfiguration" {
-        It "Get irectory synchronization settings" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDirSyncConfiguration -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
+        It "Get directory synchronization settings" {
             $result =  Get-EntraDirSyncConfiguration -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee"
             $result | Should -Not -BeNullOrEmpty
             Should -Invoke -CommandName Get-MgDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.DirectoryManagement -Times 1

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryObject.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryObject.Tests.ps1
@@ -37,6 +37,12 @@ BeforeAll {
 
 Describe "Get-EntraDirectoryObject" {
     Context "Test for Get-EntraDirectoryObject" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDirectoryObject -DirectoryObjectIds "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific object by objectId" {
             $result = Get-EntraDirectoryObject -DirectoryObjectIds '00aa00aa-bb11-cc22-dd33-44ee44ee44ee'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryObject.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryObject.Tests.ps1
@@ -28,6 +28,10 @@ BeforeAll {
     
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
 
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.Tests.ps1
@@ -46,6 +46,12 @@ BeforeAll {
 
 Describe "Get-EntraDirectoryObjectOnPremisesProvisioningError" {
     Context "Test for Get-EntraDirectoryObjectOnPremisesProvisioningError" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDirectoryObjectOnPremisesProvisioningError } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should not return empty object" {
             $result = Get-EntraDirectoryObjectOnPremisesProvisioningError 
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryObjectOnPremisesProvisioningError.Tests.ps1
@@ -34,7 +34,8 @@ BeforeAll {
     }
 
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @('User.Read.All', 'Directory.Read.All', 'Group.Read.All', 'Contacts.Read')
     }} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryRole.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryRole.Tests.ps1
@@ -25,6 +25,11 @@ BeforeAll {
     }
     
     Mock -CommandName Get-MgDirectoryRole -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
   }
   
   Describe "Get-EntraDirectoryRole" {

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryRole.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryRole.Tests.ps1
@@ -34,6 +34,12 @@ BeforeAll {
   
   Describe "Get-EntraDirectoryRole" {
     Context "Test for Get-EntraDirectoryRole" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDirectoryRole -DirectoryRoleId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDirectoryRole  -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific role" {
             $result = Get-EntraDirectoryRole -DirectoryRoleId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleMember.Tests.ps1
@@ -33,6 +33,12 @@ BeforeAll {
 
 Describe "EntraDirectoryRoleMember" {
     Context "Test for EntraDirectoryRoleMember" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDirectoryRoleMember -DirectoryRoleId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific directory rolemember" {
             $result = (Get-EntraDirectoryRoleMember -DirectoryRoleId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb") | ConvertTo-json | ConvertFrom-json
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleMember.Tests.ps1
@@ -25,6 +25,10 @@ BeforeAll {
     
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
 
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "EntraDirectoryRoleMember" {

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleTemplate.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleTemplate.Tests.ps1
@@ -21,6 +21,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgDirectoryRoleTemplate -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraDirectoryRoleTemplate" {

--- a/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleTemplate.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDirectoryRoleTemplate.Tests.ps1
@@ -30,6 +30,12 @@ BeforeAll {
 
 Describe "Get-EntraDirectoryRoleTemplate" {
     Context "Test for Get-EntraDirectoryRoleTemplate" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDirectoryRoleTemplate } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDirectoryRoleTemplate -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return all directory role template" {
             $result = Get-EntraDirectoryRoleTemplate 
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomain.Tests.ps1
@@ -35,6 +35,11 @@ $scriptblock = {
 }
   
     Mock -CommandName Get-MgDomain -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }   
 
 Describe "Get-EntraDomain" {

--- a/test/Entra/DirectoryManagement/Get-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomain.Tests.ps1
@@ -44,6 +44,12 @@ $scriptblock = {
 
 Describe "Get-EntraDomain" {
     Context "Test for Get-EntraDomain" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDomain -Name "test.mail.onmicrosoft.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDomain -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific domain" {
             $result = Get-EntraDomain -Name "test.mail.onmicrosoft.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDomainFederationSettings.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainFederationSettings.Tests.ps1
@@ -30,6 +30,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgDomainFederationConfiguration -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraDomainFederationSettings" {

--- a/test/Entra/DirectoryManagement/Get-EntraDomainFederationSettings.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainFederationSettings.Tests.ps1
@@ -39,6 +39,12 @@ BeforeAll {
 
 Describe "Get-EntraDomainFederationSettings" {
     Context "Test for Get-EntraDomainFederationSettings" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDomainFederationSettings -DomainName "test.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDomainFederationConfiguration -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return federation settings" {
             $result = Get-EntraDomainFederationSettings -DomainName "test.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDomainNameReference.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainNameReference.Tests.ps1
@@ -29,6 +29,11 @@ BeforeAll {
     
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 

--- a/test/Entra/DirectoryManagement/Get-EntraDomainNameReference.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainNameReference.Tests.ps1
@@ -40,6 +40,12 @@ BeforeAll {
 
 Describe "Get-EntraDomainNameReference" {
     Context "Test for Get-EntraDomainNameReference" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDomainNameReference -Name "M365x99297270.mail.onmicrosoft.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific domain Name Reference" {
             $result = Get-EntraDomainNameReference -Name "M365x99297270.mail.onmicrosoft.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDomainServiceConfigurationRecord.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainServiceConfigurationRecord.Tests.ps1
@@ -29,6 +29,11 @@ $scriptblock = {
 }
   
     Mock -CommandName Get-MgDomainServiceConfigurationRecord -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }   
 
 Describe "Get-EntraDomainServiceConfigurationRecord" {

--- a/test/Entra/DirectoryManagement/Get-EntraDomainServiceConfigurationRecord.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainServiceConfigurationRecord.Tests.ps1
@@ -38,7 +38,13 @@ $scriptblock = {
 
 Describe "Get-EntraDomainServiceConfigurationRecord" {
     Context "Test for Get-EntraDomainServiceConfigurationRecord" {
-        It "Should return specific domain confuguration record" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDomainServiceConfigurationRecord -Name "test.mail.onmicrosoft.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDomainServiceConfigurationRecord -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
+        It "Should return specific domain configuration record" {
             $result = Get-EntraDomainServiceConfigurationRecord -Name "test.mail.onmicrosoft.com"
             $result | Should -Not -BeNullOrEmpty
             $result.Id | should -Be '0000aaaa-11bb-cccc-dd22-eeeeee333333'

--- a/test/Entra/DirectoryManagement/Get-EntraDomainVerificationDnsRecord.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainVerificationDnsRecord.Tests.ps1
@@ -38,6 +38,12 @@ $scriptblock = {
 
 Describe "Get-EntraDomainVerificationDnsRecord" {
     Context "Test for Get-EntraDomainVerificationDnsRecord" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraDomainVerificationDnsRecord -Name "test.mail.onmicrosoft.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDomainVerificationDnsRecord -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific domain verification Dns record" {
             $result = Get-EntraDomainVerificationDnsRecord -Name "test.mail.onmicrosoft.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraDomainVerificationDnsRecord.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraDomainVerificationDnsRecord.Tests.ps1
@@ -29,6 +29,11 @@ $scriptblock = {
 }
   
     Mock -CommandName Get-MgDomainVerificationDnsRecord -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }   
 
 Describe "Get-EntraDomainVerificationDnsRecord" {

--- a/test/Entra/DirectoryManagement/Get-EntraExtensionProperty.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraExtensionProperty.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
 }
 
 Describe "Tests for Get-EntraExtensionProperty" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Get-EntraExtensionProperty -IsSyncedFromOnPremises $false } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty" {
         $result = Get-EntraExtensionProperty -IsSyncedFromOnPremises $false
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraFederationProperty.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraFederationProperty.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
 }
 Describe "Get-EntraFederationProperty" {
     Context "Test for Get-EntraFederationProperty" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraFederationProperty -DomainName "anmaji.myworkspace.contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDomainFederationConfiguration -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return the empty object" {
             $result = Get-EntraFederationProperty -DomainName "anmaji.myworkspace.contoso.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraFederationProperty.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraFederationProperty.Tests.ps1
@@ -21,6 +21,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgDomainFederationConfiguration -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Get-EntraFederationProperty" {
     Context "Test for Get-EntraFederationProperty" {

--- a/test/Entra/DirectoryManagement/Get-EntraPasswordPolicy.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraPasswordPolicy.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Get-EntraPasswordPolicy" {
     Context "Test for Get-EntraPasswordPolicy" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraPasswordPolicy -DomainName "contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgDomain -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should gets the current password policy for a tenant or a domain." {
             $result = Get-EntraPasswordPolicy -DomainName "contoso.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraPasswordPolicy.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraPasswordPolicy.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgDomain -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Get-EntraPasswordPolicy" {

--- a/test/Entra/DirectoryManagement/Get-EntraScopedRoleMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraScopedRoleMembership.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll{
     }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraScopedRoleMembership"{
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Get-EntraScopedRoleMembership -AdministrativeUnitId $unitObjId -ScopedRoleMembershipId $scopedRoleMembershipId } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty"{
         $result = Get-EntraScopedRoleMembership -AdministrativeUnitId $unitObjId -ScopedRoleMembershipId $scopedRoleMembershipId
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraScopedRoleMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraScopedRoleMembership.Tests.ps1
@@ -29,6 +29,11 @@ BeforeAll{
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraScopedRoleMembership"{
     It "Result should not be empty"{

--- a/test/Entra/DirectoryManagement/Get-EntraSubscribedSku.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraSubscribedSku.Tests.ps1
@@ -40,6 +40,12 @@ $scriptblock = {
 
 Describe "Get-EntraSubscribedSku" {
     Context "Test for Get-EntraSubscribedSku" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraSubscribedSku -SubscribedSkuId "00001111-aaaa-2222-bbbb-3333cccc4444_11112222-bbbb-3333-cccc-4444dddd5555" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgSubscribedSku -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific SubscribedSku" {
             $result = Get-EntraSubscribedSku -SubscribedSkuId "00001111-aaaa-2222-bbbb-3333cccc4444_11112222-bbbb-3333-cccc-4444dddd5555"
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraSubscribedSku.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraSubscribedSku.Tests.ps1
@@ -30,6 +30,11 @@ $scriptblock = {
 }
 
     Mock -CommandName Get-MgSubscribedSku -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.Read.All', 'LicenseAssignment.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 

--- a/test/Entra/DirectoryManagement/Get-EntraSubscription.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraSubscription.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraSubscription" {
     It "Result should not be empty" {

--- a/test/Entra/DirectoryManagement/Get-EntraSubscription.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraSubscription.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
     }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for Get-EntraSubscription" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Get-EntraSubscription -CommerceSubscriptionId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty" {
         $result = Get-EntraSubscription -CommerceSubscriptionId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Get-EntraTenantDetail.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraTenantDetail.Tests.ps1
@@ -35,6 +35,11 @@ $scriptblock = {
 }
 
     Mock -CommandName Get-MgOrganization -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 

--- a/test/Entra/DirectoryManagement/Get-EntraTenantDetail.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Get-EntraTenantDetail.Tests.ps1
@@ -45,6 +45,12 @@ $scriptblock = {
 
 Describe "Get-EntraTenantDetail" {
     Context "Test for Get-EntraTenantDetail" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Get-EntraTenantDetail -All } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgOrganization -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return all Tenant Detail" {
             $result = Get-EntraTenantDetail -All 
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/New-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraAdministrativeUnit.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for New-EntraAdministrativeUnit" {
     It "Result should not be empty" {

--- a/test/Entra/DirectoryManagement/New-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraAdministrativeUnit.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
     }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Tests for New-EntraAdministrativeUnit" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { New-EntraAdministrativeUnit -DisplayName "DummyName" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty" {
         $result = New-EntraAdministrativeUnit -DisplayName "DummyName"
         $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/New-EntraAttributeSet.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraAttributeSet.Tests.ps1
@@ -20,6 +20,11 @@ BeforeAll {
     }
     
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "New-EntraAttributeSet" {

--- a/test/Entra/DirectoryManagement/New-EntraAttributeSet.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraAttributeSet.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
   
 Describe "New-EntraAttributeSet" {
     Context "Test for New-EntraAttributeSet" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { New-EntraAttributeSet -AttributeSetId "NewCustomAttributeSet" -Description "CustomAttributeSet" -MaxAttributesPerSet 125 } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return created AttributeSet" {
             $result = New-EntraAttributeSet -AttributeSetId "NewCustomAttributeSet" -Description "CustomAttributeSet" -MaxAttributesPerSet 125 
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/New-EntraCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraCustomSecurityAttributeDefinition.Tests.ps1
@@ -33,6 +33,12 @@ BeforeAll {
 
 Describe "New-EntraCustomSecurityAttributeDefinition" {
     Context "Test for New-EntraCustomSecurityAttributeDefinition" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { New-EntraCustomSecurityAttributeDefinition -attributeSet "Engineering" -description "Active projects for user" -isCollection $true -isSearchable $true -name "Project1234" -status "Available" -type "String" -usePreDefinedValuesOnly $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should add new custom Security Attribute Definitions" {
             $result = New-EntraCustomSecurityAttributeDefinition -attributeSet "Engineering"  -description "Active projects for user" -isCollection $true -isSearchable $true -name "Project1234" -status "Available" -type "String" -usePreDefinedValuesOnly $true
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/New-EntraCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraCustomSecurityAttributeDefinition.Tests.ps1
@@ -24,6 +24,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.Read.All', 'CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "New-EntraCustomSecurityAttributeDefinition" {

--- a/test/Entra/DirectoryManagement/New-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraDomain.Tests.ps1
@@ -30,6 +30,11 @@ BeforeAll {
     }     
 
     Mock -CommandName New-MgDomain -MockWith $scriptBlock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "New-EntraDomain" {

--- a/test/Entra/DirectoryManagement/New-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/New-EntraDomain.Tests.ps1
@@ -39,6 +39,12 @@ BeforeAll {
   
 Describe "New-EntraDomain" {
     Context "Test for New-EntraDomain" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { New-EntraDomain -Name "lala.uk" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgDomain -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Create a new Domain" {
             $result = New-EntraDomain -Name "lala.uk"
             $result.ObjectId | should -Be "lala.uk" 

--- a/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnit.Tests.ps1
@@ -16,6 +16,12 @@ BeforeAll {
 }
 
 Describe "Test for Remove-EntraAdministrativeUnit" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Remove-EntraAdministrativeUnit -AdministrativeUnitId "bbbbbbbb-1111-1111-1111-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Should return empty object" {
         $result = Remove-EntraAdministrativeUnit -AdministrativeUnitId bbbbbbbb-1111-1111-1111-cccccccccccc
         $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnit.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Test for Remove-EntraAdministrativeUnit" {

--- a/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnitMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnitMember.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
 }
 
 Describe "Test for Remove-EntraAdministrativeUnitMember" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Remove-EntraAdministrativeUnitMember -AdministrativeUnitId $auId -MemberId $memId } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Should return empty object" {
         $result = Remove-EntraAdministrativeUnitMember -AdministrativeUnitId $auId -MemberId $memId
         $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnitMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraAdministrativeUnitMember.Tests.ps1
@@ -11,6 +11,11 @@ BeforeAll {
 
     $auId = "bbbbbbbb-1111-1111-1111-cccccccccccc"
     $memId = "bbbbbbbb-2222-2222-2222-cccccccccccc"
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.Read.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Test for Remove-EntraAdministrativeUnitMember" {

--- a/test/Entra/DirectoryManagement/Remove-EntraDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDevice.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgDevice -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All', 'Device.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Remove-EntraDevice" {

--- a/test/Entra/DirectoryManagement/Remove-EntraDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDevice.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraDevice" {
     Context "Test for Remove-EntraDevice" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Remove-EntraDevice -DeviceId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgDevice -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Remove-EntraDevice -DeviceId bbbbbbbb-1111-2222-3333-cccccccccccc
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredOwner.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredOwner.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgDeviceRegisteredOwnerByRef -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Remove-EntraDeviceRegisteredOwner" {

--- a/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredOwner.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredOwner.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraDeviceRegisteredOwner" {
     Context "Test for Remove-EntraDeviceRegisteredOwner" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Remove-EntraDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgDeviceRegisteredOwnerByRef -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Remove-EntraDeviceRegisteredOwner -DeviceId  "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredUser.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredUser.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraDeviceRegisteredUser" {
     Context "Test for Remove-EntraDeviceRegisteredUser" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Remove-EntraDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgDeviceRegisteredUserByRef -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Remove-EntraDeviceRegisteredUser -DeviceId  "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredUser.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDeviceRegisteredUser.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgDeviceRegisteredUserByRef -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Remove-EntraDeviceRegisteredUser" {

--- a/test/Entra/DirectoryManagement/Remove-EntraDirectoryRoleMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDirectoryRoleMember.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgDirectoryRoleMemberByRef -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.ReadWrite.Directory')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Remove-EntraDirectoryRoleMember" {

--- a/test/Entra/DirectoryManagement/Remove-EntraDirectoryRoleMember.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDirectoryRoleMember.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
 
 Describe "Remove-EntraDirectoryRoleMember" {
     Context "Test for Remove-EntraDirectoryRoleMember" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Remove-EntraDirectoryRoleMember -DirectoryRoleId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgDirectoryRoleMemberByRef -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Remove-EntraDirectoryRoleMember -DirectoryRoleId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDomain.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgDomain -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Remove-EntraDomain" {

--- a/test/Entra/DirectoryManagement/Remove-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraDomain.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
 
 Describe "Remove-EntraDomain" {
     Context "Test for Remove-EntraDomain" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Remove-EntraDomain -Name "Contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgDomain -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty domain name" {
             $result = Remove-EntraDomain -Name "Contoso.com"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraScopedRoleMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraScopedRoleMembership.Tests.ps1
@@ -16,6 +16,12 @@ BeforeAll {
 }
 
 Describe "Test for Remove-EntraScopedRoleMembership" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Remove-EntraScopedRoleMembership -AdministrativeUnitId "bbbbbbbb-1111-1111-1111-cccccccccccc" -ScopedRoleMembershipId "bbbbbbbb-2222-2222-2222-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Should return empty object" {
         $result = Remove-EntraScopedRoleMembership -AdministrativeUnitId bbbbbbbb-1111-1111-1111-cccccccccccc -ScopedRoleMembershipId bbbbbbbb-2222-2222-2222-cccccccccccc
         $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Remove-EntraScopedRoleMembership.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Remove-EntraScopedRoleMembership.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Test for Remove-EntraScopedRoleMembership" {

--- a/test/Entra/DirectoryManagement/Resolve-EntraTenant.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Resolve-EntraTenant.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
 
 Describe "Resolve-EntraTenant" {
     Context "Valid Inputs" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Resolve-EntraTenant -TenantId "12345678-1234-1234-1234-123456789abc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-MgGraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should resolve tenant by GUID" {
             $result = Resolve-EntraTenant -TenantId "12345678-1234-1234-1234-123456789abc"
             

--- a/test/Entra/DirectoryManagement/Restore-EntraDeletedDirectoryObject.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Restore-EntraDeletedDirectoryObject.Tests.ps1
@@ -24,6 +24,11 @@ BeforeAll {
     } 
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('User.ReadWrite.All', 'AdministrativeUnit.ReadWrite.All', 'Application.ReadWrite.All', 'Group.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Restore-EntraDeletedDirectoryObject" {
     Context "Restore-EntraDeletedDirectoryObject" {

--- a/test/Entra/DirectoryManagement/Restore-EntraDeletedDirectoryObject.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Restore-EntraDeletedDirectoryObject.Tests.ps1
@@ -32,6 +32,12 @@ BeforeAll {
 }
 Describe "Restore-EntraDeletedDirectoryObject" {
     Context "Restore-EntraDeletedDirectoryObject" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Restore-EntraDeletedDirectoryObject -Id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return specific MS deleted directory object" {
             $result = Restore-EntraDeletedDirectoryObject -Id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'
             $result | Should -Not -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraAdministrativeUnit.Tests.ps1
@@ -16,6 +16,12 @@ BeforeAll {
 }
 
 Describe "Test for Set-EntraAdministrativeUnit" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Set-EntraAdministrativeUnit -AdministrativeUnitId "bbbbbbbb-1111-1111-1111-cccccccccccc" -DisplayName "test" -Description "test" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Should return empty object" {
         $result = Set-EntraAdministrativeUnit -AdministrativeUnitId bbbbbbbb-1111-1111-1111-cccccccccccc -DisplayName "test" -Description "test"
         $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraAdministrativeUnit.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraAdministrativeUnit.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Test for Set-EntraAdministrativeUnit" {

--- a/test/Entra/DirectoryManagement/Set-EntraAttributeSet.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraAttributeSet.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
     
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Set-EntraAttributeSet" {

--- a/test/Entra/DirectoryManagement/Set-EntraAttributeSet.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraAttributeSet.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
   
 Describe "Set-EntraAttributeSet" {
     Context "Test for Set-EntraAttributeSet" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraAttributeSet -AttributeSetId "NewCustomAttributeSet" -Description "CustomAttributeSet" -MaxAttributesPerSet 125 } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return created AttributeSet" {
             $result = Set-EntraAttributeSet -AttributeSetId "NewCustomAttributeSet" -Description "CustomAttributeSet" -MaxAttributesPerSet 125 
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinition.Tests.ps1
@@ -17,7 +17,12 @@ BeforeAll {
 }
 
 Describe "Test for Set-EntraCustomSecurityAttributeDefinition" {
-    
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Set-EntraCustomSecurityAttributeDefinition -Id "Demo12_ProjectDatevaluevaluevalue12test" -Description "Test desc" -UsePreDefinedValuesOnly $false -Status "Available" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
+
     It "Should return empty object" {
         $result = Set-EntraCustomSecurityAttributeDefinition -Id "Demo12_ProjectDatevaluevaluevalue12test" -Description "Test desc" -UsePreDefinedValuesOnly $false -Status "Available"
         $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinition.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.Read.All', 'CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Test for Set-EntraCustomSecurityAttributeDefinition" {

--- a/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
 }
 
 Describe "Test for Set-EntraCustomSecurityAttributeDefinitionAllowedValue" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+        { Set-EntraCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Project" -Id "Alpine" -IsActive $true } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+    }
 
     It "Should return empty object" {
         $result = Set-EntraCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Project" -Id "Alpine" -IsActive $true

--- a/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Test for Set-EntraCustomSecurityAttributeDefinitionAllowedValue" {

--- a/test/Entra/DirectoryManagement/Set-EntraDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDevice.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Update-MgDevice -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All', 'Device.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Set-EntraDevice"{

--- a/test/Entra/DirectoryManagement/Set-EntraDevice.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDevice.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraDevice"{
     Context "Test for Set-EntraDevice" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraDevice -DeviceObjectId "bbbbbbbb-1111-2222-3333-cccccccccccc" -DisplayName "Mock-App" -AccountEnabled $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgDevice -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object"{
             $result = Set-EntraDevice -DeviceObjectId bbbbbbbb-1111-2222-3333-cccccccccccc -DisplayName "Mock-App" -AccountEnabled $true
             $result | Should -BeNullOrEmpty           

--- a/test/Entra/DirectoryManagement/Set-EntraDirSyncConfiguration.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDirSyncConfiguration.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
     Mock -CommandName Get-MgDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
     
     Mock -CommandName Update-MgDirectoryOnPremiseSynchronization -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Set-EntraDirSyncConfiguration" {
     Context "Test for Set-EntraDirSyncConfiguration" {

--- a/test/Entra/DirectoryManagement/Set-EntraDirSyncConfiguration.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDirSyncConfiguration.Tests.ps1
@@ -25,6 +25,12 @@ BeforeAll {
 }
 Describe "Set-EntraDirSyncConfiguration" {
     Context "Test for Set-EntraDirSyncConfiguration" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraDirSyncConfiguration -AccidentalDeletionThreshold "111" -TenantId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -Force } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should Modifies the directory synchronization settings." {
             $result = Set-EntraDirSyncConfiguration -AccidentalDeletionThreshold "111" -TenantId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -Force
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraDirSyncEnabled.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDirSyncEnabled.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All', 'Organization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Set-EntraDirSyncEnabled" {

--- a/test/Entra/DirectoryManagement/Set-EntraDirSyncEnabled.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDirSyncEnabled.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraDirSyncEnabled" {
     Context "Test for Set-EntraDirSyncEnabled" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraDirSyncEnabled -EnableDirsync $True -TenantId 'aaaaaaaa-1111-1111-1111-000000000000' -Force } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Set-EntraDirSyncEnabled -EnableDirsync $True -TenantId 'aaaaaaaa-1111-1111-1111-000000000000' -Force
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraDirSyncFeature.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDirSyncFeature.Tests.ps1
@@ -25,6 +25,12 @@ BeforeAll {
 }
 Describe "Set-EntraDirSyncFeature" {
     Context "Test for Set-EntraDirSyncFeature" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraDirSyncFeature -Features "BypassDirSyncOverrides", "PasswordSync" -Enabled $false -TenantId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -Force } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should sets identity synchronization features for a tenant." {
             $result =  Set-EntraDirSyncFeature -Features "BypassDirSyncOverrides", "PasswordSync" -Enabled $false -TenantId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -Force
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraDirSyncFeature.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDirSyncFeature.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
     Mock -CommandName Get-MgDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
     
     Mock -CommandName Update-MgDirectoryOnPremiseSynchronization -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Set-EntraDirSyncFeature" {
     Context "Test for Set-EntraDirSyncFeature" {

--- a/test/Entra/DirectoryManagement/Set-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDomain.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Update-MgDomain -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }   
 
 Describe "Set-EntraDomain"{

--- a/test/Entra/DirectoryManagement/Set-EntraDomain.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDomain.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraDomain"{
     Context "Test for Set-EntraDomain" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraDomain -Name "test.mail.onmicrosoft.com" -IsDefault $True -SupportedServices @("OrgIdAuthentication") } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgDomain -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object"{
             $result = Set-EntraDomain -Name "test.mail.onmicrosoft.com" -IsDefault $True -SupportedServices @("OrgIdAuthentication")
             $result | Should -BeNullOrEmpty           

--- a/test/Entra/DirectoryManagement/Set-EntraDomainFederationSettings.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDomainFederationSettings.Tests.ps1
@@ -40,6 +40,12 @@ BeforeAll {
 }
 Describe "Set-EntraDomainFederationSettings" {
     Context "Test for Set-EntraDomainFederationSettings" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraDomainFederationSettings -DomainName "contoso.com" -LogOffUri "https://adfs1.manan.lab/adfs/" -PassiveLogOnUri "https://adfs1.manan.lab/adfs/" -ActiveLogOnUri "https://adfs1.manan.lab/adfs/services/trust/2005/" -IssuerUri "http://adfs1.manan.lab/adfs/services/" -FederationBrandName "ADFS" -MetadataExchangeUri "https://adfs1.manan.lab/adfs/services/trust/" -PreferredAuthenticationProtocol "saml" -PromptLoginBehavior "nativeSupport" -SigningCertificate "Testcertificate" -NextSigningCertificate "Testcertificate" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgDomainFederationConfiguration -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should Updates settings for a federated domain." {
             $result =  Set-EntraDomainFederationSettings -DomainName "contoso.com" -LogOffUri "https://adfs1.manan.lab/adfs/" -PassiveLogOnUri "https://adfs1.manan.lab/adfs/" -ActiveLogOnUri "https://adfs1.manan.lab/adfs/services/trust/2005/" -IssuerUri "http://adfs1.manan.lab/adfs/services/" -FederationBrandName "ADFS" -MetadataExchangeUri "https://adfs1.manan.lab/adfs/services/trust/" -PreferredAuthenticationProtocol "saml" -PromptLoginBehavior "nativeSupport" -SigningCertificate "Testcertificate" -NextSigningCertificate "Testcertificate"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraDomainFederationSettings.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraDomainFederationSettings.Tests.ps1
@@ -32,6 +32,11 @@ BeforeAll {
     Mock -CommandName Get-MgDomainFederationConfiguration -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
 
     Mock -CommandName Update-MgDomainFederationConfiguration -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 Describe "Set-EntraDomainFederationSettings" {
     Context "Test for Set-EntraDomainFederationSettings" {

--- a/test/Entra/DirectoryManagement/Set-EntraPartnerInformation.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraPartnerInformation.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
             )
         }
     }
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
 
 Describe "Set-EntraPartnerInformation" {

--- a/test/Entra/DirectoryManagement/Set-EntraPartnerInformation.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraPartnerInformation.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Set-EntraPartnerInformation" {
     Context "Test for Set-EntraPartnerInformation" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraPartnerInformation -PartnerSupportUrl "http://www.test1.com" -PartnerCommerceUrl "http://www.test1.com" -PartnerHelpUrl "http://www.test1.com" -PartnerSupportEmails "contoso@example.com" -PartnerSupportTelephones "2342" -TenantId b73cc049-a025-4441-ba3a-8826d9a68ecc } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-MgGraphRequest -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             Mock -CommandName Invoke-MgGraphRequest -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
             $result = Set-EntraPartnerInformation -PartnerSupportUrl "http://www.test1.com" -PartnerCommerceUrl "http://www.test1.com" -PartnerHelpUrl "http://www.test1.com" -PartnerSupportEmails "contoso@example.com" -PartnerSupportTelephones "2342" -TenantId b73cc049-a025-4441-ba3a-8826d9a68ecc

--- a/test/Entra/DirectoryManagement/Set-EntraTenantDetail.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraTenantDetail.Tests.ps1
@@ -23,6 +23,12 @@ BeforeAll {
   
 Describe "Set-EntraTenantDetail" {
     Context "Test for Set-EntraTenantDetail" {
+        It "Should throw when not connected and not invoke SDK call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.DirectoryManagement
+            { Set-EntraTenantDetail -MarketingNotificationEmails "amy@contoso.com","henry@contoso.com" -SecurityComplianceNotificationMails "john@contoso.com","mary@contoso.com" -SecurityComplianceNotificationPhones "1-555-625-9999", "1-555-233-5544" -TechnicalNotificationMails "peter@contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgOrganization -ModuleName Microsoft.Entra.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Set-EntraTenantDetail -MarketingNotificationEmails "amy@contoso.com","henry@contoso.com" -SecurityComplianceNotificationMails "john@contoso.com","mary@contoso.com" -SecurityComplianceNotificationPhones "1-555-625-9999", "1-555-233-5544" -TechnicalNotificationMails "peter@contoso.com"
             $result | Should -BeNullOrEmpty

--- a/test/Entra/DirectoryManagement/Set-EntraTenantDetail.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Set-EntraTenantDetail.Tests.ps1
@@ -14,6 +14,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
     Mock -CommandName Get-MgOrganization -MockWith {$scriptblock} -ModuleName Microsoft.Entra.DirectoryManagement
     Mock -CommandName Update-MgOrganization -MockWith {} -ModuleName Microsoft.Entra.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.DirectoryManagement
 }
   
 Describe "Set-EntraTenantDetail" {


### PR DESCRIPTION
# Changes
- Added Authentication checks for these cmdlets under DirectoryManagement submodule for Entra:

   - Add-EntraAdministrativeUnitMember
   - Add-EntraCustomSecurityAttributeDefinitionAllowedValue
   - Add-EntraDeviceRegisteredOwner
   - Add-EntraDeviceRegisteredUser
   - Add-EntraDirectoryRoleMember
   - Add-EntraScopedRoleMembership
   - Confirm-EntraDomain
   - Enable-EntraDirectoryRole
   - Get-EntraAccountSku
   - Get-EntraAdministrativeUnit
   - Get-EntraAdministrativeUnitMember
   - Get-EntraAttributeSet
   - Get-EntraContact
   - Get-EntraContactDirectReport
   - Get-EntraContactManager
   - Get-EntraContactMembership
   - Get-EntraContract
   - Get-EntraCustomSecurityAttributeDefinition
   - Get-EntraCustomSecurityAttributeDefinitionAllowedValue
   - Get-EntraDeletedAdministrativeUnit
   - Get-EntraDeletedDevice
   - Get-EntraDeletedDirectoryObject
   - Get-EntraDevice
   - Get-EntraDeviceRegisteredOwner
   - Get-EntraDeviceRegisteredUser
   - Get-EntraDirectoryObject
   - Get-EntraDirectoryObjectOnPremisesProvisioningError
   - Get-EntraDirectoryRole
   - Get-EntraDirectoryRoleMember
   - Get-EntraDirectoryRoleTemplate
   - Get-EntraDirSyncConfiguration
   - Get-EntraDirSyncFeature
   - Get-EntraDomain
   - Get-EntraDomainFederationSettings
   - Get-EntraDomainNameReference
   - Get-EntraDomainServiceConfigurationRecord
   - Get-EntraDomainVerificationDnsRecord
   - Get-EntraExtensionProperty
   - Get-EntraFederationProperty
   - Get-EntraPartnerInformation
   - Get-EntraPasswordPolicy
   - Get-EntraScopedRoleMembership
   - Get-EntraSubscribedSku
   - Get-EntraSubscription
   - Get-EntraTenantDetail
   - Get-EntraUnsupportedCommand
   - New-EntraAdministrativeUnit
   - New-EntraAttributeSet
   - New-EntraCustomHeaders
   - New-EntraCustomSecurityAttributeDefinition
   - New-EntraDevice
   - New-EntraDomain
   - Remove-EntraAdministrativeUnit
   - Remove-EntraAdministrativeUnitMember
   - Remove-EntraContact
   - Remove-EntraDevice
   - Remove-EntraDeviceRegisteredOwner
   - Remove-EntraDeviceRegisteredUser
   - Remove-EntraDirectoryRoleMember
   - Remove-EntraDomain
   - Remove-EntraScopedRoleMembership
   - Resolve-EntraTenant
   - Restore-EntraDeletedDirectoryObject
   - Set-EntraAdministrativeUnit
   - Set-EntraAttributeSet
   - Set-EntraCustomSecurityAttributeDefinition
   - Set-EntraCustomSecurityAttributeDefinitionAllowedValue
   - Set-EntraDevice
   - Set-EntraDirSyncConfiguration
   - Set-EntraDirSyncEnabled
   - Set-EntraDirSyncFeature
   - Set-EntraDomain
   - Set-EntraDomainFederationSettings
   - Set-EntraPartnerInformation
   - Set-EntraTenantDetail
- Updated tests to mock Get-EntraContext for all the cmdlets listed above.
- Updated ALL tests for Entra to include authentication checks to validate the scenario.

# Issue
Link: #356