### PR TITLE
Bugfix: Removed special unicode characters causing applications beta module to break in PS 5.1

### DIFF
--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Grant-EntraBetaMCPServerPermission.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Grant-EntraBetaMCPServerPermission.ps1
@@ -223,7 +223,7 @@ function Grant-EntraBetaMcpServerPermission {
             $grant = Set-ExactScopes -clientSpId $sp.Id -resourceSpId $resourceSp.Id -targetScopes $targetScopes -Additive $additiveMode
             
             if ($grant) {
-                Write-Host "`n✓ Successfully granted permissions to $($client.Name)" -ForegroundColor Green
+                Write-Host "`nSuccess: Successfully granted permissions to $($client.Name)" -ForegroundColor Green
                 Write-Verbose "  Grant ID: $($grant.Id)"
 
                 # Display granted scopes
@@ -235,12 +235,12 @@ function Grant-EntraBetaMcpServerPermission {
                 return $grant
             }
             else {
-                Write-Host "`n⚠ No permissions were granted to $($client.Name) (empty scope list)" -ForegroundColor Yellow
+                Write-Host "`nWarning: No permissions were granted to $($client.Name) (empty scope list)" -ForegroundColor Yellow
                 return $null
             }
         }
         catch {
-            Write-Host "`n✗ Failed to grant permissions to $($client.Name)" -ForegroundColor Red
+            Write-Host "`nFailed: Failed to grant permissions to $($client.Name)" -ForegroundColor Red
             Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
             throw
         }


### PR DESCRIPTION
# Changes
- Resolved an issue where the sub-module Applications on EntraBeta would throw a parser error on PoswerShell 5.1