### PR TITLE
Fix Get-EntraGroup example description

### DIFF
--- a/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
+++ b/module/docs/entra-powershell-beta/Groups/Get-EntraBetaGroup.md
@@ -140,7 +140,7 @@ Parents of Contoso aaaaaaaa-6666-7777-8888-bbbbbbbbbbbb parentsofcontoso Parents
 
 In this example, we retrieve group using the Display Name.
 
-### Example 5: Get groups that contain a search string
+### Example 5: Get groups whose DisplayName starts with a search string
 
 ```powershell
 Connect-Entra -Scopes 'GroupMember.Read.All'

--- a/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
+++ b/module/docs/entra-powershell-v1.0/Groups/Get-EntraGroup.md
@@ -141,7 +141,7 @@ Azure Panda        qqqqqqqq-5555-0000-1111-hhhhhhhhhhhh azurepanda       Azure P
 
 In this example, we retrieve group using the Display Name.
 
-### Example 5: Get groups that contain a search string
+### Example 5: Get groups whose DisplayName starts with a search string
 
 ```powershell
 Connect-Entra -Scopes 'GroupMember.Read.All'


### PR DESCRIPTION
Fixes #1541 

The `$filter` query in the groups endpoint doesn't support `contains` operator.

<img width="842" height="137" alt="image" src="https://github.com/user-attachments/assets/b245a437-d7a7-4cff-b452-dd21f7a4611a" />
