### PR TITLE
Add persistent input validation logging

### DIFF
--- a/module/Entra/Microsoft.Entra/Applications/Add-EntraInheritablePermissionsToAgentIdentityBlueprint.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Add-EntraInheritablePermissionsToAgentIdentityBlueprint.ps1
@@ -61,6 +61,7 @@ function Add-EntraInheritablePermissionsToAgentIdentityBlueprint {
                     try {
                         $currentResourceAppId = [guid]$resourceInput.Trim()
                     } catch {
+                        Write-EntraInputValidationLog -CmdletName 'Add-EntraInheritablePermissionsToAgentIdentityBlueprint' -ParameterName 'ResourceAppId' -InvalidValue $resourceInput -ExpectedPattern 'GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)' -Message 'Invalid GUID format for Resource Application ID'
                         Write-Warning "Invalid GUID format. Skipping this entry."
                         $firstIteration = $false
                         continue

--- a/module/Entra/Microsoft.Entra/Applications/Add-EntraRequiredResourceAccessToAgentIdentityBlueprint.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Add-EntraRequiredResourceAccessToAgentIdentityBlueprint.ps1
@@ -73,6 +73,7 @@ function Add-EntraRequiredResourceAccessToAgentIdentityBlueprint {
                     try {
                         $currentResourceAppId = [guid]$resourceInput.Trim()
                     } catch {
+                        Write-EntraInputValidationLog -CmdletName 'Add-EntraRequiredResourceAccessToAgentIdentityBlueprint' -ParameterName 'ResourceAppId' -InvalidValue $resourceInput -ExpectedPattern 'GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)' -Message 'Invalid GUID format for Resource Application ID'
                         Write-Warning "Invalid GUID format. Skipping this entry."
                         $firstIteration = $false
                         continue
@@ -205,6 +206,7 @@ function Add-EntraRequiredResourceAccessToAgentIdentityBlueprint {
                                 if ($matchedPerm) { $displayName = $matchedPerm.value }
                                 Write-Host "Added $permTypeName permission: $displayName ($($validGuid.ToString()))" -ForegroundColor Green
                             } catch {
+                                Write-EntraInputValidationLog -CmdletName 'Add-EntraRequiredResourceAccessToAgentIdentityBlueprint' -ParameterName 'PermissionId' -InvalidValue $permId -ExpectedPattern 'GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)' -Message "Invalid GUID format: $permId"
                                 Write-Warning "Invalid GUID format: $permId"
                             }
                         }

--- a/module/Entra/Microsoft.Entra/Applications/Get-EntraApplicationLogo.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Get-EntraApplicationLogo.ps1
@@ -45,6 +45,7 @@ function Get-EntraApplicationLogo {
             $imageExtensions = @(".jpg", ".jpeg", ".png", ".gif", ".bmp")
 
             if (-not (Test-Path $($params.FilePath) -PathType Leaf) -and $imageExtensions -notcontains [System.IO.Path]::GetExtension($($params.FilePath))) {
+                Write-EntraInputValidationLog -CmdletName 'Get-EntraApplicationLogo' -ParameterName 'FilePath' -InvalidValue $params.FilePath -ExpectedPattern 'Valid file path with image extension (.jpg, .jpeg, .png, .gif, .bmp)' -Message 'FilePath is invalid'
                 Write-Error -Message "Get-EntraApplicationLogo : FilePath is invalid"
                 break;
             }

--- a/module/Entra/Microsoft.Entra/Applications/New-EntraApplication.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/New-EntraApplication.ps1
@@ -365,6 +365,7 @@ function New-EntraApplication {
                         if ($_.Name -eq 'legalAgeGroupRule') {
                             $validValues = @('Allow', 'RequireConsentForMinors', 'RequireConsentForKids', 'RequireConsentForPrivacyServices', 'BlockMinors')
                             if ($validValues -notcontains $_.Value) {
+                                Write-EntraInputValidationLog -CmdletName 'New-EntraApplication' -ParameterName 'legalAgeGroupRule' -InvalidValue "$($_.Value)" -ExpectedPattern "One of: $($validValues -join ', ')" -Message "Invalid value specified for property 'legalAgeGroupRule'"
                                 Write-Error "Invalid value specified for property 'legalAgeGroupRule'. Valid values are: $($validValues -join ', ')"
                                 return
                             }

--- a/module/Entra/Microsoft.Entra/Applications/New-EntraServicePrincipal.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/New-EntraServicePrincipal.ps1
@@ -210,6 +210,7 @@ function New-EntraServicePrincipal {
                     $Value = $null
             
             if (-not [bool]::TryParse($TmpValue, [ref]$Value)) {
+                Write-EntraInputValidationLog -CmdletName 'New-EntraServicePrincipal' -ParameterName 'AccountEnabled' -InvalidValue "$TmpValue" -ExpectedPattern 'Boolean (true/false)' -Message 'Invalid input for AccountEnabled'
                 throw 'Invalid input for AccountEnabled'
                 return
             }

--- a/module/Entra/Microsoft.Entra/Applications/Set-EntraApplicationLogo.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Set-EntraApplicationLogo.ps1
@@ -57,6 +57,7 @@ function Set-EntraApplicationLogo {
                     $logoBytes = [System.IO.File]::ReadAllBytes($($params.FilePath))
                 }
                 else {
+                    Write-EntraInputValidationLog -CmdletName 'Set-EntraApplicationLogo' -ParameterName 'FilePath' -InvalidValue $params.FilePath -ExpectedPattern 'Valid local file path or URL' -Message 'FilePath is invalid'
                     Write-Error -Message "FilePath is invalid" -ErrorAction Stop
                 }
             }
@@ -68,6 +69,7 @@ function Set-EntraApplicationLogo {
             Invoke-GraphRequest -Headers $customHeaders -Uri $URI -Method $Method -ContentType "image/*" -Body $logoBytes
         }
         catch [System.Net.WebException] {
+            Write-EntraInputValidationLog -CmdletName 'Set-EntraApplicationLogo' -ParameterName 'FilePath' -InvalidValue $params.FilePath -ExpectedPattern 'Valid URL' -Message 'FilePath is invalid. Invalid or malformed url'
             Write-Error -Message "FilePath is invalid. Invalid or malformed url" -ErrorAction Stop
         }
     }    

--- a/module/Entra/Microsoft.Entra/Applications/Write-EntraInputValidationLog.ps1
+++ b/module/Entra/Microsoft.Entra/Applications/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/Entra/Microsoft.Entra/CertificateBasedAuthentication/Get-EntraUserCertificateUserIdsFromCertificate.ps1
+++ b/module/Entra/Microsoft.Entra/CertificateBasedAuthentication/Get-EntraUserCertificateUserIdsFromCertificate.ps1
@@ -39,6 +39,7 @@ function Get-EntraUserCertificateUserIdsFromCertificate {
             return $certificate
         }
         else {
+            Write-EntraInputValidationLog -CmdletName 'Get-EntraUserCertificateUserIdsFromCertificate' -ParameterName 'CertificatePath' -InvalidValue $CertificatePath -ExpectedPattern 'File with .cer or .pem extension' -Message 'Unsupported certificate format'
             throw "Unsupported certificate format. Please provide a .cer or .pem file."
         }
     }

--- a/module/Entra/Microsoft.Entra/CertificateBasedAuthentication/Write-EntraInputValidationLog.ps1
+++ b/module/Entra/Microsoft.Entra/CertificateBasedAuthentication/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirSyncFeature.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Get-EntraDirSyncFeature.ps1
@@ -83,6 +83,7 @@ function Get-EntraDirSyncFeature {
         else {
             $output = $table | Where-Object { $_.dirsyncFeature -eq $Feature }
             if ($null -eq $output) {
+                Write-EntraInputValidationLog -CmdletName 'Get-EntraDirSyncFeature' -ParameterName 'Feature' -InvalidValue $Feature -ExpectedPattern 'Valid DirSync feature name' -Message 'Invalid value for parameter Feature'
                 Write-Error "Get-EntraDirSyncfeature : Invalid value for parameter.  Parameter Name: Feature."
             }
             else {

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncFeature.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Set-EntraDirSyncFeature.ps1
@@ -15,6 +15,9 @@ function Set-EntraDirSyncFeature {
 
             foreach ($item in $inputArray) {
                 if ([string]::IsNullOrWhiteSpace($item)) {
+                    if (Get-Command Write-EntraInputValidationLog -ErrorAction SilentlyContinue) {
+                        Write-EntraInputValidationLog -CmdletName 'Set-EntraDirSyncFeature' -ParameterName 'Features' -InvalidValue "$item" -ExpectedPattern 'Non-empty string' -Message "Each feature must be a non-empty string. Invalid item: '$item'"
+                    }
                     throw "Each feature must be a non-empty string. Invalid item: '$item'"
                 }
             }

--- a/module/Entra/Microsoft.Entra/DirectoryManagement/Write-EntraInputValidationLog.ps1
+++ b/module/Entra/Microsoft.Entra/DirectoryManagement/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/Entra/Microsoft.Entra/SignIns/Get-EntraPolicy.ps1
+++ b/module/Entra/Microsoft.Entra/SignIns/Get-EntraPolicy.ps1
@@ -32,6 +32,7 @@ function Get-EntraPolicy {
         $endpoints = @("homeRealmDiscoveryPolicies", "claimsMappingPolicies", "tokenIssuancePolicies", "tokenLifetimePolicies", "activityBasedTimeoutPolicies", "featureRolloutPolicies", "defaultAppManagementPolicy", "appManagementPolicies", "authenticationFlowsPolicy",	"authenticationMethodsPolicy", "permissionGrantPolicies")
         
         if ($PSBoundParameters.ContainsKey("Top") -and ($null -eq $Top -or $Top -eq 0)) {
+            Write-EntraInputValidationLog -CmdletName 'Get-EntraPolicy' -ParameterName 'Top' -InvalidValue '0' -ExpectedPattern 'Integer between 1 and 999' -Message 'Invalid page size specified'
             Write-Error "Invalid page size specified: '0'. Must be between 1 and 999 inclusive.  
 Status: 400 (BadRequest) 
 ErrorCode: Request_UnsupportedQuery"

--- a/module/Entra/Microsoft.Entra/SignIns/Write-EntraInputValidationLog.ps1
+++ b/module/Entra/Microsoft.Entra/SignIns/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/Entra/Microsoft.Entra/Users/Get-EntraUserExtension.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Get-EntraUserExtension.ps1
@@ -83,6 +83,7 @@ function Get-EntraUserExtension {
             if ($Property) {
                 $invalidProperties = $Property | Where-Object { $_ -notin $allProperties }
                 if ($invalidProperties) {
+                    Write-EntraInputValidationLog -CmdletName 'Get-EntraUserExtension' -ParameterName 'Property' -InvalidValue ($invalidProperties -join ', ') -ExpectedPattern 'Valid user extension property names' -Message "Invalid property/properties specified: $($invalidProperties -join ', ')"
                     throw "Invalid property/properties specified: $($invalidProperties -join ', ')"
                 }
                 $selectedProperties = $Property

--- a/module/Entra/Microsoft.Entra/Users/Write-EntraInputValidationLog.ps1
+++ b/module/Entra/Microsoft.Entra/Users/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Add-EntraBetaInheritablePermissionsToAgentIdentityBlueprint.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Add-EntraBetaInheritablePermissionsToAgentIdentityBlueprint.ps1
@@ -44,6 +44,7 @@ function Add-EntraBetaInheritablePermissionsToAgentIdentityBlueprint {
                     try {
                         $currentResourceAppId = [guid]$resourceInput.Trim()
                     } catch {
+                        Write-EntraInputValidationLog -CmdletName 'Add-EntraBetaInheritablePermissionsToAgentIdentityBlueprint' -ParameterName 'ResourceAppId' -InvalidValue $resourceInput -ExpectedPattern 'GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)' -Message 'Invalid GUID format for Resource Application ID'
                         Write-Warning "Invalid GUID format. Skipping this entry."
                         $firstIteration = $false
                         continue

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Add-EntraBetaRequiredResourceAccessToAgentIdentityBlueprint.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Add-EntraBetaRequiredResourceAccessToAgentIdentityBlueprint.ps1
@@ -73,6 +73,7 @@ function Add-EntraBetaRequiredResourceAccessToAgentIdentityBlueprint {
                     try {
                         $currentResourceAppId = [guid]$resourceInput.Trim()
                     } catch {
+                        Write-EntraInputValidationLog -CmdletName 'Add-EntraBetaRequiredResourceAccessToAgentIdentityBlueprint' -ParameterName 'ResourceAppId' -InvalidValue $resourceInput -ExpectedPattern 'GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)' -Message 'Invalid GUID format for Resource Application ID'
                         Write-Warning "Invalid GUID format. Skipping this entry."
                         $firstIteration = $false
                         continue
@@ -205,6 +206,7 @@ function Add-EntraBetaRequiredResourceAccessToAgentIdentityBlueprint {
                                 if ($matchedPerm) { $displayName = $matchedPerm.value }
                                 Write-Host "Added $permTypeName permission: $displayName ($($validGuid.ToString()))" -ForegroundColor Green
                             } catch {
+                                Write-EntraInputValidationLog -CmdletName 'Add-EntraBetaRequiredResourceAccessToAgentIdentityBlueprint' -ParameterName 'PermissionId' -InvalidValue $permId -ExpectedPattern 'GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)' -Message "Invalid GUID format: $permId"
                                 Write-Warning "Invalid GUID format: $permId"
                             }
                         }

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaApplicationLogo.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Get-EntraBetaApplicationLogo.ps1
@@ -42,6 +42,7 @@ function Get-EntraBetaApplicationLogo {
             $params["FilePath"] = $PSBoundParameters["FilePath"]  
             $imageExtensions = @(".jpg", ".jpeg", ".png", ".gif", ".bmp")
             if (-not (Test-Path $($params.FilePath) -PathType Leaf) -and $imageExtensions -notcontains [System.IO.Path]::GetExtension($($params.FilePath))) {
+                Write-EntraInputValidationLog -CmdletName 'Get-EntraBetaApplicationLogo' -ParameterName 'FilePath' -InvalidValue $params.FilePath -ExpectedPattern 'Valid file path with image extension (.jpg, .jpeg, .png, .gif, .bmp)' -Message 'FilePath is invalid'
                 Write-Error -Message "Get-EntraBetaApplicationLogo : FilePath is invalid"
                 break;
             }

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Grant-EntraBetaMCPServerPermission.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Grant-EntraBetaMCPServerPermission.ps1
@@ -156,6 +156,7 @@ function Grant-EntraBetaMcpServerPermission {
                     }
                 }
                 else {
+                    Write-EntraInputValidationLog -CmdletName 'Grant-EntraBetaMCPServerPermission' -ParameterName 'PredefinedAppName' -InvalidValue "$PredefinedAppName" -ExpectedPattern 'Valid predefined MCP client name' -Message "Invalid MCP client: $PredefinedAppName"
                     throw "Invalid MCP client: $PredefinedAppName"
                 }
             }
@@ -205,6 +206,7 @@ function Grant-EntraBetaMcpServerPermission {
             # Validate specified scopes
             $invalidScopes = $Scopes | Where-Object { $_ -notin $availableScopes }
             if ($invalidScopes) {
+                Write-EntraInputValidationLog -CmdletName 'Grant-EntraBetaMCPServerPermission' -ParameterName 'Scopes' -InvalidValue ($invalidScopes -join ', ') -ExpectedPattern "Valid scopes available on resource" -Message "Invalid scopes (not available on resource): $($invalidScopes -join ', ')"
                 throw "Invalid scopes (not available on resource): $($invalidScopes -join ', ')"
             }
             $targetScopes = $Scopes | Sort-Object -Unique

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/New-EntraBetaApplication.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/New-EntraBetaApplication.ps1
@@ -365,6 +365,7 @@ function New-EntraBetaApplication {
                         if ($_.Name -eq 'legalAgeGroupRule') {
                             $validValues = @('Allow', 'RequireConsentForMinors', 'RequireConsentForKids', 'RequireConsentForPrivacyServices', 'BlockMinors')
                             if ($validValues -notcontains $_.Value) {
+                                Write-EntraInputValidationLog -CmdletName 'New-EntraBetaApplication' -ParameterName 'legalAgeGroupRule' -InvalidValue "$($_.Value)" -ExpectedPattern "One of: $($validValues -join ', ')" -Message "Invalid value specified for property 'legalAgeGroupRule'"
                                 Write-Error "Invalid value specified for property 'legalAgeGroupRule'. Valid values are: $($validValues -join ', ')"
                                 return
                             }

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/New-EntraBetaServicePrincipal.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/New-EntraBetaServicePrincipal.ps1
@@ -118,6 +118,7 @@ function New-EntraBetaServicePrincipal {
             $Value = $null
             
             if (-not [bool]::TryParse($TmpValue, [ref]$Value)) {
+                Write-EntraInputValidationLog -CmdletName 'New-EntraBetaServicePrincipal' -ParameterName 'AccountEnabled' -InvalidValue "$TmpValue" -ExpectedPattern 'Boolean (true/false)' -Message 'Invalid input for AccountEnabled'
                 throw 'Invalid input for AccountEnabled'
                 return
             }

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Revoke-EntraBetaMCPServerPermission.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Revoke-EntraBetaMCPServerPermission.ps1
@@ -169,6 +169,7 @@ function Revoke-EntraBetaMcpServerPermission {
             $scopesToRevoke = @($Scopes) | Sort-Object -Unique
             $invalidScopes = $scopesToRevoke | Where-Object { $_ -notin $currentScopes }
             if ($invalidScopes) {
+                Write-EntraInputValidationLog -CmdletName 'Revoke-EntraBetaMCPServerPermission' -ParameterName 'Scopes' -InvalidValue ($invalidScopes -join ', ') -ExpectedPattern 'Currently granted scopes' -Message "The following scopes are not currently granted: $($invalidScopes -join ', ')"
                 Write-Warning "The following scopes are not currently granted: $($invalidScopes -join ', ')"
             }
 

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Set-EntraBetaApplicationLogo.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Set-EntraBetaApplicationLogo.ps1
@@ -58,6 +58,7 @@ function Set-EntraBetaApplicationLogo {
                     $logoBytes = [System.IO.File]::ReadAllBytes($($params.FilePath))
                 }
                 else {
+                    Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaApplicationLogo' -ParameterName 'FilePath' -InvalidValue $params.FilePath -ExpectedPattern 'Valid local file path or URL' -Message 'FilePath is invalid'
                     Write-Error -Message "FilePath is invalid" -ErrorAction Stop
                 }
             }
@@ -69,6 +70,7 @@ function Set-EntraBetaApplicationLogo {
             Invoke-GraphRequest -Headers $customHeaders -Uri $URI -Method $Method -ContentType "image/*" -Body $logoBytes
         }
         catch [System.Net.WebException] {
+            Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaApplicationLogo' -ParameterName 'FilePath' -InvalidValue $params.FilePath -ExpectedPattern 'Valid URL' -Message 'FilePath is invalid. Invalid or malformed url'
             Write-Error -Message "FilePath is invalid. Invalid or malformed url" -ErrorAction Stop
         }
     }    

--- a/module/EntraBeta/Microsoft.Entra.Beta/Applications/Write-EntraInputValidationLog.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Applications/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirSyncFeature.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Get-EntraBetaDirSyncFeature.ps1
@@ -83,6 +83,7 @@ function Get-EntraBetaDirSyncFeature {
         else {
             $output = $table | Where-Object { $_.dirsyncFeature -eq $Feature }
             if ($null -eq $output) {
+                Write-EntraInputValidationLog -CmdletName 'Get-EntraBetaDirSyncFeature' -ParameterName 'Feature' -InvalidValue $Feature -ExpectedPattern 'Valid DirSync feature name' -Message 'Invalid value for parameter Feature'
                 Write-Error "Get-EntraBetaDirSyncFeature : Invalid value for parameter.  Parameter Name: Feature."
             }
             else {

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncFeature.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Set-EntraBetaDirSyncFeature.ps1
@@ -17,6 +17,9 @@ function Set-EntraBetaDirSyncFeature {
 
             foreach ($item in $inputArray) {
                 if ([string]::IsNullOrWhiteSpace($item)) {
+                    if (Get-Command Write-EntraInputValidationLog -ErrorAction SilentlyContinue) {
+                        Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaDirSyncFeature' -ParameterName 'Features' -InvalidValue "$item" -ExpectedPattern 'Non-empty string' -Message "Each feature must be a non-empty string. Invalid item: '$item'"
+                    }
                     throw "Each feature must be a non-empty string. Invalid item: '$item'"
                 }
             }

--- a/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Write-EntraInputValidationLog.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/DirectoryManagement/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/EntraBeta/Microsoft.Entra.Beta/Governance/Set-EntraBetaAppRoleToApplicationUser.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Governance/Set-EntraBetaAppRoleToApplicationUser.ps1
@@ -471,6 +471,7 @@ function Set-EntraBetaAppRoleToApplicationUser {
                     Write-ColoredVerbose "UPN : $($cleanUserPrincipalName)" -Color "Green"
 
                     if (-not $cleanUserPrincipalName) { 
+                        Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaAppRoleToApplicationUser' -ParameterName 'userPrincipalName' -InvalidValue "$($user.$sourceMatchPropertyName)" -ExpectedPattern 'Valid UPN format (user@domain.com)' -Message "Skipping user due to invalid userPrincipalName"
                         Write-Warning "Skipping user due to invalid userPrincipalName: $($user.$sourceMatchPropertyName)"
                         continue 
                     }
@@ -479,6 +480,7 @@ function Set-EntraBetaAppRoleToApplicationUser {
                     Write-ColoredVerbose "DisplayName : $($cleanDisplayName)" -Color "Green"
 
                     if (-not $cleanDisplayName) { 
+                        Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaAppRoleToApplicationUser' -ParameterName 'displayName' -InvalidValue "$($user.DisplayName)" -ExpectedPattern 'Non-empty string' -Message "Skipping user due to invalid displayName"
                         Write-Warning "Skipping user due to invalid displayName: $($user.DisplayName)"
                         continue 
                     }
@@ -486,6 +488,7 @@ function Set-EntraBetaAppRoleToApplicationUser {
                     Write-ColoredVerbose "Mail nickname : $($cleanMailNickname)" -Color "Green"
     
                     if (-not $cleanMailNickname) { 
+                        Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaAppRoleToApplicationUser' -ParameterName 'mailNickname' -InvalidValue "$($user.MailNickname)" -ExpectedPattern 'Non-empty string' -Message "Skipping user due to invalid mailNickname"
                         Write-Warning "Skipping user due to invalid mailNickname: $($user.MailNickname)"
                         continue 
                     }
@@ -495,6 +498,7 @@ function Set-EntraBetaAppRoleToApplicationUser {
                     $userRoleType = SanitizeInput -Value $user.memberType
                     Write-ColoredVerbose "Role : $($userRole)" -Color "Green"
                     if (-not $userRole) {
+                        Write-EntraInputValidationLog -CmdletName 'Set-EntraBetaAppRoleToApplicationUser' -ParameterName 'Role' -InvalidValue "$($user.Role)" -ExpectedPattern 'Valid role name' -Message "Skipping user due to invalid Role"
                         Write-Warning "Skipping user due to invalid Role: $($user.Role)"
                         continue
                     }

--- a/module/EntraBeta/Microsoft.Entra.Beta/Governance/Write-EntraInputValidationLog.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/Governance/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/module/EntraBeta/Microsoft.Entra.Beta/SignIns/Get-EntraBetaPolicy.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/SignIns/Get-EntraBetaPolicy.ps1
@@ -42,6 +42,7 @@ function Get-EntraBetaPolicy {
             "permissionGrantPolicies")
         
         if ($PSBoundParameters.ContainsKey("Top") -and ($null -eq $Top -or $Top -eq 0)) {
+            Write-EntraInputValidationLog -CmdletName 'Get-EntraBetaPolicy' -ParameterName 'Top' -InvalidValue '0' -ExpectedPattern 'Integer between 1 and 999' -Message 'Invalid page size specified'
             Write-Error "Invalid page size specified: '0'. Must be between 1 and 999 inclusive.  
 Status: 400 (BadRequest) 
 ErrorCode: Request_UnsupportedQuery"

--- a/module/EntraBeta/Microsoft.Entra.Beta/SignIns/Write-EntraInputValidationLog.ps1
+++ b/module/EntraBeta/Microsoft.Entra.Beta/SignIns/Write-EntraInputValidationLog.ps1
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+function Write-EntraInputValidationLog {
+    <#
+    .SYNOPSIS
+        Logs input validation failures to persistent storage for security audit compliance.
+    .DESCRIPTION
+        Writes a structured log entry when user-provided input fails validation.
+        On Windows, logs are written to both the Windows Event Log (Application log,
+        source 'Microsoft.Entra') and to a file-based log. On Linux/macOS, logs are
+        written to a file and optionally to syslog via the 'logger' command.
+        This function satisfies Microsoft.Security.SystemsADM.10031 which requires
+        persistent logging of all user input that does not match expected patterns.
+    .PARAMETER CmdletName
+        The name of the cmdlet where the validation failure occurred.
+    .PARAMETER ParameterName
+        The name of the parameter that failed validation.
+    .PARAMETER InvalidValue
+        The value that failed validation. Sensitive values are masked.
+    .PARAMETER ExpectedPattern
+        A description of the expected input pattern.
+    .PARAMETER Message
+        An optional additional message describing the validation failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvalidValue,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedPattern,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message
+    )
+
+    $timestamp = [DateTime]::UtcNow.ToString('o')
+    $username = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } else {
+        [System.Environment]::UserName
+    }
+
+    # Mask potentially sensitive values - show only first 4 chars for values longer than 8 chars
+    $maskedValue = if ([string]::IsNullOrEmpty($InvalidValue)) {
+        '[empty]'
+    } elseif ($InvalidValue.Length -gt 8) {
+        $InvalidValue.Substring(0, 4) + '****'
+    } else {
+        '****'
+    }
+
+    $logEntry = [ordered]@{
+        Timestamp       = $timestamp
+        EventType       = 'InputValidationFailure'
+        CmdletName      = $CmdletName
+        ParameterName   = $ParameterName
+        InvalidValue    = $maskedValue
+        ExpectedPattern = if ($ExpectedPattern) { $ExpectedPattern } else { 'N/A' }
+        Message         = if ($Message) { $Message } else { 'N/A' }
+        User            = $username
+    }
+
+    $logMessage = ($logEntry.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join '; '
+
+    # Write to file-based log (always available, no admin required)
+    try {
+        $logDirectory = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'Microsoft.Entra\Logs'
+        if (-not (Test-Path $logDirectory)) {
+            New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        }
+        $logFilePath = Join-Path $logDirectory "InputValidation-$(Get-Date -Format 'yyyyMMdd').log"
+        Out-File -FilePath $logFilePath -Append -Encoding UTF8 -InputObject $logMessage
+    }
+    catch {
+        Write-Verbose "Write-EntraInputValidationLog: Failed to write to file log: $_"
+    }
+
+    # Write to Windows Event Log (persistent, centrally auditable) - Windows only
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        try {
+            $source = 'Microsoft.Entra'
+            if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+                [System.Diagnostics.EventLog]::CreateEventSource($source, 'Application')
+            }
+            Write-EventLog -LogName 'Application' -Source $source -EventId 1001 -EntryType Warning -Message $logMessage
+        }
+        catch {
+            # Event log write failure is non-fatal; file log is the primary persistent store
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to Event Log: $_"
+        }
+    } else {
+        # On non-Windows, log to syslog via logger if available
+        try {
+            if (Get-Command 'logger' -ErrorAction SilentlyContinue) {
+                logger -p user.warning -t 'Microsoft.Entra' $logMessage
+            }
+        }
+        catch {
+            Write-Verbose "Write-EntraInputValidationLog: Failed to write to syslog: $_"
+        }
+    }
+
+    Write-Verbose "Input validation failure logged: $logMessage"
+}

--- a/test/Entra/Applications/Write-EntraInputValidationLog.Integration.Tests.ps1
+++ b/test/Entra/Applications/Write-EntraInputValidationLog.Integration.Tests.ps1
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {
+    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
+    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
+    Import-Module (Join-Path $binPath "Microsoft.Entra.Applications.psd1") -Force
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Application.ReadWrite.All") } } -ModuleName Microsoft.Entra.Applications
+    Mock -CommandName New-EntraCustomHeaders -MockWith { @{"User-Agent" = "Test"} } -ModuleName Microsoft.Entra.Applications
+    Mock -CommandName Out-File -ModuleName Microsoft.Entra.Applications
+    Mock -CommandName Write-EventLog -ModuleName Microsoft.Entra.Applications
+    Mock -CommandName New-MgServicePrincipal -ModuleName Microsoft.Entra.Applications
+}
+
+Describe "New-EntraServicePrincipal - Input Validation Logging" {
+    Context "When AccountEnabled has invalid boolean value" {
+        It "Should log validation failure and throw for non-boolean AccountEnabled" {
+            { New-EntraServicePrincipal -AppId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -AccountEnabled "notaboolean" } | Should -Throw "*Invalid input for AccountEnabled*"
+        }
+    }
+}
+
+Describe "Get-EntraApplicationLogo - Input Validation Logging" {
+    Context "When FilePath is invalid" {
+        It "Should log validation failure for non-existent file path" {
+            Mock -CommandName Out-File -ModuleName Microsoft.Entra.Applications
+            Get-EntraApplicationLogo -ApplicationId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -FilePath "C:\nonexistent\path\logo.xyz" -ErrorAction SilentlyContinue
+            Should -Invoke -CommandName Out-File -ModuleName Microsoft.Entra.Applications -Times 1
+        }
+    }
+}
+
+Describe "New-EntraApplication - Input Validation Logging" {
+    Context "When legalAgeGroupRule has invalid value" {
+        BeforeAll {
+            Mock -CommandName New-MgApplication -ModuleName Microsoft.Entra.Applications
+        }
+        It "Should produce error for invalid legalAgeGroupRule value" {
+            $parentalSettings = [PSCustomObject]@{ legalAgeGroupRule = "InvalidValue" }
+            New-EntraApplication -DisplayName "TestApp" -ParentalControlSettings $parentalSettings -ErrorAction SilentlyContinue -ErrorVariable testErr
+            $testErr | Should -Not -BeNullOrEmpty
+            "$testErr" | Should -BeLike "*legalAgeGroupRule*"
+        }
+    }
+}

--- a/test/Entra/Applications/Write-EntraInputValidationLog.Integration.Tests.ps1
+++ b/test/Entra/Applications/Write-EntraInputValidationLog.Integration.Tests.ps1
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------------------------
 
 BeforeAll {
-    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
-    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
-    Import-Module (Join-Path $binPath "Microsoft.Entra.Applications.psd1") -Force
+    if ($null -eq (Get-Module -Name Microsoft.Entra.Applications)) {
+        Import-Module Microsoft.Entra.Applications
+    }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Application.ReadWrite.All") } } -ModuleName Microsoft.Entra.Applications

--- a/test/Entra/Applications/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/Applications/Write-EntraInputValidationLog.Tests.ps1
@@ -10,11 +10,13 @@ BeforeAll {
 Describe "Write-EntraInputValidationLog" {
     Context "Parameter validation" {
         It "Should require CmdletName parameter" {
-            { Write-EntraInputValidationLog -ParameterName 'Test' } | Should -Throw
+            $param = (Get-Command Write-EntraInputValidationLog).Parameters['CmdletName']
+            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
         }
 
         It "Should require ParameterName parameter" {
-            { Write-EntraInputValidationLog -CmdletName 'Test' } | Should -Throw
+            $param = (Get-Command Write-EntraInputValidationLog).Parameters['ParameterName']
+            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
         }
 
         It "Should accept all parameters without throwing" {

--- a/test/Entra/Applications/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/Applications/Write-EntraInputValidationLog.Tests.ps1
@@ -1,0 +1,105 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot "..\..\..\module\Entra\Microsoft.Entra\Applications\Write-EntraInputValidationLog.ps1"
+    . $ModulePath
+}
+
+Describe "Write-EntraInputValidationLog" {
+    Context "Parameter validation" {
+        It "Should require CmdletName parameter" {
+            { Write-EntraInputValidationLog -ParameterName 'Test' } | Should -Throw
+        }
+
+        It "Should require ParameterName parameter" {
+            { Write-EntraInputValidationLog -CmdletName 'Test' } | Should -Throw
+        }
+
+        It "Should accept all parameters without throwing" {
+            { Write-EntraInputValidationLog -CmdletName 'Get-EntraUser' -ParameterName 'UserId' -InvalidValue 'bad-value-that-is-long' -ExpectedPattern 'GUID format' -Message 'Test message' } | Should -Not -Throw
+        }
+
+        It "Should work with only mandatory parameters" {
+            { Write-EntraInputValidationLog -CmdletName 'Get-EntraUser' -ParameterName 'UserId' } | Should -Not -Throw
+        }
+    }
+
+    Context "Non-fatal behavior" {
+        It "Should not throw exceptions even when all logging fails" {
+            Mock Out-File { throw "Disk full" }
+            Mock Write-EventLog { throw "Access denied" }
+            { Write-EntraInputValidationLog -CmdletName 'Test-Cmdlet' -ParameterName 'Param1' -InvalidValue 'bad' } | Should -Not -Throw
+        }
+
+        It "Should not throw if event log source does not exist" {
+            Mock Write-EventLog { throw "Source does not exist" }
+            { Write-EntraInputValidationLog -CmdletName 'Test-Cmdlet' -ParameterName 'Param1' } | Should -Not -Throw
+        }
+    }
+
+    Context "Verbose output validation" {
+        It "Should include structured log content in Verbose output" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Get-EntraUser' -ParameterName 'UserId' -InvalidValue 'not-a-guid-value' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*InputValidationFailure*'
+            $verboseText | Should -BeLike '*CmdletName=Get-EntraUser*'
+            $verboseText | Should -BeLike '*ParameterName=UserId*'
+        }
+
+        It "Should include timestamp in verbose output" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*Timestamp=*'
+        }
+
+        It "Should include user identity in verbose output" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*User=*'
+        }
+    }
+
+    Context "Value masking in verbose output" {
+        It "Should mask values longer than 8 characters showing only first 4" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -InvalidValue 'VeryLongInvalidValue123' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*Very`*`*`*`**'
+            $verboseText | Should -Not -BeLike '*VeryLongInvalidValue123*'
+        }
+
+        It "Should fully mask values 8 characters or shorter" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -InvalidValue 'short' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*InvalidValue=`*`*`*`**'
+            $verboseText | Should -Not -BeLike '*short*'
+        }
+
+        It "Should show [empty] for null or empty values" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -InvalidValue '' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*`[empty`]*'
+        }
+    }
+
+    Context "Expected pattern and message" {
+        It "Should show N/A for missing expected pattern" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*ExpectedPattern=N/A*'
+        }
+
+        It "Should include expected pattern when provided" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -ExpectedPattern 'GUID format' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*ExpectedPattern=GUID format*'
+        }
+
+        It "Should include message when provided" {
+            $verboseOutput = Write-EntraInputValidationLog -CmdletName 'Test' -ParameterName 'P1' -Message 'Custom error message' -Verbose 4>&1
+            $verboseText = $verboseOutput | Out-String
+            $verboseText | Should -BeLike '*Message=Custom error message*'
+        }
+    }
+}

--- a/test/Entra/Applications/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/Applications/Write-EntraInputValidationLog.Tests.ps1
@@ -10,13 +10,11 @@ BeforeAll {
 Describe "Write-EntraInputValidationLog" {
     Context "Parameter validation" {
         It "Should require CmdletName parameter" {
-            $param = (Get-Command Write-EntraInputValidationLog).Parameters['CmdletName']
-            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
+            { Write-EntraInputValidationLog -ParameterName 'Test' } | Should -Throw
         }
 
         It "Should require ParameterName parameter" {
-            $param = (Get-Command Write-EntraInputValidationLog).Parameters['ParameterName']
-            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
+            { Write-EntraInputValidationLog -CmdletName 'Test' } | Should -Throw
         }
 
         It "Should accept all parameters without throwing" {

--- a/test/Entra/DirectoryManagement/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Write-EntraInputValidationLog.Tests.ps1
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------------------------
 
 BeforeAll {
-    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
-    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
-    Import-Module (Join-Path $binPath "Microsoft.Entra.DirectoryManagement.psd1") -Force
+    if ($null -eq (Get-Module -Name Microsoft.Entra.DirectoryManagement)) {
+        Import-Module Microsoft.Entra.DirectoryManagement
+    }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Directory.ReadWrite.All") } } -ModuleName Microsoft.Entra.DirectoryManagement

--- a/test/Entra/DirectoryManagement/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/DirectoryManagement/Write-EntraInputValidationLog.Tests.ps1
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {
+    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
+    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
+    Import-Module (Join-Path $binPath "Microsoft.Entra.DirectoryManagement.psd1") -Force
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Directory.ReadWrite.All") } } -ModuleName Microsoft.Entra.DirectoryManagement
+    Mock -CommandName New-EntraCustomHeaders -MockWith { @{"User-Agent" = "Test"} } -ModuleName Microsoft.Entra.DirectoryManagement
+    Mock -CommandName Out-File -ModuleName Microsoft.Entra.DirectoryManagement
+    Mock -CommandName Write-EventLog -ModuleName Microsoft.Entra.DirectoryManagement
+
+    $scriptblock = {
+        return [PSCustomObject]@{
+            "Features" = [PSCustomObject]@{
+                "BlockCloudObjectTakeoverThroughHardMatchEnabled" = $false
+                "PasswordSyncEnabled" = $false
+            }
+        }
+    }
+    Mock -CommandName Get-MgDirectoryOnPremiseSynchronization -MockWith $scriptblock -ModuleName Microsoft.Entra.DirectoryManagement
+}
+
+Describe "Get-EntraDirSyncFeature - Input Validation Logging" {
+    Context "When an invalid Feature value is provided" {
+        It "Should produce a Write-Error for invalid Feature name" {
+            Get-EntraDirSyncFeature -Feature "NonExistentFeature" -ErrorAction SilentlyContinue -ErrorVariable testErr
+            $testErr | Should -Not -BeNullOrEmpty
+            "$testErr" | Should -BeLike "*Invalid value for parameter*"
+        }
+    }
+}
+
+Describe "Set-EntraDirSyncFeature - Input Validation Logging" {
+    Context "When an empty feature string is provided" {
+        It "Should throw for empty string in Features parameter" {
+            { Set-EntraDirSyncFeature -Features @("") -Enabled $true } | Should -Throw "*non-empty string*"
+        }
+
+        It "Should throw for whitespace-only string in Features parameter" {
+            { Set-EntraDirSyncFeature -Features @("  ") -Enabled $true } | Should -Throw "*non-empty string*"
+        }
+    }
+}

--- a/test/Entra/SignIns/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/SignIns/Write-EntraInputValidationLog.Tests.ps1
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------------------------
 
 BeforeAll {
-    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
-    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
-    Import-Module (Join-Path $binPath "Microsoft.Entra.SignIns.psd1") -Force
+    if ($null -eq (Get-Module -Name Microsoft.Entra.SignIns)) {
+        Import-Module Microsoft.Entra.SignIns
+    }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Policy.Read.All") } } -ModuleName Microsoft.Entra.SignIns

--- a/test/Entra/SignIns/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/SignIns/Write-EntraInputValidationLog.Tests.ps1
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {
+    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
+    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
+    Import-Module (Join-Path $binPath "Microsoft.Entra.SignIns.psd1") -Force
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("Policy.Read.All") } } -ModuleName Microsoft.Entra.SignIns
+    Mock -CommandName Out-File -ModuleName Microsoft.Entra.SignIns
+    Mock -CommandName Write-EventLog -ModuleName Microsoft.Entra.SignIns
+}
+
+Describe "Get-EntraPolicy - Input Validation Logging" {
+    Context "When an invalid Top value is provided" {
+        It "Should log validation failure for Top value of 0" {
+            Mock -CommandName Out-File -ModuleName Microsoft.Entra.SignIns
+            Get-EntraPolicy -Top 0 -ErrorAction SilentlyContinue
+            Should -Invoke -CommandName Out-File -ModuleName Microsoft.Entra.SignIns -Times 1
+        }
+    }
+}

--- a/test/Entra/Users/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/Users/Write-EntraInputValidationLog.Tests.ps1
@@ -1,0 +1,43 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+BeforeAll {
+    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
+    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
+    Import-Module (Join-Path $binPath "Microsoft.Entra.Users.psd1") -Force
+    Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
+
+    Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("User.Read.All") } } -ModuleName Microsoft.Entra.Users
+    Mock -CommandName Out-File -ModuleName Microsoft.Entra.Users
+    Mock -CommandName Write-EventLog -ModuleName Microsoft.Entra.Users
+
+    $userMock = {
+        return [PSCustomObject]@{
+            Id = "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+            DisplayName = "Test User"
+            UserPrincipalName = "testuser@contoso.com"
+            AdditionalProperties = @{
+                "extension_aaaaaaaa00001111_customProp" = "value1"
+            }
+        }
+    }
+    Mock -CommandName Invoke-GraphRequest -MockWith $userMock -ModuleName Microsoft.Entra.Users
+}
+
+Describe "Get-EntraUserExtension - Input Validation Logging" {
+    Context "When invalid properties are specified" {
+        It "Should produce an error for invalid property names" {
+            Mock -CommandName Invoke-GraphRequest -MockWith {
+                return [PSCustomObject]@{
+                    value = @(
+                        [PSCustomObject]@{ name = "extension_aaaa_prop1"; dataType = "String" }
+                    )
+                }
+            } -ModuleName Microsoft.Entra.Users
+            $result = Get-EntraUserExtension -UserId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -Property "nonExistentProp123" -ErrorAction SilentlyContinue -ErrorVariable testErr
+            $testErr | Should -Not -BeNullOrEmpty
+            "$testErr" | Should -BeLike "*Invalid property*"
+        }
+    }
+}

--- a/test/Entra/Users/Write-EntraInputValidationLog.Tests.ps1
+++ b/test/Entra/Users/Write-EntraInputValidationLog.Tests.ps1
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------------------------
 
 BeforeAll {
-    $binPath = Join-Path $PSScriptRoot "..\..\..\bin"
-    Import-Module (Join-Path $binPath "Microsoft.Entra.Authentication.psd1") -Force
-    Import-Module (Join-Path $binPath "Microsoft.Entra.Users.psd1") -Force
+    if ($null -eq (Get-Module -Name Microsoft.Entra.Users)) {
+        Import-Module Microsoft.Entra.Users
+    }
     Import-Module (Join-Path $PSScriptRoot "..\..\Common-Functions.ps1") -Force
 
     Mock -CommandName Get-EntraContext -MockWith { @{Scopes = @("User.Read.All") } } -ModuleName Microsoft.Entra.Users


### PR DESCRIPTION
## Summary

Adds persistent logging of input validation failures to satisfy compliance requirement.

## Problem

Validation failures were only displayed to the user via Write-Warning/Write-Error/throw without being persisted for security audit purposes.

## Solution

Created `Write-EntraInputValidationLog` function that:
- Writes structured log entries to `%LOCALAPPDATA%/Microsoft.Entra/Logs/InputValidation-{date}.log`
- On Windows: also writes to Windows Event Log (Application, source 'Microsoft.Entra', EventId 1001)
- On Linux/macOS: also writes to syslog via `logger` command
- Masks sensitive values (first 4 chars + \*\*\*\* for values >8 chars)
- Is non-fatal — logging failures never block cmdlet execution

## Changes

- **9 new files**: `Write-EntraInputValidationLog.ps1` in each submodule folder (5 Entra + 4 EntraBeta)
- **23 modified cmdlets**: Added logging calls at all validation failure points
- **5 test files**: 15 unit tests + 8 integration tests (23 total, all passing)

## Cross-platform

- Uses `[System.Environment]::UserName` on non-Windows (instead of WindowsIdentity)
- Syslog fallback on Linux/macOS instead of Windows Event Log
- File logging path uses `[Environment]::GetFolderPath('LocalApplicationData')` (works on all platforms)

## Testing

- Build: ✅ passes
- Tests: ✅ 23/23 pass
- No regressions in existing tests