### PR TITLE
Unit Tests to ensure compatibility with PS 7 and PS 5.1

### DIFF
--- a/test/Entra/ModuleCompatibility.Tests.ps1
+++ b/test/Entra/ModuleCompatibility.Tests.ps1
@@ -75,10 +75,13 @@ BeforeAll {
     function Test-ModuleImportPS51 {
         param([string]$ModulePath)
         
+        # Extract module name from path for PS 5.1 import
+        $moduleName = (Get-Item $ModulePath).BaseName
+        
         $command = @"
 try {
-    Import-Module '$ModulePath' -Force -ErrorAction Stop
-    Remove-Module '$((Get-Item $ModulePath).BaseName)' -Force -ErrorAction SilentlyContinue
+    Import-Module '$moduleName' -Force -ErrorAction Stop
+    Remove-Module '$moduleName' -Force -ErrorAction SilentlyContinue
     Write-Output 'SUCCESS'
 }
 catch {

--- a/test/EntraBeta/ModuleCompatibility.Tests.ps1
+++ b/test/EntraBeta/ModuleCompatibility.Tests.ps1
@@ -73,10 +73,13 @@ BeforeAll {
     function Test-ModuleImportPS51 {
         param([string]$ModulePath)
         
+        # Extract module name from path for PS 5.1 import
+        $moduleName = (Get-Item $ModulePath).BaseName
+        
         $command = @"
 try {
-    Import-Module '$ModulePath' -Force -ErrorAction Stop
-    Remove-Module '$((Get-Item $ModulePath).BaseName)' -Force -ErrorAction SilentlyContinue
+    Import-Module '$moduleName' -Force -ErrorAction Stop
+    Remove-Module '$moduleName' -Force -ErrorAction SilentlyContinue
     Write-Output 'SUCCESS'
 }
 catch {


### PR DESCRIPTION
# Changes
Automated test suite that validates all 18 Entra and EntraBeta PowerShell modules can be successfully imported in both PowerShell 5.1 and PowerShell 7+.

### What It Tests
- Module Discovery: Verifies all expected modules exist (9 Entra + 9 EntraBeta)
- PS 7+ Compatibility: Tests all modules import successfully in current PowerShell session
- PS 5.1 Compatibility: Tests all modules import successfully in Windows PowerShell 5.1
- Manifest Validation: Confirms all .psd1 manifest files exist and can be parsed
- Export Validation: Verifies each module exports cmdlets (486 total across all modules)

### Why It Matters
PowerShell 5.1 has stricter parsing rules and different Unicode handling than PS 7+. This ensures modules work in both environments without breaking enterprise customers still using Windows PowerShell.