### PR TITLE
Route pipeline module installs through CFS feed for network isolation

### DIFF
--- a/.azure-pipelines/1es-entra-powershell-ci-build.yml
+++ b/.azure-pipelines/1es-entra-powershell-ci-build.yml
@@ -55,6 +55,11 @@ extends:
           - template: .azure-pipelines/generation-templates/generate_adapter-1es.yml@self
             parameters:
               Sign: ${{ parameters.Sign }}
+              # 1ES network isolation (CFSClean/CFSClean2) blocks the public
+              # PowerShell Gallery. Install dependencies from the CFS feed instead.
+              DependencyRepository: 'EntraCFS'
+              # TODO: replace with the onboarded CFS feed v2 index URL (see https://aka.ms/cfs).
+              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/REPLACE_WITH_CFS_FEED/nuget/v2'
 
           - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
               - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self

--- a/.azure-pipelines/1es-entra-powershell-ci-build.yml
+++ b/.azure-pipelines/1es-entra-powershell-ci-build.yml
@@ -57,9 +57,9 @@ extends:
               Sign: ${{ parameters.Sign }}
               # 1ES network isolation (CFSClean/CFSClean2) blocks the public
               # PowerShell Gallery. Install dependencies from the CFS feed instead.
-              DependencyRepository: 'EntraCFS'
-              # TODO: replace with the onboarded CFS feed v2 index URL (see https://aka.ms/cfs).
-              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/REPLACE_WITH_CFS_FEED/nuget/v2'
+              DependencyRepository: 'ODataMsrcFeed'
+              # Org-scoped feed with the PowerShell Gallery configured as an upstream source.
+              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/_packaging/ODataMsrcFeed/nuget/v2'
 
           - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
               - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self

--- a/.azure-pipelines/1es-entra-powershell-ci-build.yml
+++ b/.azure-pipelines/1es-entra-powershell-ci-build.yml
@@ -57,9 +57,9 @@ extends:
               Sign: ${{ parameters.Sign }}
               # 1ES network isolation (CFSClean/CFSClean2) blocks the public
               # PowerShell Gallery. Install dependencies from the CFS feed instead.
-              DependencyRepository: 'ODataMsrcFeed'
+              DependencyRepository: 'EntraPowerShellFeed'
               # Org-scoped feed with the PowerShell Gallery configured as an upstream source.
-              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/_packaging/ODataMsrcFeed/nuget/v2'
+              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/EntraPowerShellFeed/nuget/v2'
 
           - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
               - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self

--- a/.azure-pipelines/1es-entra-powershell-pr.yml
+++ b/.azure-pipelines/1es-entra-powershell-pr.yml
@@ -49,7 +49,7 @@ extends:
               Sign: false
               # 1ES network isolation (CFSClean/CFSClean2) blocks the public
               # PowerShell Gallery. Install dependencies from the CFS feed instead.
-              DependencyRepository: 'ODataMsrcFeed'
+              DependencyRepository: 'EntraPowerShellFeed'
               # Org-scoped feed with the PowerShell Gallery configured as an upstream source.
-              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/_packaging/ODataMsrcFeed/nuget/v2'
+              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/EntraPowerShellFeed/nuget/v2'
               

--- a/.azure-pipelines/1es-entra-powershell-pr.yml
+++ b/.azure-pipelines/1es-entra-powershell-pr.yml
@@ -47,4 +47,9 @@ extends:
           - template: .azure-pipelines/generation-templates/generate_adapter-1es.yml@self
             parameters:
               Sign: false
+              # 1ES network isolation (CFSClean/CFSClean2) blocks the public
+              # PowerShell Gallery. Install dependencies from the CFS feed instead.
+              DependencyRepository: 'EntraCFS'
+              # TODO: replace with the onboarded CFS feed v2 index URL (see https://aka.ms/cfs).
+              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/REPLACE_WITH_CFS_FEED/nuget/v2'
               

--- a/.azure-pipelines/1es-entra-powershell-pr.yml
+++ b/.azure-pipelines/1es-entra-powershell-pr.yml
@@ -49,7 +49,7 @@ extends:
               Sign: false
               # 1ES network isolation (CFSClean/CFSClean2) blocks the public
               # PowerShell Gallery. Install dependencies from the CFS feed instead.
-              DependencyRepository: 'EntraCFS'
-              # TODO: replace with the onboarded CFS feed v2 index URL (see https://aka.ms/cfs).
-              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/REPLACE_WITH_CFS_FEED/nuget/v2'
+              DependencyRepository: 'ODataMsrcFeed'
+              # Org-scoped feed with the PowerShell Gallery configured as an upstream source.
+              CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/_packaging/ODataMsrcFeed/nuget/v2'
               

--- a/.azure-pipelines/generation-templates/generate_adapter-1es.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter-1es.yml
@@ -9,8 +9,21 @@ parameters:
   - name: Integration
     type: boolean
     default: false
+  # Name of the PowerShell repository build/test dependencies are installed from.
+  # Defaults to the public PowerShell Gallery; 1ES pipelines pass a CFS-backed
+  # feed to satisfy network-isolation (CFSClean) policies.
+  - name: DependencyRepository
+    type: string
+    default: 'PSGallery'
+  # v2 index URL of the CFS feed backing DependencyRepository.
+  - name: CfsFeedUrl
+    type: string
+    default: ''
 
 steps:
+- ${{ if ne(parameters.CfsFeedUrl, '') }}:
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to CFS feed'
 - task: powershell@2
   displayName: 'Show current PowerShell version information'
   inputs:
@@ -30,12 +43,20 @@ steps:
     script: |
       ./build/Install-Dependencies.ps1 -ModuleName Entra -Verbose      
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Install PlatyPS'
   inputs:
     targetType: inline
-    script: Install-Module PlatyPS -scope currentuser -Force
+    script: ./build/Install-GalleryModule.ps1 -Name PlatyPS
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build Entra'
   inputs:
@@ -102,6 +123,10 @@ steps:
     script: |      
       ./build/Install-Dependencies.ps1 -ModuleName EntraBeta -Verbose
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build EntraBeta'
   inputs:
@@ -157,8 +182,12 @@ steps:
   displayName: 'Install Pester'
   inputs:
     targetType: inline
-    script: Install-Module Pester -scope currentuser -SkipPublisherCheck -Force
+    script: ./build/Install-GalleryModule.ps1 -Name Pester -SkipPublisherCheck
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Run tests Entra'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter-1es.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter-1es.yml
@@ -21,11 +21,10 @@ parameters:
     default: ''
 
 steps:
-# Required for installing dependencies from the private CFS feed: PowerShellGet
-# does not propagate -Credential to transitive dependency installs, so those
-# requests fall back to the Azure Artifacts credential provider, which needs the
-# token this task provides. Without it, dependencies (e.g. Microsoft.Graph.Authentication)
-# fail to install.
+# Authenticate to the private CFS feed. PowerShellGet uses the Azure Artifacts
+# credential provider to authenticate every request to the feed - including
+# transitive dependency installs (e.g. Microsoft.Graph.Authentication) - so this
+# token setup is required for dependencies to resolve.
 - ${{ if ne(parameters.CfsFeedUrl, '') }}:
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate to CFS feed'
@@ -51,7 +50,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Install PlatyPS'
   inputs:
@@ -61,7 +59,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build Entra'
   inputs:
@@ -131,7 +128,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build EntraBeta'
   inputs:
@@ -192,7 +188,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Run tests Entra'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter-1es.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter-1es.yml
@@ -21,10 +21,10 @@ parameters:
     default: ''
 
 steps:
-# Authenticate to the private CFS feed. PowerShellGet uses the Azure Artifacts
-# credential provider to authenticate every request to the feed - including
-# transitive dependency installs (e.g. Microsoft.Graph.Authentication) - so this
-# token setup is required for dependencies to resolve.
+# Sets up the Azure Artifacts credential provider. Required so that transitive
+# dependency installs (e.g. Microsoft.Graph.Authentication) authenticate to the
+# private CFS feed: PowerShellGet does not propagate -Credential to transitive
+# dependencies, so those requests rely on the credential provider instead.
 - ${{ if ne(parameters.CfsFeedUrl, '') }}:
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate to CFS feed'
@@ -50,6 +50,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Install PlatyPS'
   inputs:
@@ -59,6 +60,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build Entra'
   inputs:
@@ -128,6 +130,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build EntraBeta'
   inputs:
@@ -188,6 +191,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Run tests Entra'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter-1es.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter-1es.yml
@@ -21,6 +21,14 @@ parameters:
     default: ''
 
 steps:
+# Required for installing dependencies from the private CFS feed: PowerShellGet
+# does not propagate -Credential to transitive dependency installs, so those
+# requests fall back to the Azure Artifacts credential provider, which needs the
+# token this task provides. Without it, dependencies (e.g. Microsoft.Graph.Authentication)
+# fail to install.
+- ${{ if ne(parameters.CfsFeedUrl, '') }}:
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to CFS feed'
 - task: powershell@2
   displayName: 'Show current PowerShell version information'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter-1es.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter-1es.yml
@@ -186,7 +186,7 @@ steps:
   displayName: 'Install Pester'
   inputs:
     targetType: inline
-    script: ./build/Install-GalleryModule.ps1 -Name Pester -SkipPublisherCheck
+    script: ./build/Install-GalleryModule.ps1 -Name Pester -MaximumVersion 5.99.99 -SkipPublisherCheck
     pwsh: true
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}

--- a/.azure-pipelines/generation-templates/generate_adapter-1es.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter-1es.yml
@@ -21,9 +21,6 @@ parameters:
     default: ''
 
 steps:
-- ${{ if ne(parameters.CfsFeedUrl, '') }}:
-  - task: NuGetAuthenticate@1
-    displayName: 'Authenticate to CFS feed'
 - task: powershell@2
   displayName: 'Show current PowerShell version information'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter.yml
@@ -21,10 +21,10 @@ parameters:
     default: ''
 
 steps:
-# Authenticate to the private CFS feed. PowerShellGet uses the Azure Artifacts
-# credential provider to authenticate every request to the feed - including
-# transitive dependency installs (e.g. Microsoft.Graph.Authentication) - so this
-# token setup is required for dependencies to resolve.
+# Sets up the Azure Artifacts credential provider. Required so that transitive
+# dependency installs (e.g. Microsoft.Graph.Authentication) authenticate to the
+# private CFS feed: PowerShellGet does not propagate -Credential to transitive
+# dependencies, so those requests rely on the credential provider instead.
 - ${{ if ne(parameters.CfsFeedUrl, '') }}:
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate to CFS feed'
@@ -50,6 +50,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Install PlatyPS'
   inputs:
@@ -59,6 +60,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build Entra'
   inputs:
@@ -132,6 +134,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build EntraBeta'
   inputs:
@@ -196,6 +199,7 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Run tests Entra'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter.yml
@@ -9,8 +9,21 @@ parameters:
   - name: Integration
     type: boolean
     default: false
+  # Name of the PowerShell repository build/test dependencies are installed from.
+  # Defaults to the public PowerShell Gallery; pipelines pass a CFS-backed feed
+  # to satisfy network-isolation (CFSClean) policies.
+  - name: DependencyRepository
+    type: string
+    default: 'PSGallery'
+  # v2 index URL of the CFS feed backing DependencyRepository.
+  - name: CfsFeedUrl
+    type: string
+    default: ''
 
 steps:
+- ${{ if ne(parameters.CfsFeedUrl, '') }}:
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to CFS feed'
 - task: powershell@2
   displayName: 'Show current PowerShell version information'
   inputs:
@@ -30,12 +43,20 @@ steps:
     script: |
       ./build/Install-Dependencies.ps1 -ModuleName Entra -Verbose      
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Install PlatyPS'
   inputs:
     targetType: inline
-    script: Install-Module PlatyPS -scope currentuser -Force
+    script: ./build/Install-GalleryModule.ps1 -Name PlatyPS
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build Entra'
   inputs:
@@ -106,6 +127,10 @@ steps:
     script: |      
       ./build/Install-Dependencies.ps1 -ModuleName EntraBeta -Verbose
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build EntraBeta'
   inputs:
@@ -165,8 +190,12 @@ steps:
   displayName: 'Install Pester'
   inputs:
     targetType: inline
-    script: Install-Module Pester -scope currentuser -SkipPublisherCheck -Force
+    script: ./build/Install-GalleryModule.ps1 -Name Pester -SkipPublisherCheck
     pwsh: true
+  env:
+    DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
+    DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Run tests Entra'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter.yml
@@ -21,11 +21,10 @@ parameters:
     default: ''
 
 steps:
-# Required for installing dependencies from the private CFS feed: PowerShellGet
-# does not propagate -Credential to transitive dependency installs, so those
-# requests fall back to the Azure Artifacts credential provider, which needs the
-# token this task provides. Without it, dependencies (e.g. Microsoft.Graph.Authentication)
-# fail to install.
+# Authenticate to the private CFS feed. PowerShellGet uses the Azure Artifacts
+# credential provider to authenticate every request to the feed - including
+# transitive dependency installs (e.g. Microsoft.Graph.Authentication) - so this
+# token setup is required for dependencies to resolve.
 - ${{ if ne(parameters.CfsFeedUrl, '') }}:
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate to CFS feed'
@@ -51,7 +50,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Install PlatyPS'
   inputs:
@@ -61,7 +59,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build Entra'
   inputs:
@@ -135,7 +132,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Build EntraBeta'
   inputs:
@@ -200,7 +196,6 @@ steps:
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}
     DEPENDENCY_PS_FEED_URL: ${{ parameters.CfsFeedUrl }}
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 - task: powershell@2
   displayName: 'Run tests Entra'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter.yml
@@ -194,7 +194,7 @@ steps:
   displayName: 'Install Pester'
   inputs:
     targetType: inline
-    script: ./build/Install-GalleryModule.ps1 -Name Pester -SkipPublisherCheck
+    script: ./build/Install-GalleryModule.ps1 -Name Pester -MaximumVersion 5.99.99 -SkipPublisherCheck
     pwsh: true
   env:
     DEPENDENCY_PS_REPO: ${{ parameters.DependencyRepository }}

--- a/.azure-pipelines/generation-templates/generate_adapter.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter.yml
@@ -21,6 +21,14 @@ parameters:
     default: ''
 
 steps:
+# Required for installing dependencies from the private CFS feed: PowerShellGet
+# does not propagate -Credential to transitive dependency installs, so those
+# requests fall back to the Azure Artifacts credential provider, which needs the
+# token this task provides. Without it, dependencies (e.g. Microsoft.Graph.Authentication)
+# fail to install.
+- ${{ if ne(parameters.CfsFeedUrl, '') }}:
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to CFS feed'
 - task: powershell@2
   displayName: 'Show current PowerShell version information'
   inputs:

--- a/.azure-pipelines/generation-templates/generate_adapter.yml
+++ b/.azure-pipelines/generation-templates/generate_adapter.yml
@@ -21,9 +21,6 @@ parameters:
     default: ''
 
 steps:
-- ${{ if ne(parameters.CfsFeedUrl, '') }}:
-  - task: NuGetAuthenticate@1
-    displayName: 'Authenticate to CFS feed'
 - task: powershell@2
   displayName: 'Show current PowerShell version information'
   inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -29,6 +29,6 @@ stages:
           Sign: false
           # Install dependencies from the CFS feed to stay consistent with the
           # 1ES CI/PR pipelines (CFSClean/CFSClean2 network-isolation policies).
-          DependencyRepository: 'ODataMsrcFeed'
+          DependencyRepository: 'EntraPowerShellFeed'
           # Org-scoped feed with the PowerShell Gallery configured as an upstream source.
-          CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/_packaging/ODataMsrcFeed/nuget/v2'
+          CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/EntraPowerShellFeed/nuget/v2'

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -27,3 +27,8 @@ stages:
         parameters:
           Integration: true
           Sign: false
+          # Install dependencies from the CFS feed to stay consistent with the
+          # 1ES CI/PR pipelines (CFSClean/CFSClean2 network-isolation policies).
+          DependencyRepository: 'EntraCFS'
+          # TODO: replace with the onboarded CFS feed v2 index URL (see https://aka.ms/cfs).
+          CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/REPLACE_WITH_CFS_FEED/nuget/v2'

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -29,6 +29,6 @@ stages:
           Sign: false
           # Install dependencies from the CFS feed to stay consistent with the
           # 1ES CI/PR pipelines (CFSClean/CFSClean2 network-isolation policies).
-          DependencyRepository: 'EntraCFS'
-          # TODO: replace with the onboarded CFS feed v2 index URL (see https://aka.ms/cfs).
-          CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/One/_packaging/REPLACE_WITH_CFS_FEED/nuget/v2'
+          DependencyRepository: 'ODataMsrcFeed'
+          # Org-scoped feed with the PowerShell Gallery configured as an upstream source.
+          CfsFeedUrl: 'https://pkgs.dev.azure.com/msazure/_packaging/ODataMsrcFeed/nuget/v2'

--- a/build/Install-Dependencies.ps1
+++ b/build/Install-Dependencies.ps1
@@ -10,7 +10,14 @@ param(
 
 	[ValidateScript({ Test-Path $_ })]
 	[string]
-    $ModuleSettingsPath
+    $ModuleSettingsPath,
+
+	# PowerShell repository to install dependencies from. Defaults to the public
+	# PowerShell Gallery for local development. CI pipelines running under 1ES
+	# network isolation set DEPENDENCY_PS_REPO to a CFS-backed feed to satisfy the
+	# CFSClean/CFSClean2 policies. See build/Install-GalleryModule.ps1.
+	[string]
+	$Repository = $(if ($env:DEPENDENCY_PS_REPO) { $env:DEPENDENCY_PS_REPO } else { 'PSGallery' })
 )
 
 . "$psscriptroot/common-functions.ps1"
@@ -26,5 +33,5 @@ Write-Verbose("Skipping deprecated source module '$($content.sourceModule)' - no
 
 foreach ($moduleName in $content.destinationModuleName){
     Write-Verbose("Installing Module $($moduleName)")
-    Install-Module $moduleName -scope currentuser -RequiredVersion $content.destinationModuleVersion -Force -AllowClobber
+    & "$PSScriptRoot/Install-GalleryModule.ps1" -Name $moduleName -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber -Verbose:($VerbosePreference -eq 'Continue')
 }

--- a/build/Install-Dependencies.ps1
+++ b/build/Install-Dependencies.ps1
@@ -31,6 +31,16 @@ $content = Get-Content -Path $settingPath | ConvertFrom-Json
 # Command lists are now derived from the static mapping files instead.
 Write-Verbose("Skipping deprecated source module '$($content.sourceModule)' - no longer available on PowerShell Gallery")
 
+# Microsoft.Graph.Authentication is a direct build requirement, not just an
+# incidental transitive dependency: Publish-LocalCompatModule.ps1 publishes this
+# exact version to the local gallery when building the compatibility module. The
+# Graph SDK modules below only pull it in transitively, and transitive installs
+# are not reliably satisfied under network isolation (they bypass -Credential and
+# depend on feed/credential-provider state). Install it explicitly, first, so the
+# required version is guaranteed to be present.
+Write-Verbose("Installing Module Microsoft.Graph.Authentication")
+& "$PSScriptRoot/Install-GalleryModule.ps1" -Name 'Microsoft.Graph.Authentication' -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber
+
 foreach ($moduleName in $content.destinationModuleName){
     Write-Verbose("Installing Module $($moduleName)")
     & "$PSScriptRoot/Install-GalleryModule.ps1" -Name $moduleName -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber

--- a/build/Install-Dependencies.ps1
+++ b/build/Install-Dependencies.ps1
@@ -31,13 +31,6 @@ $content = Get-Content -Path $settingPath | ConvertFrom-Json
 # Command lists are now derived from the static mapping files instead.
 Write-Verbose("Skipping deprecated source module '$($content.sourceModule)' - no longer available on PowerShell Gallery")
 
-# Microsoft.Graph.Authentication is the shared transitive dependency of every
-# Microsoft.Graph.* submodule (pinned to the same version). Install it explicitly
-# first so the submodule installs below find it already satisfied: PowerShellGet
-# does not propagate credentials to transitive dependency installs from a private
-# (CFS) feed, which would otherwise leave this module missing at publish time.
-& "$PSScriptRoot/Install-GalleryModule.ps1" -Name 'Microsoft.Graph.Authentication' -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber
-
 foreach ($moduleName in $content.destinationModuleName){
     Write-Verbose("Installing Module $($moduleName)")
     & "$PSScriptRoot/Install-GalleryModule.ps1" -Name $moduleName -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber

--- a/build/Install-Dependencies.ps1
+++ b/build/Install-Dependencies.ps1
@@ -31,6 +31,13 @@ $content = Get-Content -Path $settingPath | ConvertFrom-Json
 # Command lists are now derived from the static mapping files instead.
 Write-Verbose("Skipping deprecated source module '$($content.sourceModule)' - no longer available on PowerShell Gallery")
 
+# Microsoft.Graph.Authentication is the shared transitive dependency of every
+# Microsoft.Graph.* submodule (pinned to the same version). Install it explicitly
+# first so the submodule installs below find it already satisfied: PowerShellGet
+# does not propagate credentials to transitive dependency installs from a private
+# (CFS) feed, which would otherwise leave this module missing at publish time.
+& "$PSScriptRoot/Install-GalleryModule.ps1" -Name 'Microsoft.Graph.Authentication' -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber
+
 foreach ($moduleName in $content.destinationModuleName){
     Write-Verbose("Installing Module $($moduleName)")
     & "$PSScriptRoot/Install-GalleryModule.ps1" -Name $moduleName -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber

--- a/build/Install-Dependencies.ps1
+++ b/build/Install-Dependencies.ps1
@@ -33,5 +33,5 @@ Write-Verbose("Skipping deprecated source module '$($content.sourceModule)' - no
 
 foreach ($moduleName in $content.destinationModuleName){
     Write-Verbose("Installing Module $($moduleName)")
-    & "$PSScriptRoot/Install-GalleryModule.ps1" -Name $moduleName -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber -Verbose:($VerbosePreference -eq 'Continue')
+    & "$PSScriptRoot/Install-GalleryModule.ps1" -Name $moduleName -RequiredVersion $content.destinationModuleVersion -Repository $Repository -AllowClobber
 }

--- a/build/Install-GalleryModule.ps1
+++ b/build/Install-GalleryModule.ps1
@@ -1,0 +1,119 @@
+# ------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
+<#
+.SYNOPSIS
+    Installs PowerShell modules used by the build, routing the download through a
+    CFS (Centralized Feed Service) feed when one is configured.
+
+.DESCRIPTION
+    The 1ES CI/PR pipelines run under network isolation. The CFSClean/CFSClean2
+    policies block access to the public PowerShell Gallery (powershellgallery.com)
+    and require every package to be restored from a CFS-backed Azure Artifacts
+    feed instead. See build/BUILD.md and https://aka.ms/1es/netiso/pipelinetemplates.
+
+    This helper is the single place where build/test dependencies are installed so
+    that the CFS wiring lives in one location:
+
+      * Local development uses the public PowerShell Gallery (the default), so no
+        extra configuration is required.
+      * CI pipelines set the DEPENDENCY_PS_REPO and DEPENDENCY_PS_FEED_URL
+        environment variables (and expose SYSTEM_ACCESSTOKEN) so the same modules
+        are restored from the CFS feed.
+
+    If a non-PSGallery repository is requested but no feed URL has been supplied
+    (for example while the CFS feed URL is still a placeholder in a draft PR), the
+    helper warns and falls back to the public PowerShell Gallery instead of
+    failing the build.
+
+.PARAMETER Name
+    One or more module names to install.
+
+.PARAMETER RequiredVersion
+    Optional exact version to install.
+
+.PARAMETER Repository
+    Name of the PowerShell repository to install from. Defaults to the value of
+    the DEPENDENCY_PS_REPO environment variable, or 'PSGallery' when it is unset.
+
+.PARAMETER FeedUrl
+    The v2 index URL of the CFS feed backing -Repository. Defaults to the
+    DEPENDENCY_PS_FEED_URL environment variable. Only used when -Repository is not
+    'PSGallery'.
+
+.PARAMETER Token
+    Access token used to authenticate to the CFS feed. Defaults to the
+    SYSTEM_ACCESSTOKEN environment variable (mapped from $(System.AccessToken) in
+    the pipeline).
+#>
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The pipeline access token is only available as plain text and must be converted to a SecureString to build a PSCredential for the CFS feed.')]
+param(
+    [Parameter(Mandatory)]
+    [string[]] $Name,
+
+    [string] $RequiredVersion,
+
+    [string] $Repository = $(if ($env:DEPENDENCY_PS_REPO) { $env:DEPENDENCY_PS_REPO } else { 'PSGallery' }),
+
+    [string] $FeedUrl = $env:DEPENDENCY_PS_FEED_URL,
+
+    [string] $Token = $env:SYSTEM_ACCESSTOKEN,
+
+    [switch] $SkipPublisherCheck,
+
+    [switch] $AllowClobber
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Treat a not-yet-onboarded placeholder feed URL as "no feed configured".
+$feedIsPlaceholder = [string]::IsNullOrWhiteSpace($FeedUrl) -or $FeedUrl -match 'REPLACE_WITH|<.*>'
+
+if ($Repository -ne 'PSGallery' -and $feedIsPlaceholder) {
+    Write-Warning "Repository '$Repository' was requested but no CFS feed URL is configured (DEPENDENCY_PS_FEED_URL). Falling back to the public PowerShell Gallery. Set the CFS feed URL to satisfy 1ES network-isolation (CFSClean) policies."
+    $Repository = 'PSGallery'
+}
+
+$credential = $null
+
+if ($Repository -ne 'PSGallery') {
+    if ($Token) {
+        $securePat = ConvertTo-SecureString $Token -AsPlainText -Force
+        $credential = [System.Management.Automation.PSCredential]::new('cfs', $securePat)
+    }
+    else {
+        Write-Warning "No access token available (SYSTEM_ACCESSTOKEN); authentication to '$Repository' may fail."
+    }
+
+    # Register the CFS feed for PowerShellGet (idempotent - registration persists
+    # across pipeline steps, but the credential does not, so it is always supplied
+    # again at install time below).
+    if (-not (Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue)) {
+        Write-Verbose "Registering PSRepository '$Repository' -> $FeedUrl"
+        $register = @{
+            Name               = $Repository
+            SourceLocation     = $FeedUrl
+            InstallationPolicy = 'Trusted'
+        }
+        if ($credential) { $register['Credential'] = $credential }
+        Register-PSRepository @register
+    }
+}
+
+foreach ($module in $Name) {
+    Write-Verbose "Installing module '$module' from repository '$Repository'"
+    $install = @{
+        Name       = $module
+        Repository = $Repository
+        Scope      = 'CurrentUser'
+        Force      = $true
+    }
+    if ($RequiredVersion)    { $install['RequiredVersion']    = $RequiredVersion }
+    if ($SkipPublisherCheck) { $install['SkipPublisherCheck'] = $true }
+    if ($AllowClobber)       { $install['AllowClobber']       = $true }
+    if ($credential)         { $install['Credential']         = $credential }
+
+    Install-Module @install
+}

--- a/build/Install-GalleryModule.ps1
+++ b/build/Install-GalleryModule.ps1
@@ -4,48 +4,14 @@
 
 <#
 .SYNOPSIS
-    Installs PowerShell modules used by the build, routing the download through a
-    CFS (Centralized Feed Service) feed when one is configured.
+    Installs build/test dependencies, from a private feed when one is configured.
 
 .DESCRIPTION
-    The 1ES CI/PR pipelines run under network isolation. The CFSClean/CFSClean2
-    policies block access to the public PowerShell Gallery (powershellgallery.com)
-    and require every package to be restored from a CFS-backed Azure Artifacts
-    feed instead. See build/BUILD.md and https://aka.ms/1es/netiso/pipelinetemplates.
-
-    This helper is the single place where build/test dependencies are installed so
-    that the CFS wiring lives in one location:
-
-      * Local development uses the public PowerShell Gallery (the default), so no
-        extra configuration is required.
-      * CI pipelines set the DEPENDENCY_PS_REPO and DEPENDENCY_PS_FEED_URL
-        environment variables (and expose SYSTEM_ACCESSTOKEN) so the same modules
-        are restored from the CFS feed.
-
-    If a non-PSGallery repository is requested but no feed URL has been supplied
-    (for example while the CFS feed URL is still a placeholder in a draft PR), the
-    helper warns and falls back to the public PowerShell Gallery instead of
-    failing the build.
-
-.PARAMETER Name
-    One or more module names to install.
-
-.PARAMETER RequiredVersion
-    Optional exact version to install.
-
-.PARAMETER Repository
-    Name of the PowerShell repository to install from. Defaults to the value of
-    the DEPENDENCY_PS_REPO environment variable, or 'PSGallery' when it is unset.
-
-.PARAMETER FeedUrl
-    The v2 index URL of the CFS feed backing -Repository. Defaults to the
-    DEPENDENCY_PS_FEED_URL environment variable. Only used when -Repository is not
-    'PSGallery'.
-
-.PARAMETER Token
-    Access token used to authenticate to the CFS feed. Defaults to the
-    SYSTEM_ACCESSTOKEN environment variable (mapped from $(System.AccessToken) in
-    the pipeline).
+    The 1ES CI/PR pipelines run under network isolation (CFSClean/CFSClean2), which
+    blocks the public PowerShell Gallery. Pipelines set DEPENDENCY_PS_REPO and
+    DEPENDENCY_PS_FEED_URL (and expose SYSTEM_ACCESSTOKEN) so modules are restored
+    from that feed; local development uses the public PowerShell Gallery by default.
+    See https://aka.ms/1es/netiso/pipelinetemplates.
 #>
 [CmdletBinding()]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The pipeline access token is only available as plain text and must be converted to a SecureString to build a PSCredential for the CFS feed.')]
@@ -68,28 +34,21 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Treat a not-yet-onboarded placeholder feed URL as "no feed configured".
-$feedIsPlaceholder = [string]::IsNullOrWhiteSpace($FeedUrl) -or $FeedUrl -match 'REPLACE_WITH|<.*>'
-
-if ($Repository -ne 'PSGallery' -and $feedIsPlaceholder) {
-    Write-Warning "Repository '$Repository' was requested but no CFS feed URL is configured (DEPENDENCY_PS_FEED_URL). Falling back to the public PowerShell Gallery. Set the CFS feed URL to satisfy 1ES network-isolation (CFSClean) policies."
-    $Repository = 'PSGallery'
-}
-
 $credential = $null
 
 if ($Repository -ne 'PSGallery') {
+    if (-not $FeedUrl) {
+        throw "Repository '$Repository' requires a feed URL. Set DEPENDENCY_PS_FEED_URL (or pass -FeedUrl)."
+    }
+
     if ($Token) {
         $securePat = ConvertTo-SecureString $Token -AsPlainText -Force
         $credential = [System.Management.Automation.PSCredential]::new('cfs', $securePat)
     }
-    else {
-        Write-Warning "No access token available (SYSTEM_ACCESSTOKEN); authentication to '$Repository' may fail."
-    }
 
-    # Register the CFS feed for PowerShellGet (idempotent - registration persists
-    # across pipeline steps, but the credential does not, so it is always supplied
-    # again at install time below).
+    # Registration persists across pipeline steps but the credential does not, so
+    # the feed is registered once here and the credential is supplied again at
+    # install time below.
     if (-not (Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue)) {
         Write-Verbose "Registering PSRepository '$Repository' -> $FeedUrl"
         $register = @{

--- a/build/Install-GalleryModule.ps1
+++ b/build/Install-GalleryModule.ps1
@@ -8,13 +8,13 @@
 
 .DESCRIPTION
     The 1ES CI/PR pipelines run under network isolation (CFSClean/CFSClean2), which
-    blocks the public PowerShell Gallery. Pipelines set DEPENDENCY_PS_REPO and
-    DEPENDENCY_PS_FEED_URL (and expose SYSTEM_ACCESSTOKEN) so modules are restored
-    from that feed; local development uses the public PowerShell Gallery by default.
-    See https://aka.ms/1es/netiso/pipelinetemplates.
+    blocks the public PowerShell Gallery. Those pipelines run NuGetAuthenticate and
+    set DEPENDENCY_PS_REPO / DEPENDENCY_PS_FEED_URL so modules (and their transitive
+    dependencies) are restored from that feed; the Azure Artifacts credential
+    provider handles authentication. Local development uses the public PowerShell
+    Gallery by default. See https://aka.ms/1es/netiso/pipelinetemplates.
 #>
 [CmdletBinding()]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The pipeline access token is only available as plain text and must be converted to a SecureString to build a PSCredential for the CFS feed.')]
 param(
     [Parameter(Mandatory)]
     [string[]] $Name,
@@ -25,8 +25,6 @@ param(
 
     [string] $FeedUrl = $env:DEPENDENCY_PS_FEED_URL,
 
-    [string] $Token = $env:SYSTEM_ACCESSTOKEN,
-
     [switch] $SkipPublisherCheck,
 
     [switch] $AllowClobber
@@ -34,30 +32,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$credential = $null
-
 if ($Repository -ne 'PSGallery') {
     if (-not $FeedUrl) {
         throw "Repository '$Repository' requires a feed URL. Set DEPENDENCY_PS_FEED_URL (or pass -FeedUrl)."
     }
 
-    if ($Token) {
-        $securePat = ConvertTo-SecureString $Token -AsPlainText -Force
-        $credential = [System.Management.Automation.PSCredential]::new('cfs', $securePat)
-    }
-
-    # Registration persists across pipeline steps but the credential does not, so
-    # the feed is registered once here and the credential is supplied again at
-    # install time below.
     if (-not (Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue)) {
         Write-Verbose "Registering PSRepository '$Repository' -> $FeedUrl"
-        $register = @{
-            Name               = $Repository
-            SourceLocation     = $FeedUrl
-            InstallationPolicy = 'Trusted'
-        }
-        if ($credential) { $register['Credential'] = $credential }
-        Register-PSRepository @register
+        Register-PSRepository -Name $Repository -SourceLocation $FeedUrl -InstallationPolicy Trusted
     }
 }
 
@@ -72,7 +54,6 @@ foreach ($module in $Name) {
     if ($RequiredVersion)    { $install['RequiredVersion']    = $RequiredVersion }
     if ($SkipPublisherCheck) { $install['SkipPublisherCheck'] = $true }
     if ($AllowClobber)       { $install['AllowClobber']       = $true }
-    if ($credential)         { $install['Credential']         = $credential }
 
     Install-Module @install
 }

--- a/build/Install-GalleryModule.ps1
+++ b/build/Install-GalleryModule.ps1
@@ -8,12 +8,21 @@
 
 .DESCRIPTION
     The 1ES CI/PR pipelines run under network isolation (CFSClean/CFSClean2), which
-    blocks the public PowerShell Gallery. Those pipelines run NuGetAuthenticate and
-    set DEPENDENCY_PS_REPO / DEPENDENCY_PS_FEED_URL so modules (and their transitive
-    dependencies) are restored from that feed; the Azure Artifacts credential
-    provider handles authentication. Local development uses the public PowerShell
-    Gallery by default. See https://aka.ms/1es/netiso/pipelinetemplates.
+    blocks the public PowerShell Gallery, so modules are restored from a CFS-backed
+    Azure Artifacts feed instead. Authenticating to that feed requires BOTH:
+
+      * -Credential (built from SYSTEM_ACCESSTOKEN): PowerShellGet uses this to
+        authenticate its own requests for the requested (top-level) modules.
+      * The Azure Artifacts credential provider (set up by the pipeline's
+        NuGetAuthenticate task): PowerShellGet does NOT propagate -Credential to
+        transitive dependency installs, so those requests authenticate through the
+        credential provider instead.
+
+    Local development uses the public PowerShell Gallery by default (no feed, no
+    token). See https://aka.ms/1es/netiso/pipelinetemplates.
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'The pipeline access token is only available as plain text (SYSTEM_ACCESSTOKEN) and must be wrapped in a PSCredential to authenticate to the private feed.')]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
@@ -25,6 +34,8 @@ param(
 
     [string] $FeedUrl = $env:DEPENDENCY_PS_FEED_URL,
 
+    [string] $Token = $env:SYSTEM_ACCESSTOKEN,
+
     [switch] $SkipPublisherCheck,
 
     [switch] $AllowClobber
@@ -32,14 +43,21 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+$credential = $null
 if ($Repository -ne 'PSGallery') {
     if (-not $FeedUrl) {
         throw "Repository '$Repository' requires a feed URL. Set DEPENDENCY_PS_FEED_URL (or pass -FeedUrl)."
     }
+    if (-not $Token) {
+        throw "Repository '$Repository' requires an access token. Set SYSTEM_ACCESSTOKEN (or pass -Token)."
+    }
+
+    $securePassword = ConvertTo-SecureString $Token -AsPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential('AzureDevOps', $securePassword)
 
     if (-not (Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue)) {
         Write-Verbose "Registering PSRepository '$Repository' -> $FeedUrl"
-        Register-PSRepository -Name $Repository -SourceLocation $FeedUrl -InstallationPolicy Trusted
+        Register-PSRepository -Name $Repository -SourceLocation $FeedUrl -InstallationPolicy Trusted -Credential $credential
     }
 }
 
@@ -54,6 +72,7 @@ foreach ($module in $Name) {
     if ($RequiredVersion)    { $install['RequiredVersion']    = $RequiredVersion }
     if ($SkipPublisherCheck) { $install['SkipPublisherCheck'] = $true }
     if ($AllowClobber)       { $install['AllowClobber']       = $true }
+    if ($credential)         { $install['Credential']         = $credential }
 
     Install-Module @install
 }

--- a/build/Install-GalleryModule.ps1
+++ b/build/Install-GalleryModule.ps1
@@ -30,6 +30,8 @@ param(
 
     [string] $RequiredVersion,
 
+    [string] $MaximumVersion,
+
     [string] $Repository = $(if ($env:DEPENDENCY_PS_REPO) { $env:DEPENDENCY_PS_REPO } else { 'PSGallery' }),
 
     [string] $FeedUrl = $env:DEPENDENCY_PS_FEED_URL,
@@ -70,6 +72,7 @@ foreach ($module in $Name) {
         Force      = $true
     }
     if ($RequiredVersion)    { $install['RequiredVersion']    = $RequiredVersion }
+    if ($MaximumVersion)     { $install['MaximumVersion']     = $MaximumVersion }
     if ($SkipPublisherCheck) { $install['SkipPublisherCheck'] = $true }
     if ($AllowClobber)       { $install['AllowClobber']       = $true }
     if ($credential)         { $install['Credential']         = $credential }


### PR DESCRIPTION
## Summary

The 1ES CI/PR pipelines run under network isolation (SFI **CFS** policies). The `Install-Module` steps were reaching the **public PowerShell Gallery**, which the `CFSClean2` policy flags as a supply-chain violation. This PR routes all pipeline PowerShell module installs through an Azure Artifacts feed (which mirrors PowerShell Gallery server-side), so the isolated build no longer contacts public package sources directly. Local development is unchanged and still uses the public PowerShell Gallery by default.

## Root causes addressed

1. **CFS network isolation** — pipeline installs hit `www.powershellgallery.com` / `cdn.powershellgallery.com` (originally **204** violations). Now routed through the feed.
2. **Feed authentication** — a private feed needs both auth paths together:
   - `NuGetAuthenticate@1` (Azure Artifacts credential provider) for **transitive** dependency installs.
   - `-Credential` (from `SYSTEM_ACCESSTOKEN`) for the **top-level** module requests PowerShellGet makes directly.
3. **Feed upstream ambiguity** — the shared `ODataMsrcFeed` also had a **nuget.org** upstream that shadowed PowerShell Gallery for package IDs on both (e.g. `Pester`, whose nuget.org entry is a Chocolatey package with no root module manifest). Switched to a dedicated, PowerShell-Gallery-only feed.
4. **Pester major version** — the test suite uses Pester 5 syntax (`Invoke-Pester -OutputFile/-OutputFormat`), which Pester 6 removed. Pinned to the 5.x line.
5. **Deterministic dependency graph** — `Microsoft.Graph.Authentication` is a hard requirement of `Publish-LocalCompatModule.ps1` and was only resolved transitively (which bypasses `-Credential` and behaves inconsistently across feeds). Now installed explicitly.

## Changes

- **`build/Install-GalleryModule.ps1`** (new) — central helper that installs modules from the configured feed (registering it with a token-based credential) or from PowerShell Gallery by default. Supports `-RequiredVersion` / `-MaximumVersion`.
- **`build/Install-Dependencies.ps1`** — routes installs through the helper; adds a `-Repository` parameter (defaults to `$env:DEPENDENCY_PS_REPO` or `PSGallery`); installs `Microsoft.Graph.Authentication` explicitly at `destinationModuleVersion`.
- **`.azure-pipelines/generation-templates/generate_adapter-1es.yml`** and **`generate_adapter.yml`** — add `DependencyRepository` / `CfsFeedUrl` parameters; add guarded `NuGetAuthenticate@1`; route PlatyPS / Pester / dependency installs through the helper; cap Pester at `5.99.99`.
- **`.azure-pipelines/1es-entra-powershell-pr.yml`**, **`1es-entra-powershell-ci-build.yml`**, **`integration-tests.yml`** — pass the dedicated feed.

## Feed

Dedicated, project-scoped feed **`EntraPowerShellFeed`** (project `One`) with **PowerShell Gallery as its only upstream** (no nuget.org), so every module resolves to the correct PowerShell module:

```
DependencyRepository: EntraPowerShellFeed
CfsFeedUrl:           https://pkgs.dev.azure.com/msazure/One/_packaging/EntraPowerShellFeed/nuget/v2
```

The pipeline build identity has **collaborator** access (read + save-from-upstream). Upstream caching is on-demand — no sync automation required.

## Latest run — status

Build [`cfs-network-isolation-feed-PR-2026-07-14.6` (172177331)](https://msazure.visualstudio.com/One/_build/results?buildId=172177331) on commit `502b1005c`: **succeeded** — 0 failed steps.

| Step | Result |
| --- | --- |
| 🔒 Start / Stop Network Isolation | ✅ |
| Install Dependencies Entra / EntraBeta | ✅ |
| Publish to Local Gallery Entra / EntraBeta | ✅ |
| Install Pester | ✅ |
| Run tests Entra / EntraBeta | ✅ |
| Run PSScriptAnalyzer | ✅ |

## Latest run — CFS policy compliance

From the **Stop Network Isolation** log of run 172177331:

| Policy | Status |
| --- | --- |
| CFSClean | ✅ COMPLIANT |
| CFSClean2 | ⚠️ NOT COMPLIANT — **3 violations** (down from 204) |
| CFSClean3 | ✅ COMPLIANT |
| Default Deny | ✅ COMPLIANT |

The **3 residual `CFSClean2` violations** are all `pwsh.exe → www.powershellgallery.com`. They are **non-blocking** (the build succeeds; the policy is currently in audit/warn mode). They originate from pipeline steps **not yet routed through the feed** — most likely the `PSScriptAnalyzer@1` marketplace task (which bootstraps the PSScriptAnalyzer module from PowerShell Gallery) and/or `Publish-Module` dependency resolution. **Follow-up:** route/replace those remaining `pwsh` module operations through the feed to reach full `CFSClean2` compliance before the policy is enforced as blocking.

## Local development impact

None. With no `DEPENDENCY_PS_REPO` set, `Install-Dependencies.ps1` and the helper default to the public PowerShell Gallery, so local build/test behavior is unchanged.
