### PR TITLE
New-EntraInvitation & New-EntraBetaInvitation param objects type updated from MSOL types

### DIFF
--- a/module/Entra/Microsoft.Entra/SignIns/New-EntraInvitation.ps1
+++ b/module/Entra/Microsoft.Entra/SignIns/New-EntraInvitation.ps1
@@ -15,10 +15,10 @@ function New-EntraInvitation {
         [System.String] $InviteRedirectUrl,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl")]
-        [Microsoft.Open.MSGraph.Model.InvitedUserMessageInfo] $InvitedUserMessageInfo,
+        [Microsoft.Graph.PowerShell.Models.IMicrosoftGraphInvitedUserMessageInfo] $InvitedUserMessageInfo,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl")]
-        [Microsoft.Open.MSGraph.Model.User] $InvitedUser,
+        [Microsoft.Graph.PowerShell.Models.IMicrosoftGraphUser] $InvitedUser,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl")]
         [System.Nullable`1[System.Boolean]] $SendInvitationMessage,

--- a/module/EntraBeta/Microsoft.Entra.Beta/SignIns/New-EntraBetaInvitation.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/SignIns/New-EntraBetaInvitation.ps1
@@ -12,7 +12,7 @@ function New-EntraBetaInvitation {
         [System.String] $InvitedUserDisplayName,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl")]
-        [Microsoft.Open.MSGraph.Model.InvitedUserMessageInfo] $InvitedUserMessageInfo,
+        [Microsoft.Graph.Beta.PowerShell.Models.IMicrosoftGraphInvitedUserMessageInfo] $InvitedUserMessageInfo,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl", Mandatory = $true)]
         [System.String] $InvitedUserEmailAddress,
@@ -21,7 +21,7 @@ function New-EntraBetaInvitation {
         [switch] $ResetRedemption,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl")]
-        [Microsoft.Open.MSGraph.Model.User] $InvitedUser,
+        [Microsoft.Graph.Beta.PowerShell.Models.IMicrosoftGraphUser] $InvitedUser,
                 
         [Parameter(ParameterSetName = "ByEmailAndRedirectUrl")]
         [System.String] $InvitedUserType,


### PR DESCRIPTION
# Changes
- Updated `-InvitedUser` parameter type to `Microsoft.Graph.Beta.PowerShell.Models.IMicrosoftGraphUser` for `New-EntraBetaInvitation` command.
- Updated `-InvitedUser` parameter type to `Microsoft.Graph.PowerShell.Models.IMicrosoftGraphUser` for `New-EntraInvitation` command.
- Updated `-InvitedUserMessageInfo` parameter type to `Microsoft.Graph.Beta.PowerShell.Models.IMicrosoftGraphInvitedUserMessageInfo` for `New-EntraBetaInvitation` command.
- Updated `-InvitedUserMessageInfo` parameter type to `Microsoft.Graph.PowerShell.Models.IMicrosoftGraphInvitedUserMessageInfo` for `New-EntraInvitation` command.

## Issue
closes: #1578