### PR TITLE
356 - Added Authentication checks for cmdlets under DirectoryManagement submodule for Entra Beta

### DIFF
--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaAdministrativeUnitMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaAdministrativeUnitMember.ps1
@@ -13,6 +13,16 @@ function Add-EntraBetaAdministrativeUnitMember {
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Unique ID of the administrative unit.")]
         [System.String] $AdministrativeUnitId
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.ps1
@@ -16,6 +16,15 @@ function Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue {
     [System.String] $CustomSecurityAttributeDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaDeviceRegisteredOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaDeviceRegisteredOwner.ps1
@@ -14,6 +14,15 @@ function Add-EntraBetaDeviceRegisteredOwner {
         [System.String] $OwnerId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaDeviceRegisteredUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaDeviceRegisteredUser.ps1
@@ -14,6 +14,15 @@ function Add-EntraBetaDeviceRegisteredUser {
         [System.String] $UserId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaScopedRoleMembership.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Add-EntraBetaScopedRoleMembership.ps1
@@ -18,6 +18,16 @@ function Add-EntraBetaScopedRoleMembership {
     [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
     [System.String] $AdministrativeUnitId
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Confirm-EntraBetaDomain.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Confirm-EntraBetaDomain.ps1
@@ -11,6 +11,16 @@ function Confirm-EntraBetaDomain {
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false, HelpMessage = "Allows external admin takeover of an unmanaged domain. Default is false.")]
         [System.Boolean] $ForceTakeover
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS { 
         $params = @{}
         $body = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Enable-EntraBetaDirectoryRole.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Enable-EntraBetaDirectoryRole.ps1
@@ -10,6 +10,15 @@ function Enable-EntraBetaDirectoryRole {
     [System.String] $RoleTemplateId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAccountSku.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAccountSku.ps1
@@ -10,6 +10,15 @@ function Get-EntraBetaAccountSku {
         [System.Guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All, LicenseAssignment.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAdministrativeUnit.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAdministrativeUnit.ps1
@@ -23,6 +23,15 @@ function Get-EntraBetaAdministrativeUnit {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAdministrativeUnitMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAdministrativeUnitMember.ps1
@@ -20,6 +20,15 @@ function Get-EntraBetaAdministrativeUnitMember {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAttributeSet.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaAttributeSet.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaAttributeSet {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContact.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContact.ps1
@@ -19,6 +19,16 @@ function Get-EntraBetaContact {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContactDirectReport.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContactDirectReport.ps1
@@ -20,6 +20,15 @@ function Get-EntraBetaContactDirectReport {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContactManager.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContactManager.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaContactManager {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContactMembership.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContactMembership.ps1
@@ -20,6 +20,15 @@ function Get-EntraBetaContactMembership {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContract.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaContract.ps1
@@ -23,6 +23,15 @@ function Get-EntraBetaContract {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $keysChanged = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaCustomSecurityAttributeDefinition {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.ps1
@@ -19,6 +19,15 @@ function Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes  CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeletedAdministrativeUnit.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeletedAdministrativeUnit.ps1
@@ -28,6 +28,15 @@ function Get-EntraBetaDeletedAdministrativeUnit {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes  AdministrativeUnit.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeletedDevice.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeletedDevice.ps1
@@ -28,6 +28,15 @@ function Get-EntraBetaDeletedDevice {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes  Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeletedDirectoryObject.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeletedDirectoryObject.ps1
@@ -14,6 +14,15 @@ function Get-EntraBetaDeletedDirectoryObject {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes  AdministrativeUnit.Read.All, Application.Read.All, Group.Read.All, User.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDevice.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDevice.ps1
@@ -26,6 +26,15 @@ function Get-EntraBetaDevice {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeviceRegisteredOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeviceRegisteredOwner.ps1
@@ -20,6 +20,16 @@ function Get-EntraBetaDeviceRegisteredOwner {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeviceRegisteredUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDeviceRegisteredUser.ps1
@@ -21,6 +21,15 @@ function Get-EntraBetaDeviceRegisteredUser {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Device.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirSyncConfiguration.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirSyncConfiguration.ps1
@@ -10,6 +10,15 @@ function Get-EntraBetaDirSyncConfiguration {
         [System.guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirSyncFeature.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirSyncFeature.ps1
@@ -12,6 +12,16 @@ function Get-EntraBetaDirSyncFeature {
         [Parameter(ParameterSetName = "GetQuery", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [System.String]$Feature
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryObject.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryObject.ps1
@@ -19,6 +19,15 @@ function Get-EntraBetaDirectoryObject {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.ps1
@@ -11,7 +11,15 @@ function Get-EntraBetaDirectoryObjectOnPremisesProvisioningError {
         [Obsolete('This parameter provides compatibility with Azure AD and MSOnline for partner scenarios. TenantID is the signed-in user''s tenant ID. It should not be used for any other purpose.')]
         [System.Guid] $TenantId
     )
-    begin { }
+    
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.Read.All, Directory.Read.All, Group.Read.All, Contacts.Read' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
 
     process {
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryRole.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryRole.ps1
@@ -18,6 +18,15 @@ function Get-EntraBetaDirectoryRole {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $keysChanged = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryRoleMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryRoleMember.ps1
@@ -12,6 +12,16 @@ function Get-EntraBetaDirectoryRoleMember {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryRoleTemplate.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectoryRoleTemplate.ps1
@@ -10,6 +10,15 @@ function Get-EntraBetaDirectoryRoleTemplate {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectorySetting.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectorySetting.ps1
@@ -20,6 +20,15 @@ function Get-EntraBetaDirectorySetting {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.ReadWrite.All, Group.Read.All, Group.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectorySettingTemplate.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirectorySettingTemplate.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaDirectorySettingTemplate {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand        

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomain.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomain.ps1
@@ -13,6 +13,14 @@ function Get-EntraBetaDomain {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
 
     PROCESS {    
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainFederationSettings.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainFederationSettings.ps1
@@ -14,6 +14,16 @@ function Get-EntraBetaDomainFederationSettings {
         [Obsolete("This parameter provides compatibility with Azure AD and MSOnline for partner scenarios. TenantID is the signed-in user's tenant ID. It should not be used for any other purpose.")]
         [System.guid] $TenantId
     ) 
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     process { 
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainNameReference.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainNameReference.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaDomainNameReference {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainServiceConfigurationRecord.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainServiceConfigurationRecord.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaDomainServiceConfigurationRecord {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainVerificationDnsRecord.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDomainVerificationDnsRecord.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaDomainVerificationDnsRecord {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaFederationProperty.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaFederationProperty.ps1
@@ -7,7 +7,16 @@ function Get-EntraBetaFederationProperty {
     param (
         [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)][System.String] $DomainName,
         [Parameter(ParameterSetName = "GetQuery", Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)][Switch] $SupportMultipleDomain
-        )
+    )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
 
     PROCESS {    
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaPartnerInformation.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaPartnerInformation.ps1
@@ -10,6 +10,15 @@ function Get-EntraBetaPartnerInformation {
         [System.Guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaPasswordPolicy.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaPasswordPolicy.ps1
@@ -8,6 +8,15 @@ function Get-EntraBetaPasswordPolicy {
         [Parameter(ParameterSetName = "GetById", Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)][System.String] $DomainName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaScopedRoleMembership.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaScopedRoleMembership.ps1
@@ -14,6 +14,16 @@ function Get-EntraBetaScopedRoleMembership {
         [Alias("Select")]
         [System.String[]] $Property
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.Read.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+    
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaSubscribedSku.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaSubscribedSku.ps1
@@ -13,6 +13,15 @@ function Get-EntraBetaSubscribedSku {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All, LicenseAssignment.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaSubscription.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaSubscription.ps1
@@ -24,6 +24,15 @@ function Get-EntraBetaSubscription {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $topCount = 0

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaTenantDetail.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaTenantDetail.ps1
@@ -17,6 +17,15 @@ function Get-EntraBetaTenantDetail {
         [System.String[]] $Property
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaAdministrativeUnit.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaAdministrativeUnit.ps1
@@ -23,6 +23,15 @@ function New-EntraBetaAdministrativeUnit {
         [System.String] $Visibility
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaAdministrativeUnitMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaAdministrativeUnitMember.ps1
@@ -36,6 +36,15 @@ function New-EntraBetaAdministrativeUnitMember {
     [System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.AssignedLabel]] $AssignedLabels
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaAttributeSet.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaAttributeSet.ps1
@@ -16,6 +16,15 @@ function New-EntraBetaAttributeSet {
     [System.String] $Description
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaCustomSecurityAttributeDefinition.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaCustomSecurityAttributeDefinition.ps1
@@ -31,6 +31,15 @@ function New-EntraBetaCustomSecurityAttributeDefinition {
     [System.String] $Type
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaDevice.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaDevice.ps1
@@ -52,6 +52,15 @@ function New-EntraBetaDevice {
     [System.String] $DeviceTrustType
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All, Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaDirectorySetting.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaDirectorySetting.ps1
@@ -10,6 +10,15 @@ function New-EntraBetaDirectorySetting {
     [Microsoft.Open.MSGraph.Model.DirectorySetting] $DirectorySetting
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.ReadWrite.All, Group.Read.All , Group.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaDomain.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/New-EntraBetaDomain.ps1
@@ -19,6 +19,15 @@ function New-EntraBetaDomain {
     [System.Collections.Generic.List`1[System.String]] $SupportedServices
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.Alll' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaAdministrativeUnit.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaAdministrativeUnit.ps1
@@ -10,6 +10,15 @@ function Remove-EntraBetaAdministrativeUnit {
     [System.String] $AdministrativeUnitId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaAdministrativeUnitMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaAdministrativeUnitMember.ps1
@@ -13,6 +13,15 @@ function Remove-EntraBetaAdministrativeUnitMember {
     [System.String] $AdministrativeUnitId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaContact.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaContact.ps1
@@ -10,6 +10,15 @@ function Remove-EntraBetaContact {
     [System.String] $OrgContactId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OrgContact.Read.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDevice.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDevice.ps1
@@ -10,6 +10,15 @@ function Remove-EntraBetaDevice {
     [System.String] $DeviceId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All, Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredOwner.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredOwner.ps1
@@ -13,6 +13,15 @@ function Remove-EntraBetaDeviceRegisteredOwner {
     [System.String] $OwnerId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredUser.ps1
@@ -13,6 +13,15 @@ function Remove-EntraBetaDeviceRegisteredUser {
     [System.String] $UserId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDirectoryRoleMember.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDirectoryRoleMember.ps1
@@ -13,6 +13,15 @@ function Remove-EntraBetaDirectoryRoleMember {
     [System.String] $DirectoryRoleId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDirectorySetting.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDirectorySetting.ps1
@@ -10,6 +10,15 @@ function Remove-EntraBetaDirectorySetting {
     [System.String] $Id
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDomain.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaDomain.ps1
@@ -10,6 +10,15 @@ function Remove-EntraBetaDomain {
     [System.String] $Name
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaScopedRoleMembership.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Remove-EntraBetaScopedRoleMembership.ps1
@@ -13,6 +13,15 @@ function Remove-EntraBetaScopedRoleMembership {
     [System.String] $ScopedRoleMembershipId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes RoleManagement.ReadWrite.Directory' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Resolve-EntraBetaTenant.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Resolve-EntraBetaTenant.ps1
@@ -58,6 +58,13 @@ function Resolve-EntraBetaTenant {
     )
 
     begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CrossTenantInformation.ReadBasic.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+
         # Retrieve endpoint information based on the environment
         $graphEndpoint = (Get-EntraEnvironment -Name $Environment).GraphEndpoint
         $azureAdEndpoint = (Get-EntraEnvironment -Name $Environment).AzureAdEndpoint

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Restore-EntraBetaDeletedDirectoryObject.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Restore-EntraBetaDeletedDirectoryObject.ps1
@@ -26,6 +26,15 @@ function Restore-EntraBetaDeletedDirectoryObject {
         [System.String] $NewUserPrincipalName
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes User.ReadWrite.All, AdministrativeUnit.ReadWrite.All, Application.ReadWrite.All, Group.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaAdministrativeUnit.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaAdministrativeUnit.ps1
@@ -29,6 +29,15 @@ function Set-EntraBetaAdministrativeUnit {
         [System.String] $Visibility
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes AdministrativeUnit.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $body = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaAttributeSet.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaAttributeSet.ps1
@@ -14,6 +14,16 @@ function Set-EntraBetaAttributeSet {
     [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
     [System.Int32] $MaxAttributesPerSet
     )
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinition.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinition.ps1
@@ -19,6 +19,15 @@ function Set-EntraBetaCustomSecurityAttributeDefinition {
     [System.String] $Id
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.ps1
@@ -16,6 +16,15 @@ function Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue {
     [System.String] $CustomSecurityAttributeDefinitionId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes CustomSecAttributeDefinition.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDevice.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDevice.ps1
@@ -40,6 +40,15 @@ function Set-EntraBetaDevice {
     [System.Collections.Generic.List`1[System.String]] $SystemLabels
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.AccessAsUser.All, Device.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncConfiguration.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncConfiguration.ps1
@@ -15,6 +15,15 @@ function Set-EntraBetaDirSyncConfiguration {
         [switch] $Force
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncEnabled.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncEnabled.ps1
@@ -15,6 +15,15 @@ function Set-EntraBetaDirSyncEnabled {
         [switch] $Force
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All, Organization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncFeature.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncFeature.ps1
@@ -38,6 +38,13 @@ function Set-EntraBetaDirSyncFeature {
     )
 
     begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes OnPremDirectorySynchronization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    
         $params = @{}
         $featuresCollection = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirectorySetting.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirectorySetting.ps1
@@ -13,6 +13,15 @@ function Set-EntraBetaDirectorySetting {
     [System.String] $Id
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Directory.ReadWrite.All, Policy.ReadWrite.Authorization' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDomain.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDomain.ps1
@@ -20,6 +20,15 @@ function Set-EntraBetaDomain {
     [System.Collections.Generic.List`1[System.String]] $SupportedServices
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {    
     $params = @{}
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDomainFederationSettings.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDomainFederationSettings.ps1
@@ -18,6 +18,16 @@ function Set-EntraBetaDomainFederationSettings {
             [Parameter(Mandatory = $false,ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]$SigningCertificateUpdateStatus,
             [Parameter(Mandatory = $false,ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)][string]$PromptLoginBehavior
             ) 
+
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Domain.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
         process { 
             $params = @{}
             $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaPartnerInformation.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaPartnerInformation.ps1
@@ -31,6 +31,14 @@ function Set-EntraBetaPartnerInformation {
         [System.Guid] $TenantId
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
 
     PROCESS {    
         $params = @{}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaTenantDetail.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaTenantDetail.ps1
@@ -22,6 +22,15 @@ function Set-EntraBetaTenantDetail {
     [System.Collections.Generic.List`1[System.String]] $TechnicalNotificationMails
     )
 
+    begin {
+        # Ensure connection to Microsoft Entra
+        if (-not (Get-EntraContext)) {
+            $errorMessage = "Not connected to Microsoft Graph. Use 'Connect-Entra -Scopes Organization.ReadWrite.All' to authenticate."
+            Write-Error -Message $errorMessage -ErrorAction Stop
+            return
+        }
+    }
+
     PROCESS {
         $params = @{}
         $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/docs/entra-powershell-beta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.md
+++ b/module/docs/entra-powershell-beta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.md
@@ -55,7 +55,7 @@ In delegated scenarios with work or school accounts, the signed-in user must be 
 ### Example 1: Get a list of all custom security attribute definitions
 
 ```powershell
-Connect-Entra -Scopes 'CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All'
+Connect-Entra -Scopes 'CustomSecAttributeDefinition.Read.All', 'CustomSecAttributeDefinition.ReadWrite.All'
 Get-EntraBetaCustomSecurityAttributeDefinition
 ```
 
@@ -71,7 +71,7 @@ This example returns all custom security attribute definitions.
 ### Example 2: Get a specific custom security attribute definition
 
 ```powershell
-Connect-Entra -Scopes 'CustomSecAttributeDefinition.Read.All, CustomSecAttributeDefinition.ReadWrite.All'
+Connect-Entra -Scopes 'CustomSecAttributeDefinition.Read.All', 'CustomSecAttributeDefinition.ReadWrite.All'
 $attributeDefinition = Get-EntraBetaCustomSecurityAttributeDefinition | Where-Object {$_.Name -eq 'Engineering'}
 Get-EntraBetaCustomSecurityAttributeDefinition -Id $attributeDefinition.Id
 ```

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -10,7 +10,8 @@ BeforeAll {
 
     Mock -CommandName New-MgBetaAdministrativeUnitMemberByRef -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @("AdministrativeUnit.ReadWrite.All")
     }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -20,6 +20,12 @@ BeforeAll {
 
 Describe "Add-EntraBetaAdministrativeUnitMember" {
     Context "Test for Add-EntraBetaAdministrativeUnitMember" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Add-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "eeeeeeee-4444-5555-6666-ffffffffffff" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaAdministrativeUnitMemberByRef -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Add-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "eeeeeeee-4444-5555-6666-ffffffffffff"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -19,6 +19,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Add-EntraBetacustomSecurityAttributeDefinitionAllowedValue" {

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Add-EntraBetacustomSecurityAttributeDefinitionAllowedValue" {
     Context "Test for Add-EntraBetacustomSecurityAttributeDefinitionAllowedValue" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Add-EntraBetacustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId Engineering_Projectt -Id "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -IsActive $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should update a specific value for the Id" {
             $result = Add-EntraBetacustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId Engineering_Projectt -Id "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -IsActive $true
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredOwner.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredOwner.Tests.ps1
@@ -19,6 +19,11 @@ BeforeAll {
 
 Describe "Add-EntraBetaDeviceRegisteredOwner" {
     Context "Test for Add-EntraBetaDeviceRegisteredOwner" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Add-EntraBetaDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDeviceRegisteredOwnerByRef -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
         It "Should return empty object" {
             $result = Add-EntraBetaDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredOwner.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredOwner.Tests.ps1
@@ -8,7 +8,8 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @("Directory.AccessAsUser.All")
     }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredUser.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredUser.Tests.ps1
@@ -8,7 +8,8 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{
-        Environment = "Global"
+        Environment = @{ Name = "Global" }
+        Scopes      = @("Device.ReadWrite.All")
     }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     Mock -CommandName Get-EntraEnvironment -MockWith {return @{
         GraphEndpoint = "https://graph.microsoft.com"

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredUser.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaDeviceRegisteredUser.Tests.ps1
@@ -19,6 +19,12 @@ BeforeAll {
 
 Describe "Add-EntraBetaDeviceRegisteredUser" {
     Context "Test for Add-EntraBetaDeviceRegisteredUser" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Add-EntraBetaDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDeviceRegisteredUserByRef -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Add-EntraBetaDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaScopedRoleMembership.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaScopedRoleMembership.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
     }
 
     Mock -CommandName New-MgBetaDirectoryAdministrativeUnitScopedRoleMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+    
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("RoleManagement.ReadWrite.Directory")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Add-EntraBetaScopedRoleMembership" {

--- a/test/EntraBeta/DirectoryManagement/Add-EntraBetaScopedRoleMembership.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Add-EntraBetaScopedRoleMembership.Tests.ps1
@@ -35,6 +35,14 @@ BeforeAll {
 
 Describe "Add-EntraBetaScopedRoleMembership" {
     Context "Test for Add-EntraBetaScopedRoleMembership" {
+        It "Should throw when not connected and not invoke SDK" {
+            $RoleMember = New-Object -TypeName Microsoft.Open.MSGraph.Model.MsRoleMemberInfo
+            $RoleMember.Id = "a23541ee-4fe9-4cf2-b628-102ebaef8f7e"
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Add-EntraBetaScopedRoleMembership -AdministrativeUnitId "0e3840ee-40b6-4b72-827b-c06e1f59d2be" -RoleObjectId "135c35cd-85c2-4543-b86c-8f6dbedea4cf" -RoleMemberInfo $RoleMember } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDirectoryAdministrativeUnitScopedRoleMember -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should add a user to the specified role within the specified administrative unit" {
             $RoleMember = New-Object -TypeName Microsoft.Open.MSGraph.Model.MsRoleMemberInfo
             $RoleMember.Id = "a23541ee-4fe9-4cf2-b628-102ebaef8f7e"

--- a/test/EntraBeta/DirectoryManagement/Confirm-EntraBetaDomain.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Confirm-EntraBetaDomain.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("Domain.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Confirm-EntraBetaDomain" {

--- a/test/EntraBeta/DirectoryManagement/Confirm-EntraBetaDomain.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Confirm-EntraBetaDomain.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Confirm-EntraBetaDomain" {
     Context "Test for Confirm-EntraBetaDomain" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Confirm-EntraBetaDomain -DomainName "Contoso.com" -ForceTakeover $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return empty object" {
             $result = Confirm-EntraBetaDomain -DomainName "Contoso.com" -ForceTakeover $true
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAccountSku.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAccountSku.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaSubscribedSku -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.Read.All', 'LicenseAssignment.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaAccountSku" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAccountSku.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAccountSku.Tests.ps1
@@ -31,6 +31,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaAccountSku" {
     Context "Test for Get-EntraBetaAccountSku" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaAccountSku -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaSubscribedSku -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Returns all the SKUs for a company." {
             $result = Get-EntraBetaAccountSku -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnit.Tests.ps1
@@ -25,6 +25,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgBetaAdministrativeUnit -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaAdministrativeUnit" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnit.Tests.ps1
@@ -34,6 +34,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaAdministrativeUnit" {
     Context "Test for Get-EntraBetaAdministrativeUnit" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaAdministrativeUnit -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return specific administrative unit" {
             $result = Get-EntraBetaAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaAdministrativeUnitMember" {
     Context "Test for Get-EntraBetaAdministrativeUnitMember" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "pppppppp-1111-1111-1111-aaaaaaaaaaaa" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaAdministrativeUnitMember -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return specific administrative unit member" {
             $result = Get-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "pppppppp-1111-1111-1111-aaaaaaaaaaaa"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgBetaAdministrativeUnitMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaAdministrativeUnitMember" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAttributeSet.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAttributeSet.Tests.ps1
@@ -20,6 +20,11 @@ BeforeAll {
         )
     }
     Mock -CommandName  Get-MgBetaDirectoryAttributeSet -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaAttributeSet" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaAttributeSet.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaAttributeSet.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaAttributeSet" {
     Context "Test for Get-EntraBetaAttributeSet" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaAttributeSet -AttributeSetId "bbbbcccc-1111-dddd-2222-eeee3333ffff" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryAttributeSet -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should get attribute set by AttributeSetId" {
             $result = Get-EntraBetaAttributeSet -AttributeSetId "bbbbcccc-1111-dddd-2222-eeee3333ffff"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName  Get-MgBetaDirectoryCustomSecurityAttributeDefinition -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('CustomSecAttributeDefinition.Read.All', 'CustomSecAttributeDefinition.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaCustomSecurityAttributeDefinition" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaCustomSecurityAttributeDefinition" {
     Context "Test for Get-EntraBetaCustomSecurityAttributeDefinition" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaCustomSecurityAttributeDefinition -Id "bbbbbbbb-1111-2222-3333-cccccccccc55" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryCustomSecurityAttributeDefinition -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should get custom security attribute definition by Id" {
             $result = Get-EntraBetaCustomSecurityAttributeDefinition -Id "bbbbbbbb-1111-2222-3333-cccccccccc55"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue" {
     Context "Test for Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Projectt" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should get query for given CustomSecurityAttributeDefinitionId" {
             $result = Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId Engineering_Projectt
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -19,6 +19,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedAdministrativeUnit.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgBetaDirectoryDeletedItemAsAdministrativeUnit -MockWith $mockDeletedAdministrativeUnit -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("AdministrativeUnit.Read.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDeletedAdministrativeUnit" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedAdministrativeUnit.Tests.ps1
@@ -35,6 +35,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDeletedAdministrativeUnit" {
     Context "Test for Get-EntraBetaDeletedAdministrativeUnit" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDeletedAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryDeletedItemAsAdministrativeUnit -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return all administrative units" {
             $result = Get-EntraBetaDeletedAdministrativeUnit
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDevice.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgBetaDirectoryDeletedItemAsDevice -MockWith $mockDeletedDevice -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("Device.Read.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDeletedDevice" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDevice.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDeletedDevice" {
     Context "Test for Get-EntraBetaDeletedDevice" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDeletedDevice } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryDeletedItemAsDevice -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should return all devices" {
             $result = Get-EntraBetaDeletedDevice
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDirectoryObject.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDirectoryObject.Tests.ps1
@@ -24,6 +24,11 @@ BeforeAll {
     }
     
     Mock -CommandName Get-MgBetaDirectoryDeletedItem -MockWith $mockDeletedDirectoryObject -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.Read.All', 'Application.Read.All','Group.Read.All','User.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDeletedDirectoryObject" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDirectoryObject.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeletedDirectoryObject.Tests.ps1
@@ -32,6 +32,12 @@ BeforeAll {
 }
 
 Describe "Get-EntraBetaDeletedDirectoryObject" {
+    It "Should throw when not connected and not invoke SDK" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+        { Get-EntraBetaDeletedDirectoryObject -Id "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Get-MgBetaDirectoryDeletedItem -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+    }
+
     It "Result should return DeletedDirectoryObject using alias" {
         $result = Get-EntraBetaDeletedDirectoryObject -Id "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
         $result.Id | should -Be "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDevice.Tests.ps1
@@ -37,6 +37,12 @@ BeforeAll {
   
 Describe "Get-EntraBetaDevice" {
     Context "Test for Get-EntraBetaDevice" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDevice -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDevice -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific device" {
             $result = Get-EntraBetaDevice -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDevice.Tests.ps1
@@ -28,6 +28,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgBetaDevice -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
   
 Describe "Get-EntraBetaDevice" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredOwner.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredOwner.Tests.ps1
@@ -28,6 +28,11 @@ BeforeAll {
     
 
     Mock -CommandName Get-MgBetaDeviceRegisteredOwner -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDeviceRegisteredOwner" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredOwner.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredOwner.Tests.ps1
@@ -37,6 +37,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDeviceRegisteredOwner" {
     Context "Test for Get-EntraBetaDeviceRegisteredOwner" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDeviceRegisteredOwner -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific device registered owner" {
             $result = Get-EntraBetaDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredUser.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredUser.Tests.ps1
@@ -39,6 +39,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDeviceRegisteredUser" {
     Context "Test for Get-EntraBetaDeviceRegisteredUser" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDeviceRegisteredUser -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific device registered User" {
             $result = Get-EntraBetaDeviceRegisteredUser -DeviceId "8542ebd1-3d49-4073-9dce-30f197c67755"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredUser.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDeviceRegisteredUser.Tests.ps1
@@ -28,6 +28,11 @@ BeforeAll {
     }    
 
     Mock -CommandName Get-MgBetaDeviceRegisteredUser -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Device.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncConfiguration.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncConfiguration.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
         }
     }
     Mock -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Get-EntraBetaDirSyncConfiguration" {
     Context "Test for Get-EntraBetaDirSyncConfiguration" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncConfiguration.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncConfiguration.Tests.ps1
@@ -26,7 +26,13 @@ BeforeAll {
 }
 Describe "Get-EntraBetaDirSyncConfiguration" {
     Context "Test for Get-EntraBetaDirSyncConfiguration" {
-        It "Get irectory synchronization settings" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDirSyncConfiguration -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
+        It "Get directory synchronization settings" {
             $result =  Get-EntraBetaDirSyncConfiguration -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee"
             $result | Should -Not -BeNullOrEmpty
             Should -Invoke -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 1

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncFeature.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncFeature.Tests.ps1
@@ -44,6 +44,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDirSyncFeature" {
     Context "Test for Get-EntraBetaDirSyncFeature" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDirSyncFeature -Feature PasswordSync } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Returns all the sync features" {
             $result = Get-EntraBetaDirSyncFeature
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncFeature.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirSyncFeature.Tests.ps1
@@ -35,6 +35,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDirSyncFeature" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.Tests.ps1
@@ -44,6 +44,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDirectoryObjectOnPremisesProvisioningError" {
     Context "Test for Get-EntraBetaDirectoryObjectOnPremisesProvisioningError" {
+        It "Should throw when not connected and not invoke graph call" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDirectoryObjectOnPremisesProvisioningError } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should not return empty object" {
             $result = Get-EntraBetaDirectoryObjectOnPremisesProvisioningError 
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectoryObjectOnPremisesProvisioningError.Tests.ps1
@@ -35,6 +35,11 @@ BeforeAll {
     }
     
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('User.Read.All', 'Directory.Read.All', 'Group.Read.All', 'Contacts.Read')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDirectoryObjectOnPremisesProvisioningError" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySetting.Tests.ps1
@@ -30,6 +30,12 @@ BeforeAll {
   
 Describe "Get-EntraBetaDirectorySetting" {
     Context "Test for Get-EntraBetaDirectorySetting" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDirectorySetting -Id "bbbbbbbb-1111-2222-3333-cccccccccc55" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectorySetting -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should gets a directory setting from Azure Active Directory (AD)" {
             $result = Get-EntraBetaDirectorySetting -Id "bbbbbbbb-1111-2222-3333-cccccccccc55"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySetting.Tests.ps1
@@ -21,6 +21,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDirectorySetting -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.ReadWrite.All', 'Group.Read.All', 'Group.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
   
 Describe "Get-EntraBetaDirectorySetting" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySettingTemplate.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySettingTemplate.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
   
 Describe "Get-EntraBetaDirectorySettingTemplate" {
     Context "Test for Get-EntraBetaDirectorySettingTemplate" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDirectorySettingTemplate -Id "bbbbbbbb-1111-2222-3333-cccccccccc55" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectorySettingTemplate -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should gets a directory setting template from Azure Active Directory (AD)." {
             $result = Get-EntraBetaDirectorySettingTemplate -Id "bbbbbbbb-1111-2222-3333-cccccccccc55"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySettingTemplate.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDirectorySettingTemplate.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDirectorySettingTemplate -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
   
 Describe "Get-EntraBetaDirectorySettingTemplate" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDomainFederationSettings.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDomainFederationSettings.Tests.ps1
@@ -30,6 +30,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDomainFederationConfiguration -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaDomainFederationSettings" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaDomainFederationSettings.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaDomainFederationSettings.Tests.ps1
@@ -39,6 +39,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaDomainFederationSettings" {
     Context "Test for Get-EntraBetaDomainFederationSettings" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaDomainFederationSettings -DomainName "test.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDomainFederationConfiguration -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return federation settings" {
             $result = Get-EntraBetaDomainFederationSettings -DomainName "test.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaFederationProperty.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaFederationProperty.Tests.ps1
@@ -21,6 +21,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDomainFederationConfiguration -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Get-EntraFederationProperty" {
     Context "Test for Get-EntraFederationProperty" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaFederationProperty.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaFederationProperty.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
 }
 Describe "Get-EntraFederationProperty" {
     Context "Test for Get-EntraFederationProperty" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaFederationProperty -DomainName "contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDomainFederationConfiguration -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return the empty object" {
             $result = Get-EntraBetaFederationProperty -DomainName "contoso.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaPasswordPolicy.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaPasswordPolicy.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaPasswordPolicy" {
     Context "Test for Get-EntraBetaPasswordPolicy" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaPasswordPolicy -DomainName "contoso.com" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDomain -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should gets the current password policy for a tenant or a domain." {
             $result = Get-EntraBetaPasswordPolicy -DomainName "contoso.com"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaPasswordPolicy.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaPasswordPolicy.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName Get-MgBetaDomain -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaPasswordPolicy" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaScopedRoleMembership.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaScopedRoleMembership.Tests.ps1
@@ -35,6 +35,12 @@ BeforeAll {
 
 Describe "Get-EntraBetaScopedRoleMembership" {
     Context "Test for Get-EntraBetaScopedRoleMembership" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Get-EntraBetaScopedRoleMembership -AdministrativeUnitId "dddddddd-1111-2222-3333-eeeeeeeeeeee" -ScopedRoleMembershipId "zTVcE8KFQ0W4bI9tvt6kz9Es_cQCeeJLolvVzF_5NRdnAVb9H_8aR410OwBwq86hU" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Get-MgBetaDirectoryAdministrativeUnitScopedRoleMember -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific scoped role membership" {
             $result = Get-EntraBetaScopedRoleMembership -AdministrativeUnitId "dddddddd-1111-2222-3333-eeeeeeeeeeee" -ScopedRoleMembershipId "zTVcE8KFQ0W4bI9tvt6kz9Es_cQCeeJLolvVzF_5NRdnAVb9H_8aR410OwBwq86hU"
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaScopedRoleMembership.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaScopedRoleMembership.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
     }
 
     Mock -CommandName Get-MgBetaDirectoryAdministrativeUnitScopedRoleMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Get-EntraBetaScopedRoleMembership" {

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaSubscription.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaSubscription.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
     }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Tests for Get-EntraBetaSubscription" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+        { Get-EntraBetaSubscription -CommerceSubscriptionId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty" {
         $result = Get-EntraBetaSubscription -CommerceSubscriptionId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
         $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Get-EntraBetaSubscription.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Get-EntraBetaSubscription.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.Read.All', 'LicenseAssignment.Read.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Tests for Get-EntraBetaSubscription" {
     It "Result should not be empty" {

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnit.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
     }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Tests for New-EntraBetaAdministrativeUnit" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+        { New-EntraBetaAdministrativeUnit -DisplayName "DummyName" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+    }
+
     It "Result should not be empty" {
         $result = New-EntraBetaAdministrativeUnit -DisplayName "DummyName"
         $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnit.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
     }
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Tests for New-EntraBetaAdministrativeUnit" {
     It "Result should not be empty" {

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -38,6 +38,11 @@ BeforeAll {
     }
 
     Mock -CommandName New-MGBetaAdministrativeUnitMember -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "New-EntraBetaAdministrativeUnitMember" {

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -47,6 +47,12 @@ BeforeAll {
 
 Describe "New-EntraBetaAdministrativeUnitMember" {
     Context "Test for New-EntraBetaAdministrativeUnitMember" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { New-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" -DisplayName  "Mock-Admin-UnitMember" -Description "NewAdministrativeUnitMember" -MailEnabled $True -MailNickname "Mock-Admin-UnitMember" -SecurityEnabled $False } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MGBetaAdministrativeUnitMember -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return created administrative unit member" {
             $result = New-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" -OdataType "Microsoft.Graph.Group" -DisplayName  "Mock-Admin-UnitMember" -Description "NewAdministrativeUnitMember" -MailEnabled $True -MailNickname "Mock-Admin-UnitMember" -SecurityEnabled $False -GroupTypes @("Unified","DynamicMembership") -MembershipRule "(user.department -contains 'Marketing')" -MembershipRuleProcessingState "On" -IsAssignableToRole $False
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaAttributeSet.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaAttributeSet.Tests.ps1
@@ -20,6 +20,11 @@ BeforeAll {
         )
     }
     Mock -CommandName  New-MgBetaDirectoryAttributeSet -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "New-EntraBetaAttributeSet" {

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaAttributeSet.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaAttributeSet.Tests.ps1
@@ -29,6 +29,12 @@ BeforeAll {
 
 Describe "New-EntraBetaAttributeSet" {
     Context "Test for New-EntraBetaAttributeSet" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { New-EntraBetaAttributeSet -AttributeSetId "bbbbbbbb-1111-2222-3333-cccccccccc55" -Description "New AttributeSet" -MaxAttributesPerSet 21 } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDirectoryAttributeSet -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should create new attribute set" {
             $result = New-EntraBetaAttributeSet -AttributeSetId "bbbbbbbb-1111-2222-3333-cccccccccc55" -Description "New AttributeSet" -MaxAttributesPerSet 21
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
@@ -36,6 +36,12 @@ BeforeAll {
 
 Describe "New-EntraBetaCustomSecurityAttributeDefinition" {
     Context "Test for New-EntraBetaCustomSecurityAttributeDefinition" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { New-EntraBetaCustomSecurityAttributeDefinition -AttributeSet "Test" -Name "Date" -Description "Target completion date" -Type "String" -Status "Available" -IsCollection $false -IsSearchable $true -UsePreDefinedValuesOnly $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDirectoryCustomSecurityAttributeDefinition -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should create new custom security attribute definition" {
             $result = New-EntraBetaCustomSecurityAttributeDefinition -AttributeSet "Test" -Name "Date" -Description "Target completion date" -Type "String" -Status "Available" -IsCollection $false -IsSearchable $true -UsePreDefinedValuesOnly $true
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
@@ -27,6 +27,11 @@ BeforeAll {
         )
     }    
     Mock -CommandName  New-MgBetaDirectoryCustomSecurityAttributeDefinition -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "New-EntraBetaCustomSecurityAttributeDefinition" {

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaDirectorySetting.Tests.ps1
@@ -52,6 +52,11 @@ BeforeAll {
     Mock -CommandName Get-MgBetaDirectorySettingTemplate -MockWith $scriptblock1 -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 
     Mock -CommandName New-MgBetaDirectorySetting -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.ReadWrite.All', 'Group.Read.All' , 'Group.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "New-EntraBetaDirectorySetting" {

--- a/test/EntraBeta/DirectoryManagement/New-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/New-EntraBetaDirectorySetting.Tests.ps1
@@ -61,6 +61,12 @@ BeforeAll {
 
 Describe "New-EntraBetaDirectorySetting" {
     Context "Test for New-EntraBetaDirectorySetting" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { New-EntraBetaDirectorySetting -DirectorySetting $null } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName New-MgBetaDirectorySetting -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should creates a directory settings object in Azure Active Directory (AD)" {
             $template = Get-EntraBetaDirectorySettingTemplate -Id "bbbbbbbb-1111-2222-3333-cccccccccc56"
             $settingsCopy = $template.CreateDirectorySetting()

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnit.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     
 
     Mock -CommandName Remove-MgBetaAdministrativeUnit -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaAdministrativeUnit" {

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnit.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaAdministrativeUnit" {
     Context "Test for Remove-EntraBetaAdministrativeUnit" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaAdministrativeUnit -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Remove-EntraBetaAdministrativeUnit -AdministrativeUnitId "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb" 
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     
 
     Mock -CommandName Remove-MgBetaDirectoryAdministrativeUnitMemberByRef -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaAdministrativeUnitMember" {

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnitMember.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaAdministrativeUnitMember.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaAdministrativeUnitMember" {
     Context "Test for Remove-EntraBetaAdministrativeUnitMember" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "dddddddd-9999-0000-1111-eeeeeeeeeeee" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaDirectoryAdministrativeUnitMemberByRef -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Remove-EntraBetaAdministrativeUnitMember -AdministrativeUnitId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -MemberId "dddddddd-9999-0000-1111-eeeeeeeeeeee"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDevice.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaDevice" {
     Context "Test for Remove-EntraBetaDevice" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaDevice -DeviceId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaDevice -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Remove-EntraBetaDevice -DeviceId bbbbbbbb-1111-2222-3333-cccccccccccc
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDevice.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgBetaDevice -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All', 'Device.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaDevice" {

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredOwner.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredOwner.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaDeviceRegisteredOwner" {
     Context "Test for Remove-EntraBetaDeviceRegisteredOwner" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaDeviceRegisteredOwner -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaDeviceRegisteredOwnerByRef -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Remove-EntraBetaDeviceRegisteredOwner -DeviceId  "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredOwner.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredOwner.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgBetaDeviceRegisteredOwnerByRef -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaDeviceRegisteredOwner" {

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredUser.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredUser.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgBetaDeviceRegisteredUserByRef -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaDeviceRegisteredUser" {

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredUser.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDeviceRegisteredUser.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaDeviceRegisteredUser" {
     Context "Test for Remove-EntraBetaDeviceRegisteredUser" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaDeviceRegisteredUser -DeviceId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaDeviceRegisteredUserByRef -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Remove-EntraBetaDeviceRegisteredUser -DeviceId  "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -UserId "bbbbbbbb-1111-2222-3333-cccccccccccc"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDirectorySetting.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaDirectorySetting" {
     Context "Test for Remove-EntraBetaDirectorySetting" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaDirectorySetting -Id "bbbbcccc-1111-dddd-2222-eeee3333ffff" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaDirectorySetting -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should removes a directory setting from Azure Active Directory (AD)" {
             $result = Remove-EntraBetaDirectorySetting -Id "bbbbcccc-1111-dddd-2222-eeee3333ffff"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaDirectorySetting.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Remove-MgBetaDirectorySetting -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.ReadWrite.Directory')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaDirectorySetting" {

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaScopedRoleMembership.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaScopedRoleMembership.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Remove-EntraBetaScopedRoleMembership" {
     Context "Test for Remove-EntraBetaScopedRoleMembership" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Remove-EntraBetaScopedRoleMembership -AdministrativeUnitId "dddddddd-1111-2222-3333-eeeeeeeeeeee" -ScopedRoleMembershipId "zTVcE8KFQ0W4bI9tvt6kz9Es_cQCeeJLolvVzF_5NRdnAVb9H_8aR410OwBwq86hU" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Remove-MgBetaDirectoryAdministrativeUnitScopedRoleMember -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object" {
             $result = Remove-EntraBetaScopedRoleMembership -AdministrativeUnitId "dddddddd-1111-2222-3333-eeeeeeeeeeee" -ScopedRoleMembershipId "zTVcE8KFQ0W4bI9tvt6kz9Es_cQCeeJLolvVzF_5NRdnAVb9H_8aR410OwBwq86hU"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Remove-EntraBetaScopedRoleMembership.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Remove-EntraBetaScopedRoleMembership.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     
 
     Mock -CommandName Remove-MgBetaDirectoryAdministrativeUnitScopedRoleMember -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('RoleManagement.Read.Directory')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Remove-EntraBetaScopedRoleMembership" {

--- a/test/EntraBeta/DirectoryManagement/Resolve-EntraBetaTenant.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Resolve-EntraBetaTenant.Tests.ps1
@@ -17,6 +17,12 @@ BeforeAll {
 
 Describe "Resolve-EntraBetaTenant" {
     Context "Valid Inputs" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Resolve-EntraBetaTenant -TenantId "12345678-1234-1234-1234-123456789abc" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-MgGraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should resolve tenant by GUID" {
             $result = Resolve-EntraBetaTenant -TenantId "12345678-1234-1234-1234-123456789abc"
             

--- a/test/EntraBeta/DirectoryManagement/Restore-EntraBetaDeletedDirectoryObject.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Restore-EntraBetaDeletedDirectoryObject.Tests.ps1
@@ -32,6 +32,12 @@ BeforeAll {
 }
 Describe "Restore-EntraBetaDeletedDirectoryObject" {
     Context "Restore-EntraBetaDeletedDirectoryObject" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Restore-EntraBetaDeletedDirectoryObject -Id "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return specific MS deleted directory object" {
             $result = Restore-EntraBetaDeletedDirectoryObject -Id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'
             $result | Should -Not -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Restore-EntraBetaDeletedDirectoryObject.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Restore-EntraBetaDeletedDirectoryObject.Tests.ps1
@@ -24,6 +24,11 @@ BeforeAll {
     } 
 
     Mock -CommandName Invoke-GraphRequest -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('User.ReadWrite.All', 'AdministrativeUnit.ReadWrite.All', 'Application.ReadWrite.All', 'Group.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Restore-EntraBetaDeletedDirectoryObject" {
     Context "Restore-EntraBetaDeletedDirectoryObject" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaAdministrativeUnit.Tests.ps1
@@ -8,6 +8,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Invoke-GraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('AdministrativeUnit.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Test for Set-EntraBetaAdministrativeUnit" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaAdministrativeUnit.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaAdministrativeUnit.Tests.ps1
@@ -16,6 +16,12 @@ BeforeAll {
 }
 
 Describe "Test for Set-EntraBetaAdministrativeUnit" {
+    It "Should throw when not connected and not invoke graph call" {
+        Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+        { Set-EntraBetaAdministrativeUnit -AdministrativeUnitId "bbbbbbbb-1111-1111-1111-cccccccccccc" -DisplayName "test" -Description "test" } | Should -Throw "Not connected to Microsoft Graph*"
+        Should -Invoke -CommandName Invoke-GraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+    }
+
     It "Should return empty object" {
         $result = Set-EntraBetaAdministrativeUnit -AdministrativeUnitId bbbbbbbb-1111-1111-1111-cccccccccccc -DisplayName "test" -Description "test"
         $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaAttributeSet.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaAttributeSet.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName  Update-MgBetaDirectoryAttributeSet -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Set-EntraBetaAttributeSet" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaAttributeSet.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaAttributeSet.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraBetaAttributeSet" {
     Context "Test for Set-EntraBetaAttributeSet" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaAttributeSet -AttributeSetId "aaaabbbb-0000-cccc-1111-dddd2222eeee" -Description "Update AttributeSet" -MaxAttributesPerSet 22 } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDirectoryAttributeSet -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should update attribute set" {
             $result = Set-EntraBetaAttributeSet -AttributeSetId "aaaabbbb-0000-cccc-1111-dddd2222eeee" -Description "Update AttributeSet" -MaxAttributesPerSet 22
             $result | Should -Be -NullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Update-MgBetaDirectoryCustomSecurityAttributeDefinition -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Set-EntraBetaCustomSecurityAttributeDefinition" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinition.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraBetaCustomSecurityAttributeDefinition" {
     Context "Test for Set-EntraBetaCustomSecurityAttributeDefinition" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaCustomSecurityAttributeDefinition -Id "aaaabbbb-0000-cccc-1111-dddd2222eeee" -Description "Target completion date" -Status "Available" -UsePreDefinedValuesOnly $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDirectoryCustomSecurityAttributeDefinition -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should update custom security attribute definition" {
             $result = Set-EntraBetaCustomSecurityAttributeDefinition -Id "aaaabbbb-0000-cccc-1111-dddd2222eeee" -Description "Target completion date" -Status "Available" -UsePreDefinedValuesOnly $true
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Update-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @("CustomSecAttributeDefinition.ReadWrite.All")
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue" {
     Context "Test for Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Projectt" -Id "aaaabbbb-0000-cccc-1111-dddd2222eeee" -IsActive $false } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should update a specific value for the Id" {
             $result = Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId Engineering_Projectt -Id "aaaabbbb-0000-cccc-1111-dddd2222eeee" -IsActive $false
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDevice.Tests.ps1
@@ -18,6 +18,12 @@ BeforeAll {
 
 Describe "Set-EntraBetaDevice"{
     Context "Test for Set-EntraBetaDevice" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaDevice -DeviceObjectId "bbbbbbbb-1111-2222-3333-cccccccccccc" -DisplayName "Mock-App" -AccountEnabled $true } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDevice -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object"{
             $result = Set-EntraBetaDevice -DeviceObjectId bbbbbbbb-1111-2222-3333-cccccccccccc -DisplayName "Mock-App" -AccountEnabled $true
             $result | Should -BeNullOrEmpty           

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDevice.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDevice.Tests.ps1
@@ -9,6 +9,11 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Update-MgBetaDevice -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.AccessAsUser.All', 'Device.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Set-EntraBetaDevice"{

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncConfiguration.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncConfiguration.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
     Mock -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     
     Mock -CommandName Update-MgBetaDirectoryOnPremiseSynchronization -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Set-EntraBetaDirSyncConfiguration" {
     Context "Test for Set-EntraBetaDirSyncConfiguration" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncConfiguration.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncConfiguration.Tests.ps1
@@ -25,6 +25,12 @@ BeforeAll {
 }
 Describe "Set-EntraBetaDirSyncConfiguration" {
     Context "Test for Set-EntraBetaDirSyncConfiguration" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaDirSyncConfiguration -AccidentalDeletionThreshold "111" -TenantId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -Force } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should Modifies the directory synchronization settings." {
             $result = Set-EntraBetaDirSyncConfiguration -AccidentalDeletionThreshold "111" -TenantId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee" -Force
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncEnabled.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncEnabled.Tests.ps1
@@ -17,6 +17,11 @@ BeforeAll {
     Mock -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     
     Mock -CommandName Update-MgBetaOrganization -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All', 'Organization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Set-EntraBetaDirSyncEnabled" {
     Context "Test for Set-EntraBetaDirSyncEnabled" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncEnabled.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncEnabled.Tests.ps1
@@ -25,6 +25,12 @@ BeforeAll {
 }
 Describe "Set-EntraBetaDirSyncEnabled" {
     Context "Test for Set-EntraBetaDirSyncEnabled" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaDirSyncEnabled -EnableDirsync $True -TenantId 'aaaaaaaa-1111-1111-1111-000000000000' -Force } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaOrganization -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should Modifies the directory synchronization settings." {
             $result = Set-EntraBetaDirSyncEnabled -EnableDirsync $True -TenantId 'aaaaaaaa-1111-1111-1111-000000000000' -Force
             write-host $result

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncFeature.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncFeature.Tests.ps1
@@ -26,6 +26,12 @@ BeforeAll {
 }
 Describe "Set-EntraBetaDirSyncFeature" {
     Context "Test for Set-EntraBetaDirSyncFeature" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaDirSyncFeature -Features "BypassDirSyncOverrides", "PasswordSync" -Enable $false -TenantId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Force } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDirectoryOnPremiseSynchronization -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should sets identity synchronization features for a tenant." {
             $result =  Set-EntraBetaDirSyncFeature -Features "BypassDirSyncOverrides", "PasswordSync" -Enable $false -TenantId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Force -ErrorAction SilentlyContinue
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncFeature.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirSyncFeature.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
     Mock -CommandName Get-MgBetaDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
     
     Mock -CommandName Update-MgBetaDirectoryOnPremiseSynchronization -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('OnPremDirectorySynchronization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Set-EntraBetaDirSyncFeature" {
     Context "Test for Set-EntraBetaDirSyncFeature" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirectorySetting.Tests.ps1
@@ -30,6 +30,11 @@ BeforeAll {
     Mock -CommandName Get-MgBetaDirectorySettingTemplate -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 
     Mock -CommandName Update-MgBetaDirectorySetting -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Directory.ReadWrite.All', 'Policy.ReadWrite.Authorization')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Set-EntraBetaDirectorySetting" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirectorySetting.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDirectorySetting.Tests.ps1
@@ -39,6 +39,15 @@ BeforeAll {
 
 Describe "Set-EntraBetaDirectorySetting" {
     Context "Test for Set-EntraBetaDirectorySetting" {
+        It "Should throw when not connected and not invoke SDK" {
+            $template = Get-EntraBetaDirectorySettingTemplate -Id "aaaabbbb-0000-cccc-1111-dddd2222eeee"
+            $settingsCopy = $template.CreateDirectorySetting()
+            $settingsCopy["EnableBannedPasswordCheckOnPremises"] = "False"
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaDirectorySetting -Id "bbbbcccc-1111-dddd-2222-eeee3333ffff" -DirectorySetting $settingsCopy } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDirectorySetting -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+
         It "Should updates a directory setting in Azure Active Directory (AD)" {
             $template = Get-EntraBetaDirectorySettingTemplate -Id "aaaabbbb-0000-cccc-1111-dddd2222eeee"
             $settingsCopy = $template.CreateDirectorySetting()

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDomainFederationSettings.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDomainFederationSettings.Tests.ps1
@@ -32,6 +32,11 @@ BeforeAll {
     Mock -CommandName Get-MgBetaDomainFederationConfiguration -MockWith $scriptblock -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 
     Mock -CommandName Update-MgBetaDomainFederationConfiguration -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Domain.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 Describe "Set-EntraBetaDomainFederationSettings" {
     Context "Test for Set-EntraBetaDomainFederationSettings" {

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaDomainFederationSettings.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaDomainFederationSettings.Tests.ps1
@@ -40,6 +40,12 @@ BeforeAll {
 }
 Describe "Set-EntraBetaDomainFederationSettings" {
     Context "Test for Set-EntraBetaDomainFederationSettings" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaDomainFederationSettings -DomainName "manan.lab.myworkspace.microsoft.com" -LogOffUri "https://adfs1.manan.lab/adfs/" -PassiveLogOnUri "https://adfs1.manan.lab/adfs/" -ActiveLogOnUri "https://adfs1.manan.lab/adfs/services/trust/2005/" -IssuerUri "http://adfs1.manan.lab/adfs/services/" -FederationBrandName "ADFS" -MetadataExchangeUri "https://adfs1.manan.lab/adfs/services/trust/" -PreferredAuthenticationProtocol "saml" -PromptLoginBehavior "nativeSupport" } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Update-MgBetaDomainFederationConfiguration -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should Updates settings for a federated domain." {
             $result =  Set-EntraBetaDomainFederationSettings -DomainName "manan.lab.myworkspace.microsoft.com" -LogOffUri "https://adfs1.manan.lab/adfs/" -PassiveLogOnUri "https://adfs1.manan.lab/adfs/" -ActiveLogOnUri "https://adfs1.manan.lab/adfs/services/trust/2005/" -IssuerUri "http://adfs1.manan.lab/adfs/services/" -FederationBrandName "ADFS" -MetadataExchangeUri "https://adfs1.manan.lab/adfs/services/trust/" -PreferredAuthenticationProtocol "saml" -PromptLoginBehavior "nativeSupport"
             $result | Should -BeNullOrEmpty

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaPartnerInformation.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaPartnerInformation.Tests.ps1
@@ -27,6 +27,12 @@ BeforeAll {
 
 Describe "Set-EntraBetaPartnerInformation"{
     Context "Test for Set-EntraBetaPartnerInformation" {
+        It "Should throw when not connected and not invoke SDK" {
+            Mock -CommandName Get-EntraContext -MockWith { $null } -ModuleName Microsoft.Entra.Beta.DirectoryManagement
+            { Set-EntraBetaPartnerInformation -PartnerSupportUrl "http://www.test1.com" -PartnerCommerceUrl "http://www.test1.com" -PartnerHelpUrl "http://www.test1.com" -PartnerSupportEmails "contoso@example.com" -PartnerSupportTelephones "2342" -TenantId b73cc049-a025-4441-ba3a-8826d9a68ecc } | Should -Throw "Not connected to Microsoft Graph*"
+            Should -Invoke -CommandName Invoke-MgGraphRequest -ModuleName Microsoft.Entra.Beta.DirectoryManagement -Times 0
+        }
+        
         It "Should return empty object"{
             Mock -CommandName Invoke-MgGraphRequest -MockWith {} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
             $result = Set-EntraBetaPartnerInformation -PartnerSupportUrl "http://www.test1.com" -PartnerCommerceUrl "http://www.test1.com" -PartnerHelpUrl "http://www.test1.com" -PartnerSupportEmails "contoso@example.com" -PartnerSupportTelephones "2342" -TenantId b73cc049-a025-4441-ba3a-8826d9a68ecc

--- a/test/EntraBeta/DirectoryManagement/Set-EntraBetaPartnerInformation.Tests.ps1
+++ b/test/EntraBeta/DirectoryManagement/Set-EntraBetaPartnerInformation.Tests.ps1
@@ -18,6 +18,11 @@ BeforeAll {
             )
         }
     }
+
+    Mock -CommandName Get-EntraContext -MockWith { @{
+        Environment = @{ Name = "Global" }
+        Scopes      = @('Organization.ReadWrite.All')
+    }} -ModuleName Microsoft.Entra.Beta.DirectoryManagement
 }
 
 Describe "Set-EntraBetaPartnerInformation"{


### PR DESCRIPTION
# Changes
- Added Authentication checks for these cmdlets under DirectoryManagement submodule for Entra Beta:
   - Add-EntraBetaAdministrativeUnitMember
   - Add-EntraBetaCustomSecurityAttributeDefinitionAllowedValue
   - Add-EntraBetaDeviceRegisteredOwner
   - Add-EntraBetaDeviceRegisteredUser
   - Add-EntraBetaDirectoryRoleMember
   - Add-EntraBetaScopedRoleMembership
   - Confirm-EntraBetaDomain
   - Enable-EntraBetaDirectoryRole
   - Get-EntraBetaAccountSku
   - Get-EntraBetaAdministrativeUnit
   - Get-EntraBetaAdministrativeUnitMember
   - Get-EntraBetaAttributeSet
   - Get-EntraBetaContact
   - Get-EntraBetaContactDirectReport
   - Get-EntraBetaContactManager
   - Get-EntraBetaContactMembership
   - Get-EntraBetaContract
   - Get-EntraBetaCustomSecurityAttributeDefinition
   - Get-EntraBetaCustomSecurityAttributeDefinitionAllowedValue
   - Get-EntraBetaDeletedAdministrativeUnit
   - Get-EntraBetaDeletedDevice
   - Get-EntraBetaDeletedDirectoryObject
   - Get-EntraBetaDevice
   - Get-EntraBetaDeviceRegisteredOwner
   - Get-EntraBetaDeviceRegisteredUser
   - Get-EntraBetaDirectoryObject
   - Get-EntraBetaDirectoryObjectOnPremisesProvisioningError
   - Get-EntraBetaDirectoryRole
   - Get-EntraBetaDirectoryRoleMember
   - Get-EntraBetaDirectoryRoleTemplate
   - Get-EntraBetaDirectorySetting
   - Get-EntraBetaDirectorySettingTemplate
   - Get-EntraBetaDirSyncConfiguration
   - Get-EntraBetaDirSyncFeature
   - Get-EntraBetaDomain
   - Get-EntraBetaDomainFederationSettings
   - Get-EntraBetaDomainNameReference
   - Get-EntraBetaDomainServiceConfigurationRecord
   - Get-EntraBetaDomainVerificationDnsRecord
   - Get-EntraBetaFederationProperty
   - Get-EntraBetaPartnerInformation
   - Get-EntraBetaPasswordPolicy
   - Get-EntraBetaScopedRoleMembership
   - Get-EntraBetaSubscribedSku
   - Get-EntraBetaSubscription
   - Get-EntraBetaTenantDetail
   - New-EntraBetaAdministrativeUnit
   - New-EntraBetaAdministrativeUnitMember
   - New-EntraBetaAttributeSet
   - New-EntraBetaCustomHeaders
   - New-EntraBetaCustomSecurityAttributeDefinition
   - New-EntraBetaDevice
   - New-EntraBetaDirectorySetting
   - New-EntraBetaDomain
   - Remove-EntraBetaAdministrativeUnit
   - Remove-EntraBetaAdministrativeUnitMember
   - Remove-EntraBetaContact
   - Remove-EntraBetaDevice
   - Remove-EntraBetaDeviceRegisteredOwner
   - Remove-EntraBetaDeviceRegisteredUser
   - Remove-EntraBetaDirectoryRoleMember
   - Remove-EntraBetaDirectorySetting
   - Remove-EntraBetaDomain
   - Remove-EntraBetaScopedRoleMembership
   - Resolve-EntraBetaTenant
   - Restore-EntraBetaDeletedDirectoryObject
   - Set-EntraBetaAdministrativeUnit
   - Set-EntraBetaAttributeSet
   - Set-EntraBetaCustomSecurityAttributeDefinition
   - Set-EntraBetaCustomSecurityAttributeDefinitionAllowedValue
   - Set-EntraBetaDevice
   - Set-EntraBetaDirectorySetting
   - Set-EntraBetaDirSyncConfiguration
   - Set-EntraBetaDirSyncEnabled
   - Set-EntraBetaDirSyncFeature
   - Set-EntraBetaDomain
   - Set-EntraBetaDomainFederationSettings
   - Set-EntraBetaPartnerInformation
   - Set-EntraBetaTenantDetail
- Updated tests to mock Get-EntraContext for all the cmdlets listed above.
- Updated ALL tests for Entra to include authentication checks to validate the scenario.

# Issue
Link: #356