### PR TITLE
ci: update ESRP code signing to v6

### DIFF
--- a/.azure-pipelines/common-templates/esrp/codesign-nuget.yml
+++ b/.azure-pipelines/common-templates/esrp/codesign-nuget.yml
@@ -10,7 +10,7 @@ parameters:
     default: "*.nupkg"
 
 steps:
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5 
+  - task: EsrpCodeSigning@6 
     displayName: 'NuGet CodeSigning' 
     inputs: 
       ConnectedServiceName: 'EntraPowerShell ESRP CodeSign and NUGET'

--- a/.azure-pipelines/common-templates/esrp/codesign.yml
+++ b/.azure-pipelines/common-templates/esrp/codesign.yml
@@ -10,7 +10,7 @@ parameters:
       default: ".*.dll"
 
 steps:
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+    - task: EsrpCodeSigning@6
       displayName: ESRP DLL CodeSigning
       inputs:
         ConnectedServiceName: 'EntraPowerShell ESRP CodeSign and NUGET' 


### PR DESCRIPTION
## Summary
- Update ESRP code signing pipeline tasks from v5 to v6.
- Use the short `EsrpCodeSigning@6` task name in ESRP templates.

## Notes
ESRP code signing v5 runs on Node16 and is getting deprecated, so this moves the pipelines to v6.